### PR TITLE
docs: remove implementation-jargon from S0/S1 docs

### DIFF
--- a/packages/adapter-mock/src/createMockAdapter.docs.md
+++ b/packages/adapter-mock/src/createMockAdapter.docs.md
@@ -1,5 +1,5 @@
 # createMockAdapter
 
 `createMockAdapter()` returns a pure-JavaScript `VGPUAdapter`. Its devices allocate
-in-memory buffers backed by `Uint8Array`, making the core seam testable without Dawn
-or native GPU libraries.
+in-memory buffers backed by `Uint8Array`, making core testable without Dawn or native
+GPU libraries.

--- a/packages/core/src/App.docs.md
+++ b/packages/core/src/App.docs.md
@@ -1,5 +1,5 @@
 # App
 
-`App.create({ adapter })` is the rapid bootstrap surface for the Adapter ↔ Core seam.
+`App.create({ adapter })` is the bootstrap entry point for creating a vgpu device.
 It asks the supplied `VGPUAdapter` for a `Device` and returns the explicit aggregate
 `{ device, queue }`. It never uses ambient context or `AsyncLocalStorage`.

--- a/packages/core/src/VGPUAdapter.docs.md
+++ b/packages/core/src/VGPUAdapter.docs.md
@@ -1,5 +1,5 @@
 # VGPUAdapter
 
-`VGPUAdapter` is the seam interface implemented by concrete adapters. Core asks an
-adapter for a `Device` and does not know whether the implementation is Dawn-backed,
+`VGPUAdapter` is the interface implemented by concrete adapters. Core asks an adapter
+for a `Device` and does not know whether the implementation is Dawn-backed,
 browser-backed, or pure JavaScript mock memory.

--- a/packages/core/src/createMockGPUDevice.docs.md
+++ b/packages/core/src/createMockGPUDevice.docs.md
@@ -1,5 +1,5 @@
 # createMockGPUDevice
 
 `createMockGPUDevice()` creates the in-memory WebGPU-shaped object used by the mock
-adapter. It is public only to let `@vgpu/adapter-mock` satisfy the same seam as real
-adapters while keeping mock storage logic local to core tests.
+adapter. It is public so `@vgpu/adapter-mock` can expose the same adapter contract as
+other adapters while keeping mock storage logic local to core tests.

--- a/packages/render/tests/triangle.test.ts
+++ b/packages/render/tests/triangle.test.ts
@@ -87,7 +87,7 @@ test.skipIf(process.env.VGPU_DOCKER_TEST !== "1")("renders hello triangle from p
   const pixels = await target.read();
   expect(maxRedInTopRegion(pixels)).toBeGreaterThan(200);
   // Snapshot asserts the hello-triangle is rendered byte-equal to the committed PNG.
-  // Threshold 0.001 (0.1% pixel diff) per S2 acceptance criteria (issue #21 line 30).
+  // Threshold 0.001 allows a 0.1% pixel diff tolerance for this snapshot.
   // Dawn's OpenGL software backend on node:22-trixie-slim is deterministic across runs.
   await expect(pixels).toMatchImageSnapshot({ testName: "hello-triangle", width: 256, height: 256, threshold: 0.001 });
   device.destroy();


### PR DESCRIPTION
Sweeps remaining `.docs.md` files and JSDoc comments for phase/seam references that leaked from S0/S1 planning into user-facing docs.

This applies the cleanup standard already in effect for S2/S3 docs to the older S0/S1 files (flagged as pre-existing tech debt by the S3 PR orchestrator).

Pure docs cleanup; no code, types, exports, tests, or behavior changed.