### PR TITLE
feat: core↔render rapid path with hello triangle

### DIFF
--- a/docs/allowlist.txt
+++ b/docs/allowlist.txt
@@ -29,6 +29,8 @@
 @vgpu/render createRenderPipeline packages/render/src/createRenderPipeline.docs.md
 @vgpu/render RenderPass packages/render/src/RenderPass.docs.md
 @vgpu/render RenderPassOptions packages/render/src/RenderPass.docs.md
+@vgpu/render RenderPassDrawOptions packages/render/src/RenderPass.docs.md
+@vgpu/render RenderPassDynamicOffsets packages/render/src/RenderPass.docs.md
 @vgpu/render ColorAttachment packages/render/src/RenderPass.docs.md
 @vgpu/wgsl/runtime resolveShader packages/wgsl/src/runtime/resolveShader.docs.md
 @vgpu/wgsl/runtime ResolveOptions packages/wgsl/src/runtime/resolveShader.docs.md

--- a/docs/allowlist.txt
+++ b/docs/allowlist.txt
@@ -36,6 +36,8 @@
 @vgpu/render UniformPoolOptions packages/render/src/UniformPool.docs.md
 @vgpu/render UniformLayout packages/render/src/UniformPool.docs.md
 @vgpu/render UniformSlot packages/render/src/UniformPool.docs.md
+@vgpu/render RapidRenderer packages/render/src/RapidRenderer.docs.md
+@vgpu/render DrawSpec packages/render/src/RapidRenderer.docs.md
 @vgpu/wgsl/runtime resolveShader packages/wgsl/src/runtime/resolveShader.docs.md
 @vgpu/wgsl/runtime ResolveOptions packages/wgsl/src/runtime/resolveShader.docs.md
 @vgpu/wgsl/runtime ResolvedShader packages/wgsl/src/runtime/resolveShader.docs.md

--- a/docs/allowlist.txt
+++ b/docs/allowlist.txt
@@ -32,6 +32,10 @@
 @vgpu/render RenderPassDrawOptions packages/render/src/RenderPass.docs.md
 @vgpu/render RenderPassDynamicOffsets packages/render/src/RenderPass.docs.md
 @vgpu/render ColorAttachment packages/render/src/RenderPass.docs.md
+@vgpu/render UniformPool packages/render/src/UniformPool.docs.md
+@vgpu/render UniformPoolOptions packages/render/src/UniformPool.docs.md
+@vgpu/render UniformLayout packages/render/src/UniformPool.docs.md
+@vgpu/render UniformSlot packages/render/src/UniformPool.docs.md
 @vgpu/wgsl/runtime resolveShader packages/wgsl/src/runtime/resolveShader.docs.md
 @vgpu/wgsl/runtime ResolveOptions packages/wgsl/src/runtime/resolveShader.docs.md
 @vgpu/wgsl/runtime ResolvedShader packages/wgsl/src/runtime/resolveShader.docs.md

--- a/packages/render/src/RapidRenderer.docs.md
+++ b/packages/render/src/RapidRenderer.docs.md
@@ -1,0 +1,44 @@
+# RapidRenderer
+
+`RapidRenderer` is a direct draw entry point for code that already has a
+compiled render pipeline and a render target view. Construct it with a core
+`Device`, then call `draw(spec)` to clear the target, bind the pipeline, draw
+vertices, end the render pass, and submit the command buffer.
+
+## Signature
+
+```ts
+const renderer = new RapidRenderer(device);
+await renderer.draw({ pipeline, target, vertexCount: 3 });
+```
+
+`renderer.gpu` returns the underlying `GPUDevice` for callers that need raw
+WebGPU access.
+
+## DrawSpec
+
+`DrawSpec` contains:
+
+- `pipeline`: a raw `GPURenderPipeline`, such as one returned by
+  `createRenderPipeline()`.
+- `target`: a raw `GPUTextureView` to render into.
+- `vertexCount`: the number of vertices to draw.
+- `clearValue`: optional `GPUColor`; when omitted, the target is cleared to
+  opaque black.
+
+`draw(spec)` returns a `Promise<void>` that resolves after commands have been
+submitted. It does not wait for GPU completion.
+
+Example:
+
+```ts
+const pipeline = createRenderPipeline(device, {
+  shader,
+  vertex: { entry: "vs_main" },
+  fragment: { entry: "fs_main", targets: [{ format: "rgba8unorm" }] },
+  primitive: { topology: "triangle-list" },
+});
+
+const renderer = new RapidRenderer(device);
+await renderer.draw({ pipeline, target: texture.createView(), vertexCount: 3 });
+```

--- a/packages/render/src/RenderPass.docs.md
+++ b/packages/render/src/RenderPass.docs.md
@@ -1,13 +1,26 @@
 # RenderPass
 
 `RenderPass` is a command-encoding wrapper for drawing into color
-attachments. Construct it with a core `Device` and `RenderPassOptions`, call
-`setPipeline(...)`, issue `draw(...)`, then call `end()` to finish the pass and
-submit the command buffer through `Device.queue`.
+attachments. Construct it with a core `Device` and `RenderPassOptions`, encode
+render commands, then call `end()` to finish the pass and submit the command
+buffer through `Device.queue`.
 
 `RenderPassOptions` contains `colorAttachments` and an optional `label`.
 `ColorAttachment.view` accepts either a core `Texture` or a raw
 `GPUTextureView`; `loadOp`, `storeOp`, and `clearValue` are forwarded to WebGPU.
+
+Commands mirror the WebGPU render pass encoder:
+
+- `setPipeline(pipeline)` binds a raw `GPURenderPipeline`.
+- `setBindGroup(index, group, dynamicOffsets?)` binds a raw `GPUBindGroup`.
+- `setVertexBuffer(slot, buffer, offset?, size?)` binds a core `Buffer` or raw
+  `GPUBuffer` for vertex input.
+- `draw({ vertexCount, instanceCount?, firstVertex?, firstInstance? })` issues a
+  non-indexed draw. The numeric WebGPU-style `draw(vertexCount, ...)` call is
+  also accepted.
+
+Use `gpu` when you need direct `GPURenderPassEncoder` access for commands that
+are not wrapped yet.
 
 Invariants: a pass is single-use. After `end()`, the underlying
 `GPURenderPassEncoder` is invalid, so `RenderPass.gpu` throws `VGPUError` with
@@ -21,6 +34,8 @@ const pass = new RenderPass(device, {
   colorAttachments: [{ view: target, loadOp: "clear", storeOp: "store", clearValue: [0, 0, 0, 1] }],
 });
 pass.setPipeline(pipeline);
-pass.draw(3);
+pass.setBindGroup(0, uniforms);
+pass.setVertexBuffer(0, vertices);
+pass.draw({ vertexCount: 3 });
 pass.end();
 ```

--- a/packages/render/src/UniformPool.docs.md
+++ b/packages/render/src/UniformPool.docs.md
@@ -12,10 +12,9 @@ uses for dynamic uniform buffers.
 Options:
 
 - `capacityBytes`: total byte capacity for one frame. Defaults to 4 MiB.
-- `minOffsetAlignment`: byte alignment for returned offsets. Defaults to the
-  device limit when available, otherwise 256 bytes.
-- `maxUniformBindingSize`: largest accepted layout size. Defaults to the device
-  limit when available, otherwise 64 KiB.
+
+Returned offsets use the device's minimum uniform buffer offset alignment, and
+layout sizes are checked against the device's maximum uniform binding size.
 
 ## Layouts and slots
 
@@ -33,7 +32,8 @@ A slot exposes:
 - `gpu`: the backing `GPUBuffer` for low-level code that needs it.
 
 `bindGroup` and `bindGroupLayout` are currently `null`; callers can still use
-the returned offsets and CPU mirror behavior today.
+the returned offsets and CPU mirror behavior today. A slot must be used with the
+pool that allocated it.
 
 ## Frame lifecycle
 

--- a/packages/render/src/UniformPool.docs.md
+++ b/packages/render/src/UniformPool.docs.md
@@ -1,0 +1,53 @@
+# UniformPool
+
+`UniformPool` is a frame-local CPU-side allocator for uniform data. It stores
+encoded uniform bytes in one `ArrayBuffer` and returns dynamic offsets from
+slot pushes, so render code can keep the same offset-oriented shape that WebGPU
+uses for dynamic uniform buffers.
+
+## Signature
+
+`new UniformPool(device, opts?)`
+
+Options:
+
+- `capacityBytes`: total byte capacity for one frame. Defaults to 4 MiB.
+- `minOffsetAlignment`: byte alignment for returned offsets. Defaults to the
+  device limit when available, otherwise 256 bytes.
+- `maxUniformBindingSize`: largest accepted layout size. Defaults to the device
+  limit when available, otherwise 64 KiB.
+
+## Layouts and slots
+
+Call `pool.alloc(layout)` to create a `UniformSlot`. A layout provides a
+host-shareable `size` and an `encode(value, dst, byteOffset)` function that
+writes the value into the pool's `cpuMirror` `ArrayBuffer`.
+
+A slot exposes:
+
+- `stride`: the layout size rounded up to `minOffsetAlignment`.
+- `push(value)`: encodes a value into the CPU mirror and returns the dynamic
+  offset for that write.
+- `pushBytes(bytes)`: copies already encoded bytes whose length equals the
+  layout size.
+- `gpu`: the backing `GPUBuffer` for low-level code that needs it.
+
+`bindGroup` and `bindGroupLayout` are currently `null`; callers can still use
+the returned offsets and CPU mirror behavior today.
+
+## Frame lifecycle
+
+Use one frame cycle at a time:
+
+1. `beginFrame(frameIndex)` resets `usedBytes` to zero and allows pushes.
+2. `slot.push(...)` writes into `cpuMirror` at the current offset.
+3. `endFrame()` closes the frame's writes.
+
+After `endFrame()`, pushing again before the next `beginFrame()` throws a
+`VGPUError` with code `VGPU-CORE-UNIFORM-POOL-PUSH-AFTER-FLUSH`.
+
+If a push would exceed `capacityBytes`, it throws `VGPU-UNIFORM-POOL-OVERFLOW`.
+If a layout is too large for the pool or binding limit, `alloc()` throws
+`VGPU-UNIFORM-LAYOUT-OVERSIZED`.
+
+Call `dispose()` to destroy the backing GPU buffer. Repeated disposal is safe.

--- a/packages/render/src/index.ts
+++ b/packages/render/src/index.ts
@@ -1,4 +1,9 @@
 export { createRenderPipeline } from "./pipeline.ts";
 export { RenderPass } from "./render-pass.ts";
 export type { RenderPipelineOptions } from "./pipeline.ts";
-export type { ColorAttachment, RenderPassOptions } from "./render-pass.ts";
+export type {
+  ColorAttachment,
+  RenderPassDrawOptions,
+  RenderPassDynamicOffsets,
+  RenderPassOptions,
+} from "./render-pass.ts";

--- a/packages/render/src/index.ts
+++ b/packages/render/src/index.ts
@@ -1,6 +1,8 @@
 export { createRenderPipeline } from "./pipeline.ts";
 export { RenderPass } from "./render-pass.ts";
+export { UniformPool } from "./uniform-pool.ts";
 export type { RenderPipelineOptions } from "./pipeline.ts";
+export type { UniformLayout, UniformPoolOptions, UniformSlot } from "./uniform-pool-types.ts";
 export type {
   ColorAttachment,
   RenderPassDrawOptions,

--- a/packages/render/src/index.ts
+++ b/packages/render/src/index.ts
@@ -1,7 +1,9 @@
 export { createRenderPipeline } from "./pipeline.ts";
 export { RenderPass } from "./render-pass.ts";
+export { RapidRenderer } from "./rapid-renderer.ts";
 export { UniformPool } from "./uniform-pool.ts";
 export type { RenderPipelineOptions } from "./pipeline.ts";
+export type { DrawSpec } from "./rapid-renderer.ts";
 export type { UniformLayout, UniformPoolOptions, UniformSlot } from "./uniform-pool-types.ts";
 export type {
   ColorAttachment,

--- a/packages/render/src/rapid-renderer.ts
+++ b/packages/render/src/rapid-renderer.ts
@@ -1,0 +1,53 @@
+import type { Device } from "@vgpu/core";
+import { RenderPass } from "./render-pass.ts";
+
+export interface DrawSpec {
+  /** Compiled render pipeline. Required. */
+  readonly pipeline: GPURenderPipeline;
+
+  /** Render target view to render into. Required. */
+  readonly target: GPUTextureView;
+
+  /** Number of vertices to draw. Required. */
+  readonly vertexCount: number;
+
+  /** Optional clear color. Defaults to opaque black [0,0,0,1] when omitted. */
+  readonly clearValue?: GPUColor;
+}
+
+export class RapidRenderer {
+  constructor(private readonly device: Device) {}
+
+  get gpu(): GPUDevice {
+    return this.device.gpu;
+  }
+
+  async draw(spec: DrawSpec): Promise<void> {
+    const pass = new RenderPass(this.device, {
+      colorAttachments: [
+        {
+          view: spec.target,
+          loadOp: "clear",
+          storeOp: "store",
+          clearValue: colorTuple(spec.clearValue),
+        },
+      ],
+    });
+    pass.setPipeline(spec.pipeline);
+    pass.draw({ vertexCount: spec.vertexCount });
+    pass.end();
+  }
+}
+
+function colorTuple(color: GPUColor | undefined): readonly [number, number, number, number] {
+  if (!color) return [0, 0, 0, 1];
+  if (isIterableColor(color)) {
+    const values = Array.from(color);
+    return [values[0] ?? 0, values[1] ?? 0, values[2] ?? 0, values[3] ?? 1];
+  }
+  return [color.r, color.g, color.b, color.a];
+}
+
+function isIterableColor(color: GPUColor): color is Iterable<number> {
+  return Symbol.iterator in Object(color);
+}

--- a/packages/render/src/render-pass.ts
+++ b/packages/render/src/render-pass.ts
@@ -1,4 +1,4 @@
-import { VGPUError, type Device, type Texture } from "@vgpu/core";
+import { Buffer, VGPUError, type Device, type Texture } from "@vgpu/core";
 
 const textureBrand = Symbol.for("vgpu/Texture");
 
@@ -13,6 +13,15 @@ export interface ColorAttachment {
   readonly storeOp: GPUStoreOp;
   readonly clearValue?: readonly [number, number, number, number];
 }
+
+export interface RenderPassDrawOptions {
+  readonly vertexCount: number;
+  readonly instanceCount?: number;
+  readonly firstVertex?: number;
+  readonly firstInstance?: number;
+}
+
+export type RenderPassDynamicOffsets = readonly GPUBufferDynamicOffset[] | Uint32Array;
 
 export class RenderPass {
   private readonly encoder: GPUCommandEncoder;
@@ -41,8 +50,27 @@ export class RenderPass {
     this.gpu.setPipeline(pipeline);
   }
 
-  draw(vertexCount: number, instanceCount = 1, firstVertex = 0, firstInstance = 0): void {
-    this.gpu.draw(vertexCount, instanceCount, firstVertex, firstInstance);
+  setBindGroup(index: number, group: GPUBindGroup | null, dynamicOffsets?: RenderPassDynamicOffsets): void {
+    this.gpu.setBindGroup(index, group, dynamicOffsets);
+  }
+
+  setVertexBuffer(slot: number, buffer: Buffer | GPUBuffer | null, offset = 0, size?: GPUSize64): void {
+    this.gpu.setVertexBuffer(slot, gpuBuffer(buffer), offset, size);
+  }
+
+  draw(options: RenderPassDrawOptions): void;
+  draw(vertexCount: number, instanceCount?: number, firstVertex?: number, firstInstance?: number): void;
+  draw(optionsOrVertexCount: RenderPassDrawOptions | number, instanceCount = 1, firstVertex = 0, firstInstance = 0): void {
+    if (typeof optionsOrVertexCount === "number") {
+      this.gpu.draw(optionsOrVertexCount, instanceCount, firstVertex, firstInstance);
+      return;
+    }
+    this.gpu.draw(
+      optionsOrVertexCount.vertexCount,
+      optionsOrVertexCount.instanceCount ?? 1,
+      optionsOrVertexCount.firstVertex ?? 0,
+      optionsOrVertexCount.firstInstance ?? 0,
+    );
   }
 
   end(): void {
@@ -65,6 +93,10 @@ function colorAttachment(attachment: ColorAttachment): GPURenderPassColorAttachm
     storeOp: attachment.storeOp,
     clearValue: attachment.clearValue,
   };
+}
+
+function gpuBuffer(buffer: Buffer | GPUBuffer | null): GPUBuffer | null {
+  return buffer instanceof Buffer ? buffer.gpu : buffer;
 }
 
 function isVGPUTexture(view: Texture | GPUTextureView): view is Texture {

--- a/packages/render/src/uniform-pool-types.ts
+++ b/packages/render/src/uniform-pool-types.ts
@@ -2,8 +2,6 @@ import type { UniformPool } from "./uniform-pool.ts";
 
 export interface UniformPoolOptions {
   readonly capacityBytes?: number;
-  readonly minOffsetAlignment?: number;
-  readonly maxUniformBindingSize?: number;
 }
 
 export interface UniformLayout<T> {

--- a/packages/render/src/uniform-pool-types.ts
+++ b/packages/render/src/uniform-pool-types.ts
@@ -1,0 +1,24 @@
+import type { UniformPool } from "./uniform-pool.ts";
+
+export interface UniformPoolOptions {
+  readonly capacityBytes?: number;
+  readonly minOffsetAlignment?: number;
+  readonly maxUniformBindingSize?: number;
+}
+
+export interface UniformLayout<T> {
+  readonly size: number;
+  readonly bindings?: readonly GPUBindGroupLayoutEntry[];
+  encode(value: T, dst: ArrayBuffer, byteOffset: number): void;
+}
+
+export interface UniformSlot<T> {
+  readonly pool: UniformPool;
+  readonly layout: UniformLayout<T>;
+  readonly bindGroup: GPUBindGroup | null;
+  readonly bindGroupLayout: GPUBindGroupLayout | null;
+  readonly gpu: GPUBuffer;
+  readonly stride: number;
+  push(value: T): number;
+  pushBytes(bytes: ArrayBufferView<ArrayBuffer>): number;
+}

--- a/packages/render/src/uniform-pool.ts
+++ b/packages/render/src/uniform-pool.ts
@@ -1,0 +1,143 @@
+import { VGPUError, type Device } from "@vgpu/core";
+import type { UniformLayout, UniformPoolOptions, UniformSlot } from "./uniform-pool-types.ts";
+
+const defaultCapacityBytes = 4 * 1024 * 1024;
+const defaultMinOffsetAlignment = 256;
+const defaultMaxUniformBindingSize = 64 * 1024;
+const uniformUsage = 64;
+const copyDstUsage = 8;
+
+export class UniformPool {
+  readonly minOffsetAlignment: number;
+  readonly capacityBytes: number;
+  readonly maxUniformBindingSize: number;
+  readonly cpuMirror: ArrayBuffer;
+  readonly gpu: GPUBuffer;
+  private readonly bytes: Uint8Array;
+  private head = 0;
+  private flushed = false;
+  private isDisposed = false;
+
+  constructor(readonly device: Device, opts: UniformPoolOptions = {}) {
+    this.capacityBytes = opts.capacityBytes ?? defaultCapacityBytes;
+    this.minOffsetAlignment = opts.minOffsetAlignment ?? deviceLimit(device, "minUniformBufferOffsetAlignment", defaultMinOffsetAlignment);
+    this.maxUniformBindingSize = opts.maxUniformBindingSize ?? deviceLimit(device, "maxUniformBufferBindingSize", defaultMaxUniformBindingSize);
+    this.cpuMirror = new ArrayBuffer(this.capacityBytes);
+    this.bytes = new Uint8Array(this.cpuMirror);
+    this.gpu = device.gpu.createBuffer({ label: "vgpu UniformPool", size: this.capacityBytes, usage: uniformUsage | copyDstUsage });
+  }
+
+  get usedBytes(): number {
+    return this.head;
+  }
+
+  get disposed(): boolean {
+    return this.isDisposed;
+  }
+
+  alloc<T>(layout: UniformLayout<T>): UniformSlot<T> {
+    this.assertUsable("UniformPool.alloc");
+    this.assertLayoutFits(layout);
+    return new PoolSlot(this, layout, roundUp(layout.size, this.minOffsetAlignment));
+  }
+
+  push<T>(slot: UniformSlot<T>, value: T): number {
+    return this.write(slot.layout.size, slot.stride, (offset) => slot.layout.encode(value, this.cpuMirror, offset));
+  }
+
+  pushBytes(slot: UniformSlot<unknown>, bytes: ArrayBufferView<ArrayBuffer>): number {
+    if (bytes.byteLength !== slot.layout.size) {
+      throw new VGPUError({
+        code: "VGPU-CORE-INVALID-USAGE",
+        message: `Uniform bytes must match layout size ${slot.layout.size}.`,
+        where: "UniformSlot.pushBytes",
+      });
+    }
+    return this.write(slot.layout.size, slot.stride, (offset) => this.bytes.set(viewBytes(bytes), offset));
+  }
+
+  beginFrame(_frameIndex: number): void {
+    this.assertUsable("UniformPool.beginFrame");
+    this.head = 0;
+    this.flushed = false;
+  }
+
+  endFrame(): void {
+    this.assertUsable("UniformPool.endFrame");
+    // TODO(uniform-pool): GPU upload wires up when first real consumer lands
+    this.flushed = true;
+  }
+
+  dispose(): void {
+    if (this.isDisposed) return;
+    this.isDisposed = true;
+    this.gpu.destroy();
+  }
+
+  private write(layoutSize: number, stride: number, encode: (byteOffset: number) => void): number {
+    this.assertUsable("UniformSlot.push");
+    this.assertCanPush(layoutSize, stride);
+    const offset = this.head;
+    encode(offset);
+    this.head += stride;
+    return offset;
+  }
+
+  private assertCanPush(layoutSize: number, stride: number): void {
+    if (this.flushed) {
+      throw new VGPUError({
+        code: "VGPU-CORE-UNIFORM-POOL-PUSH-AFTER-FLUSH",
+        message: "Call UniformPool.beginFrame() before pushing more uniform data after endFrame().",
+        where: "UniformSlot.push",
+      });
+    }
+    if (this.head + stride <= this.capacityBytes) return;
+    throw new VGPUError({
+      code: "VGPU-UNIFORM-POOL-OVERFLOW",
+      message: `UniformPool capacity ${this.capacityBytes} bytes is exceeded by a ${layoutSize}-byte layout.`,
+      where: "UniformSlot.push",
+    });
+  }
+
+  private assertLayoutFits(layout: UniformLayout<unknown>): void {
+    if (layout.size <= this.capacityBytes && layout.size <= this.maxUniformBindingSize) return;
+    throw new VGPUError({
+      code: "VGPU-UNIFORM-LAYOUT-OVERSIZED",
+      message: `Uniform layout size ${layout.size} bytes is too large for this pool.`,
+      where: "UniformPool.alloc",
+    });
+  }
+
+  private assertUsable(where: string): void {
+    if (!this.isDisposed) return;
+    throw new VGPUError({ code: "VGPU-CORE-INVALID-USAGE", message: "UniformPool has been disposed.", where });
+  }
+}
+
+class PoolSlot<T> implements UniformSlot<T> {
+  readonly bindGroup: GPUBindGroup | null = null;
+  readonly bindGroupLayout: GPUBindGroupLayout | null = null;
+  readonly gpu: GPUBuffer;
+  constructor(readonly pool: UniformPool, readonly layout: UniformLayout<T>, readonly stride: number) {
+    this.gpu = pool.gpu;
+  }
+  push(value: T): number {
+    return this.pool.push(this, value);
+  }
+  pushBytes(bytes: ArrayBufferView<ArrayBuffer>): number {
+    return this.pool.pushBytes(this, bytes);
+  }
+}
+
+function roundUp(value: number, alignment: number): number {
+  return Math.ceil(value / alignment) * alignment;
+}
+
+function deviceLimit(device: Device, key: keyof GPUSupportedLimits, fallback: number): number {
+  const limits = (device.gpu as GPUDevice & { readonly limits?: Partial<Record<keyof GPUSupportedLimits, number>> }).limits;
+  return limits?.[key] ?? fallback;
+}
+
+function viewBytes(view: ArrayBufferView<ArrayBuffer>): Uint8Array {
+  return new Uint8Array(view.buffer, view.byteOffset, view.byteLength);
+}

--- a/packages/render/src/uniform-pool.ts
+++ b/packages/render/src/uniform-pool.ts
@@ -20,8 +20,8 @@ export class UniformPool {
 
   constructor(readonly device: Device, opts: UniformPoolOptions = {}) {
     this.capacityBytes = opts.capacityBytes ?? defaultCapacityBytes;
-    this.minOffsetAlignment = opts.minOffsetAlignment ?? deviceLimit(device, "minUniformBufferOffsetAlignment", defaultMinOffsetAlignment);
-    this.maxUniformBindingSize = opts.maxUniformBindingSize ?? deviceLimit(device, "maxUniformBufferBindingSize", defaultMaxUniformBindingSize);
+    this.minOffsetAlignment = deviceLimit(device, "minUniformBufferOffsetAlignment", defaultMinOffsetAlignment);
+    this.maxUniformBindingSize = deviceLimit(device, "maxUniformBufferBindingSize", defaultMaxUniformBindingSize);
     this.cpuMirror = new ArrayBuffer(this.capacityBytes);
     this.bytes = new Uint8Array(this.cpuMirror);
     this.gpu = device.gpu.createBuffer({ label: "vgpu UniformPool", size: this.capacityBytes, usage: uniformUsage | copyDstUsage });
@@ -42,10 +42,12 @@ export class UniformPool {
   }
 
   push<T>(slot: UniformSlot<T>, value: T): number {
+    this.assertOwnsSlot(slot, "UniformPool.push");
     return this.write(slot.layout.size, slot.stride, (offset) => slot.layout.encode(value, this.cpuMirror, offset));
   }
 
   pushBytes(slot: UniformSlot<unknown>, bytes: ArrayBufferView<ArrayBuffer>): number {
+    this.assertOwnsSlot(slot, "UniformPool.pushBytes");
     if (bytes.byteLength !== slot.layout.size) {
       throw new VGPUError({
         code: "VGPU-CORE-INVALID-USAGE",
@@ -72,6 +74,15 @@ export class UniformPool {
     if (this.isDisposed) return;
     this.isDisposed = true;
     this.gpu.destroy();
+  }
+
+  private assertOwnsSlot(slot: UniformSlot<unknown>, where: string): void {
+    if (slot.pool === this) return;
+    throw new VGPUError({
+      code: "VGPU-CORE-INVALID-USAGE",
+      message: "UniformSlot was allocated by a different UniformPool.",
+      where,
+    });
   }
 
   private write(layoutSize: number, stride: number, encode: (byteOffset: number) => void): number {
@@ -121,12 +132,8 @@ class PoolSlot<T> implements UniformSlot<T> {
   constructor(readonly pool: UniformPool, readonly layout: UniformLayout<T>, readonly stride: number) {
     this.gpu = pool.gpu;
   }
-  push(value: T): number {
-    return this.pool.push(this, value);
-  }
-  pushBytes(bytes: ArrayBufferView<ArrayBuffer>): number {
-    return this.pool.pushBytes(this, bytes);
-  }
+  push(value: T): number { return this.pool.push(this, value); }
+  pushBytes(bytes: ArrayBufferView<ArrayBuffer>): number { return this.pool.pushBytes(this, bytes); }
 }
 
 function roundUp(value: number, alignment: number): number {

--- a/packages/render/tests/rapid-renderer-triangle.test.ts
+++ b/packages/render/tests/rapid-renderer-triangle.test.ts
@@ -1,0 +1,129 @@
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import pixelmatch from "pixelmatch";
+import { PNG } from "pngjs";
+import { expect, test } from "vitest";
+import { createNodeAdapter } from "@vgpu/adapter-node";
+import { App, Device } from "@vgpu/core";
+import { createRenderPipeline, RapidRenderer } from "@vgpu/render";
+import { compile } from "@vgpu/wgsl";
+
+const TRIANGLE_WGSL = `
+struct VSOut {
+  @builtin(position) pos: vec4f,
+  @location(0) color: vec3f,
+};
+
+@vertex
+fn vs_main(@builtin(vertex_index) vi: u32) -> VSOut {
+  var positions = array<vec2f, 3>(
+    vec2f(0.0,  0.5),
+    vec2f(-0.5, -0.5),
+    vec2f(0.5, -0.5)
+  );
+  var colors = array<vec3f, 3>(
+    vec3f(1.0, 0.0, 0.0),
+    vec3f(0.0, 1.0, 0.0),
+    vec3f(0.0, 0.0, 1.0)
+  );
+  var out: VSOut;
+  out.pos = vec4f(positions[vi], 0.0, 1.0);
+  out.color = colors[vi];
+  return out;
+}
+
+@fragment
+fn fs_main(in: VSOut) -> @location(0) vec4f {
+  return vec4f(in.color, 1.0);
+}
+`;
+
+test.skipIf(process.env.VGPU_DOCKER_TEST !== "1")(
+  "renders hello triangle via RapidRenderer.draw byte-equal to plain-WGSL snapshot",
+  async () => {
+    const { device } = await App.create({ adapter: createNodeAdapter() });
+    const target = device.createTexture({ size: [256, 256], format: "rgba8unorm", usage: ["render_attachment", "copy_src"] });
+    const shader = device.createShader(compile(TRIANGLE_WGSL));
+    const pipeline = createRenderPipeline(device, {
+      shader,
+      vertex: { entry: "vs_main" },
+      fragment: { entry: "fs_main", targets: [{ format: "rgba8unorm" }] },
+      primitive: { topology: "triangle-list" },
+    });
+
+    await new RapidRenderer(device).draw({ pipeline, target: target.createView(), vertexCount: 3 });
+
+    const pixels = await target.read();
+    const expected = PNG.sync.read(await readFile(join(process.cwd(), "packages/render/tests/__snapshots__/hello-triangle.png")));
+    const actual = new PNG({ width: 256, height: 256 });
+    actual.data.set(pixels);
+    const mismatched = pixelmatch(actual.data, expected.data, null, 256, 256, { threshold: 0.001 });
+    expect(mismatched).toBe(0);
+    device.destroy();
+  },
+);
+
+test("RapidRenderer.draw uses public core Device without raw Dawn assumptions", async () => {
+  const recorder = createRecordingDevice();
+  const device = new Device(recorder.gpu, null);
+  const renderer = new RapidRenderer(device);
+
+  await renderer.draw({ pipeline: recorder.pipeline, target: recorder.target, vertexCount: 3 });
+
+  expect(recorder.calls).toEqual(["createCommandEncoder", "beginRenderPass", "setPipeline", "draw", "end", "finish", "submit"]);
+  expect(recorder.propertyReads).toEqual(["queue", "createCommandEncoder", "submit"]);
+  expect(recorder.colorAttachment()?.view).toBe(recorder.target);
+  expect(recorder.colorAttachment()?.clearValue).toEqual([0, 0, 0, 1]);
+});
+
+interface RecordingDevice {
+  readonly gpu: GPUDevice;
+  readonly pipeline: GPURenderPipeline;
+  readonly target: GPUTextureView;
+  readonly calls: string[];
+  readonly propertyReads: string[];
+  colorAttachment(): GPURenderPassColorAttachment | undefined;
+}
+
+function createRecordingDevice(): RecordingDevice {
+  const calls: string[] = [];
+  const propertyReads: string[] = [];
+  let passDescriptor: GPURenderPassDescriptor | undefined;
+  const pipeline = {} as GPURenderPipeline;
+  const target = {} as GPUTextureView;
+  const commandBuffer = {} as GPUCommandBuffer;
+  const queue = new Proxy({ submit: () => calls.push("submit") }, { get: recordProperty(propertyReads) }) as unknown as GPUQueue;
+  const pass = {
+    setPipeline: () => calls.push("setPipeline"),
+    draw: () => calls.push("draw"),
+    end: () => calls.push("end"),
+  } as unknown as GPURenderPassEncoder;
+  const encoder = {
+    beginRenderPass(descriptor: GPURenderPassDescriptor): GPURenderPassEncoder {
+      calls.push("beginRenderPass");
+      passDescriptor = descriptor;
+      return pass;
+    },
+    finish(): GPUCommandBuffer {
+      calls.push("finish");
+      return commandBuffer;
+    },
+  } as unknown as GPUCommandEncoder;
+  const base = {
+    createCommandEncoder(): GPUCommandEncoder {
+      calls.push("createCommandEncoder");
+      return encoder;
+    },
+    destroy() {},
+    queue,
+  };
+  const gpu = new Proxy(base, { get: recordProperty(propertyReads) }) as unknown as GPUDevice;
+  return { gpu, pipeline, target, calls, propertyReads, colorAttachment: () => passDescriptor?.colorAttachments[0] ?? undefined };
+}
+
+function recordProperty(propertyReads: string[]) {
+  return (target: object, property: string | symbol, receiver: unknown): unknown => {
+    if (typeof property === "string") propertyReads.push(property);
+    return Reflect.get(target, property, receiver);
+  };
+}

--- a/packages/render/tests/rapid-renderer.test.ts
+++ b/packages/render/tests/rapid-renderer.test.ts
@@ -1,0 +1,123 @@
+import { expect, test } from "vitest";
+import { createMockAdapter } from "@vgpu/adapter-mock";
+import { App, Device } from "@vgpu/core";
+import { RapidRenderer, type DrawSpec } from "@vgpu/render";
+
+test("constructs against a mock-adapter device", async () => {
+  const { device } = await App.create({ adapter: createMockAdapter() });
+  const renderer = new RapidRenderer(device);
+
+  expect(renderer.gpu).toBe(device.gpu);
+  device.destroy();
+});
+
+test("issues a render pass for the given pipeline and target", async () => {
+  const recorder = createRecordingDevice();
+  const device = new Device(recorder.gpu, null);
+  const renderer = new RapidRenderer(device);
+
+  await renderer.draw({ pipeline: recorder.pipeline, target: recorder.target, vertexCount: 3, clearValue: [0.1, 0.2, 0.3, 1] });
+
+  expect(recorder.calls.map((call) => call.name)).toEqual([
+    "createCommandEncoder",
+    "beginRenderPass",
+    "setPipeline",
+    "draw",
+    "end",
+    "finish",
+    "submit",
+  ]);
+  expect(recorder.colorAttachment()?.clearValue).toEqual([0.1, 0.2, 0.3, 1]);
+});
+
+test("awaits draw and resolves once commands are submitted", async () => {
+  const recorder = createRecordingDevice();
+  const device = new Device(recorder.gpu, null);
+  const renderer = new RapidRenderer(device);
+
+  await expect(renderer.draw({ pipeline: recorder.pipeline, target: recorder.target, vertexCount: 6 })).resolves.toBeUndefined();
+
+  expect(recorder.calls.at(-1)?.name).toBe("submit");
+});
+
+test("defaults clear value to opaque black when omitted", async () => {
+  const recorder = createRecordingDevice();
+  const device = new Device(recorder.gpu, null);
+  const renderer = new RapidRenderer(device);
+
+  await renderer.draw({ pipeline: recorder.pipeline, target: recorder.target, vertexCount: 3 });
+
+  expect(recorder.colorAttachment()?.clearValue).toEqual([0, 0, 0, 1]);
+});
+
+test("reaches no Dawn-specific properties", async () => {
+  const recorder = createRecordingDevice();
+  const device = new Device(recorder.gpu, null);
+  const renderer = new RapidRenderer(device);
+
+  await renderer.draw({ pipeline: recorder.pipeline, target: recorder.target, vertexCount: 3 });
+
+  expect(recorder.propertiesRead).toEqual(["queue"]);
+});
+
+interface RecordedCall {
+  readonly name: string;
+}
+
+interface RecordingDevice {
+  readonly gpu: GPUDevice;
+  readonly pipeline: GPURenderPipeline;
+  readonly target: GPUTextureView;
+  readonly calls: RecordedCall[];
+  readonly propertiesRead: string[];
+  colorAttachment(): GPURenderPassColorAttachment | undefined;
+}
+
+function createRecordingDevice(): RecordingDevice {
+  const calls: RecordedCall[] = [];
+  const propertiesRead: string[] = [];
+  let passDescriptor: GPURenderPassDescriptor | undefined;
+  const pipeline = {} as GPURenderPipeline;
+  const target = {} as GPUTextureView;
+  const commandBuffer = {} as GPUCommandBuffer;
+  const queue = { submit: () => calls.push({ name: "submit" }) } as unknown as GPUQueue;
+  const pass = {
+    setPipeline: () => calls.push({ name: "setPipeline" }),
+    draw: () => calls.push({ name: "draw" }),
+    end: () => calls.push({ name: "end" }),
+  } as unknown as GPURenderPassEncoder;
+  const encoder = {
+    beginRenderPass(descriptor: GPURenderPassDescriptor): GPURenderPassEncoder {
+      calls.push({ name: "beginRenderPass" });
+      passDescriptor = descriptor;
+      return pass;
+    },
+    finish(): GPUCommandBuffer {
+      calls.push({ name: "finish" });
+      return commandBuffer;
+    },
+  } as unknown as GPUCommandEncoder;
+  const base = {
+    createCommandEncoder(): GPUCommandEncoder {
+      calls.push({ name: "createCommandEncoder" });
+      return encoder;
+    },
+    destroy() {},
+  };
+  const gpu = new Proxy(base, {
+    get(targetDevice, property, receiver): unknown {
+      if (property === "queue") {
+        propertiesRead.push("queue");
+        return queue;
+      }
+      return Reflect.get(targetDevice, property, receiver);
+    },
+  }) as unknown as GPUDevice;
+  return { gpu, pipeline, target, calls, propertiesRead, colorAttachment: () => passDescriptor?.colorAttachments[0] ?? undefined };
+}
+
+function acceptsDrawSpec(spec: DrawSpec): DrawSpec {
+  return spec;
+}
+
+void acceptsDrawSpec;

--- a/packages/render/tests/render-pass.test.ts
+++ b/packages/render/tests/render-pass.test.ts
@@ -1,0 +1,80 @@
+import { expect, test, vi } from "vitest";
+import { createMockAdapter } from "@vgpu/adapter-mock";
+import { App, type Device } from "@vgpu/core";
+import { RenderPass } from "@vgpu/render";
+
+interface RecordedRenderPass {
+  readonly setPipeline: ReturnType<typeof vi.fn>;
+  readonly setBindGroup: ReturnType<typeof vi.fn>;
+  readonly setVertexBuffer: ReturnType<typeof vi.fn>;
+  readonly draw: ReturnType<typeof vi.fn>;
+  readonly end: ReturnType<typeof vi.fn>;
+}
+
+test("sets bind group at index", async () => {
+  const { device, passEncoder } = await createRenderPassFixture();
+  const bindGroup = {} as GPUBindGroup;
+  const pass = new RenderPass(device, { colorAttachments: [colorAttachment()] });
+
+  pass.setBindGroup(2, bindGroup, [16, 32]);
+
+  expect(passEncoder.setBindGroup).toHaveBeenCalledWith(2, bindGroup, [16, 32]);
+  device.destroy();
+});
+
+test("sets vertex buffer at slot", async () => {
+  const { device, passEncoder } = await createRenderPassFixture();
+  const vertexBuffer = {} as GPUBuffer;
+  const pass = new RenderPass(device, { colorAttachments: [colorAttachment()] });
+
+  pass.setVertexBuffer(1, vertexBuffer, 64, 128);
+
+  expect(passEncoder.setVertexBuffer).toHaveBeenCalledWith(1, vertexBuffer, 64, 128);
+  device.destroy();
+});
+
+test("draws from object options", async () => {
+  const { device, passEncoder } = await createRenderPassFixture();
+  const pass = new RenderPass(device, { colorAttachments: [colorAttachment()] });
+
+  pass.draw({ vertexCount: 3, instanceCount: 2, firstVertex: 1, firstInstance: 4 });
+
+  expect(passEncoder.draw).toHaveBeenCalledWith(3, 2, 1, 4);
+  device.destroy();
+});
+
+test("prevents encoding after end", async () => {
+  const { device } = await createRenderPassFixture();
+  const pass = new RenderPass(device, { colorAttachments: [colorAttachment()] });
+
+  pass.end();
+
+  expect(() => pass.setBindGroup(0, {} as GPUBindGroup)).toThrow(/RenderPass\.gpu/);
+  try {
+    pass.setBindGroup(0, {} as GPUBindGroup);
+  } catch (error) {
+    expect(error).toMatchObject({ code: "VGPU-RENDER-PASS-ENDED" });
+  }
+  device.destroy();
+});
+
+async function createRenderPassFixture(): Promise<{ readonly device: Device; readonly passEncoder: RecordedRenderPass }> {
+  const { device } = await App.create({ adapter: createMockAdapter() });
+  const passEncoder: RecordedRenderPass = {
+    setPipeline: vi.fn(),
+    setBindGroup: vi.fn(),
+    setVertexBuffer: vi.fn(),
+    draw: vi.fn(),
+    end: vi.fn(),
+  };
+  const commandEncoder = {
+    beginRenderPass: vi.fn(() => passEncoder as unknown as GPURenderPassEncoder),
+    finish: vi.fn(() => ({} as GPUCommandBuffer)),
+  };
+  device.gpu.createCommandEncoder = vi.fn(() => commandEncoder as unknown as GPUCommandEncoder);
+  return { device, passEncoder };
+}
+
+function colorAttachment(): GPURenderPassColorAttachment {
+  return { view: {} as GPUTextureView, loadOp: "clear", storeOp: "store" };
+}

--- a/packages/render/tests/uniform-pool.test.ts
+++ b/packages/render/tests/uniform-pool.test.ts
@@ -1,0 +1,118 @@
+import { expect, test } from "vitest";
+import { createMockAdapter } from "@vgpu/adapter-mock";
+import { App } from "@vgpu/core";
+import { UniformPool, type UniformLayout } from "@vgpu/render";
+
+test("allocates a slot with the expected shape", async () => {
+  const { device } = await App.create({ adapter: createMockAdapter() });
+  const pool = new UniformPool(device, { capacityBytes: 512, minOffsetAlignment: 256 });
+
+  const slot = pool.alloc(floatLayout());
+
+  expect(slot).toMatchObject({ pool, stride: 256, bindGroup: null, bindGroupLayout: null });
+  expect(slot.gpu).toBe(pool.gpu);
+  device.destroy();
+});
+
+test("allocates distinct slots for repeated layouts", async () => {
+  const { device } = await App.create({ adapter: createMockAdapter() });
+  const pool = new UniformPool(device, { capacityBytes: 512, minOffsetAlignment: 256 });
+
+  expect(pool.alloc(floatLayout())).not.toBe(pool.alloc(floatLayout()));
+  device.destroy();
+});
+
+test("push writes encoded bytes into the CPU mirror", async () => {
+  const { device } = await App.create({ adapter: createMockAdapter() });
+  const pool = new UniformPool(device, { capacityBytes: 512, minOffsetAlignment: 256 });
+  const slot = pool.alloc(floatLayout());
+
+  const offset = slot.push(42);
+
+  expect(offset).toBe(0);
+  expect(new DataView(pool.cpuMirror).getFloat32(0, true)).toBe(42);
+  expect(pool.usedBytes).toBe(256);
+  device.destroy();
+});
+
+test("beginFrame resets frame-local writes after endFrame", async () => {
+  const { device } = await App.create({ adapter: createMockAdapter() });
+  const pool = new UniformPool(device, { capacityBytes: 512, minOffsetAlignment: 256 });
+  const slot = pool.alloc(floatLayout());
+  slot.push(1);
+
+  pool.endFrame();
+  pool.beginFrame(1);
+  const offset = slot.push(2);
+
+  expect(offset).toBe(0);
+  expect(pool.usedBytes).toBe(256);
+  expect(new DataView(pool.cpuMirror).getFloat32(0, true)).toBe(2);
+  device.destroy();
+});
+
+test("throws when pushing after endFrame before the next beginFrame", async () => {
+  const { device } = await App.create({ adapter: createMockAdapter() });
+  const pool = new UniformPool(device, { capacityBytes: 512, minOffsetAlignment: 256 });
+  const slot = pool.alloc(floatLayout());
+  pool.endFrame();
+
+  expect(() => slot.push(1)).toThrow(/beginFrame/);
+  try {
+    slot.push(1);
+  } catch (error) {
+    expect(error).toMatchObject({ code: "VGPU-CORE-UNIFORM-POOL-PUSH-AFTER-FLUSH" });
+  }
+  device.destroy();
+});
+
+test("throws when pushes exceed capacity", async () => {
+  const { device } = await App.create({ adapter: createMockAdapter() });
+  const pool = new UniformPool(device, { capacityBytes: 256, minOffsetAlignment: 256 });
+  const slot = pool.alloc(floatLayout());
+  slot.push(1);
+
+  expect(() => slot.push(2)).toThrow(/capacity/);
+  try {
+    slot.push(2);
+  } catch (error) {
+    expect(error).toMatchObject({ code: "VGPU-UNIFORM-POOL-OVERFLOW" });
+  }
+  device.destroy();
+});
+
+test("throws when a layout cannot fit in one binding", async () => {
+  const { device } = await App.create({ adapter: createMockAdapter() });
+  const pool = new UniformPool(device, { capacityBytes: 512, maxUniformBindingSize: 256 });
+
+  expect(() => pool.alloc(bytesLayout(300))).toThrow(/layout/);
+  try {
+    pool.alloc(bytesLayout(300));
+  } catch (error) {
+    expect(error).toMatchObject({ code: "VGPU-UNIFORM-LAYOUT-OVERSIZED" });
+  }
+  device.destroy();
+});
+
+test("dispose releases the backing buffer", async () => {
+  const { device } = await App.create({ adapter: createMockAdapter() });
+  const pool = new UniformPool(device, { capacityBytes: 512 });
+
+  pool.dispose();
+
+  expect(pool.disposed).toBe(true);
+  device.destroy();
+});
+
+function floatLayout(): UniformLayout<number> {
+  return {
+    size: 4,
+    encode(value, dst, byteOffset) {
+      new DataView(dst).setFloat32(byteOffset, value, true);
+    },
+  };
+}
+
+function bytesLayout(size: number): UniformLayout<Uint8Array> {
+  return { size, encode: (value, dst, byteOffset) => new Uint8Array(dst, byteOffset, value.byteLength).set(value) };
+}

--- a/packages/render/tests/uniform-pool.test.ts
+++ b/packages/render/tests/uniform-pool.test.ts
@@ -1,14 +1,12 @@
 import { expect, test } from "vitest";
 import { createMockAdapter } from "@vgpu/adapter-mock";
-import { App } from "@vgpu/core";
+import { App, createMockGPUDevice, Device } from "@vgpu/core";
 import { UniformPool, type UniformLayout } from "@vgpu/render";
 
 test("allocates a slot with the expected shape", async () => {
   const { device } = await App.create({ adapter: createMockAdapter() });
-  const pool = new UniformPool(device, { capacityBytes: 512, minOffsetAlignment: 256 });
-
+  const pool = new UniformPool(device, { capacityBytes: 512 });
   const slot = pool.alloc(floatLayout());
-
   expect(slot).toMatchObject({ pool, stride: 256, bindGroup: null, bindGroupLayout: null });
   expect(slot.gpu).toBe(pool.gpu);
   device.destroy();
@@ -16,19 +14,16 @@ test("allocates a slot with the expected shape", async () => {
 
 test("allocates distinct slots for repeated layouts", async () => {
   const { device } = await App.create({ adapter: createMockAdapter() });
-  const pool = new UniformPool(device, { capacityBytes: 512, minOffsetAlignment: 256 });
-
+  const pool = new UniformPool(device, { capacityBytes: 512 });
   expect(pool.alloc(floatLayout())).not.toBe(pool.alloc(floatLayout()));
   device.destroy();
 });
 
 test("push writes encoded bytes into the CPU mirror", async () => {
   const { device } = await App.create({ adapter: createMockAdapter() });
-  const pool = new UniformPool(device, { capacityBytes: 512, minOffsetAlignment: 256 });
+  const pool = new UniformPool(device, { capacityBytes: 512 });
   const slot = pool.alloc(floatLayout());
-
   const offset = slot.push(42);
-
   expect(offset).toBe(0);
   expect(new DataView(pool.cpuMirror).getFloat32(0, true)).toBe(42);
   expect(pool.usedBytes).toBe(256);
@@ -37,14 +32,12 @@ test("push writes encoded bytes into the CPU mirror", async () => {
 
 test("beginFrame resets frame-local writes after endFrame", async () => {
   const { device } = await App.create({ adapter: createMockAdapter() });
-  const pool = new UniformPool(device, { capacityBytes: 512, minOffsetAlignment: 256 });
+  const pool = new UniformPool(device, { capacityBytes: 512 });
   const slot = pool.alloc(floatLayout());
   slot.push(1);
-
   pool.endFrame();
   pool.beginFrame(1);
   const offset = slot.push(2);
-
   expect(offset).toBe(0);
   expect(pool.usedBytes).toBe(256);
   expect(new DataView(pool.cpuMirror).getFloat32(0, true)).toBe(2);
@@ -53,66 +46,83 @@ test("beginFrame resets frame-local writes after endFrame", async () => {
 
 test("throws when pushing after endFrame before the next beginFrame", async () => {
   const { device } = await App.create({ adapter: createMockAdapter() });
-  const pool = new UniformPool(device, { capacityBytes: 512, minOffsetAlignment: 256 });
+  const pool = new UniformPool(device, { capacityBytes: 512 });
   const slot = pool.alloc(floatLayout());
   pool.endFrame();
-
   expect(() => slot.push(1)).toThrow(/beginFrame/);
-  try {
-    slot.push(1);
-  } catch (error) {
-    expect(error).toMatchObject({ code: "VGPU-CORE-UNIFORM-POOL-PUSH-AFTER-FLUSH" });
-  }
+  expectInvalidCode(() => slot.push(1), "VGPU-CORE-UNIFORM-POOL-PUSH-AFTER-FLUSH");
   device.destroy();
 });
 
 test("throws when pushes exceed capacity", async () => {
   const { device } = await App.create({ adapter: createMockAdapter() });
-  const pool = new UniformPool(device, { capacityBytes: 256, minOffsetAlignment: 256 });
+  const pool = new UniformPool(device, { capacityBytes: 256 });
   const slot = pool.alloc(floatLayout());
   slot.push(1);
-
   expect(() => slot.push(2)).toThrow(/capacity/);
-  try {
-    slot.push(2);
-  } catch (error) {
-    expect(error).toMatchObject({ code: "VGPU-UNIFORM-POOL-OVERFLOW" });
-  }
+  expectInvalidCode(() => slot.push(2), "VGPU-UNIFORM-POOL-OVERFLOW");
   device.destroy();
 });
 
-test("throws when a layout cannot fit in one binding", async () => {
-  const { device } = await App.create({ adapter: createMockAdapter() });
-  const pool = new UniformPool(device, { capacityBytes: 512, maxUniformBindingSize: 256 });
-
-  expect(() => pool.alloc(bytesLayout(300))).toThrow(/layout/);
-  try {
-    pool.alloc(bytesLayout(300));
-  } catch (error) {
-    expect(error).toMatchObject({ code: "VGPU-UNIFORM-LAYOUT-OVERSIZED" });
-  }
-  device.destroy();
-});
-
-test("dispose releases the backing buffer", async () => {
-  const { device } = await App.create({ adapter: createMockAdapter() });
+test("throws when a layout cannot fit in one binding", () => {
+  const device = createDevice({ maxUniformBufferBindingSize: 256 });
   const pool = new UniformPool(device, { capacityBytes: 512 });
+  expect(() => pool.alloc(bytesLayout(300))).toThrow(/layout/);
+  expectInvalidCode(() => pool.alloc(bytesLayout(300)), "VGPU-UNIFORM-LAYOUT-OVERSIZED");
+  device.destroy();
+});
 
+test("dispose releases the backing buffer", () => {
+  let destroyed = false;
+  const device = createDevice({}, (buffer) => {
+    const destroy = buffer.destroy.bind(buffer);
+    Object.defineProperty(buffer, "destroy", { value: () => { destroyed = true; destroy(); } });
+    return buffer;
+  });
+  const pool = new UniformPool(device, { capacityBytes: 512 });
   pool.dispose();
-
   expect(pool.disposed).toBe(true);
+  expect(destroyed).toBe(true);
+  device.destroy();
+});
+
+test("rejects a slot allocated by a different pool", async () => {
+  const { device } = await App.create({ adapter: createMockAdapter() });
+  const poolA = new UniformPool(device, { capacityBytes: 512 });
+  const poolB = new UniformPool(device, { capacityBytes: 512 });
+  const slot = poolB.alloc(floatLayout());
+  expectInvalidCode(() => poolA.push(slot, 1), "VGPU-CORE-INVALID-USAGE");
+  expectInvalidCode(() => poolA.pushBytes(slot, new Float32Array([1])), "VGPU-CORE-INVALID-USAGE");
   device.destroy();
 });
 
 function floatLayout(): UniformLayout<number> {
-  return {
-    size: 4,
-    encode(value, dst, byteOffset) {
-      new DataView(dst).setFloat32(byteOffset, value, true);
-    },
-  };
+  return { size: 4, encode: (value, dst, byteOffset) => new DataView(dst).setFloat32(byteOffset, value, true) };
 }
 
 function bytesLayout(size: number): UniformLayout<Uint8Array> {
   return { size, encode: (value, dst, byteOffset) => new Uint8Array(dst, byteOffset, value.byteLength).set(value) };
+}
+
+function expectInvalidCode(action: () => void, code: string): void {
+  let thrown: unknown;
+  try {
+    action();
+  } catch (error) {
+    thrown = error;
+  }
+  expect(thrown).toMatchObject({ code });
+}
+
+function createDevice(
+  limits: Partial<Record<keyof GPUSupportedLimits, number>>,
+  createBuffer?: (buffer: GPUBuffer) => GPUBuffer,
+): Device {
+  const base = createMockGPUDevice();
+  const gpu = {
+    ...base,
+    limits,
+    createBuffer: (descriptor: GPUBufferDescriptor) => createBuffer?.(base.createBuffer(descriptor)) ?? base.createBuffer(descriptor),
+  } as unknown as GPUDevice;
+  return new Device(gpu, null);
 }

--- a/packages/render/tests/uniform-pool.test.ts
+++ b/packages/render/tests/uniform-pool.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "vitest";
 import { createMockAdapter } from "@vgpu/adapter-mock";
-import { App, createMockGPUDevice, Device } from "@vgpu/core";
+import { App, createMockGPUDevice, Device, VGPUError } from "@vgpu/core";
 import { UniformPool, type UniformLayout } from "@vgpu/render";
 
 test("allocates a slot with the expected shape", async () => {
@@ -111,6 +111,7 @@ function expectInvalidCode(action: () => void, code: string): void {
   } catch (error) {
     thrown = error;
   }
+  expect(thrown).toBeInstanceOf(VGPUError);
   expect(thrown).toMatchObject({ code });
 }
 


### PR DESCRIPTION
## Summary

This branch adds the core render path users need to encode draw commands through the render package and validate that RapidRenderer produces the same hello-triangle pixels as the existing plain-WGSL path.

Closes #23

## Public API additions

- RenderPass: `RenderPass`, `RenderPassOptions`, `ColorAttachment`, `RenderPassDrawOptions`, `RenderPassDynamicOffsets`
- UniformPool: `UniformPool`, `UniformPoolOptions`, `UniformLayout`, `UniformSlot`
- RapidRenderer: `RapidRenderer`, `DrawSpec`

## Validation

- `pnpm typecheck`
- `pnpm test:fast`
- `pnpm test:docker`
- `pnpm bundle-check`

## Bundle size

| Package | main | this branch | Delta | Budget |
| --- | ---: | ---: | ---: | ---: |
| `@vgpu/adapter-mock` | 12020 B | 12020 B | +0 B | 20480 B |
| `@vgpu/adapter-node` | 14425 B | 14425 B | +0 B | 30720 B |
| `@vgpu/core` | 26005 B | 26005 B | +0 B | 51200 B |
| `@vgpu/render` | 15225 B | 22527 B | +7302 B | 40960 B |
| `@vgpu/wgsl` | 688 B | 688 B | +0 B | 25600 B |

## Snapshot integrity

`packages/render/tests/__snapshots__/hello-triangle.png` SHA256 `7c7ac707cc2086d2d49d0ace09e531d1a0c5acf37ae1629df8aa8ba6c7ddcc2c` byte-equal to existing baseline.
