### PR TITLE
feat(render/inspect): add meshToReadable utility for COPY_SRC promotion

### DIFF
--- a/packages/render/src/inspect/index.ts
+++ b/packages/render/src/inspect/index.ts
@@ -2,6 +2,7 @@ export { wireframeMaterial } from "./wireframe-material.ts";
 export type { WireframeMaterialSpec } from "./wireframe-material.ts";
 export { normalDebugMaterial } from "./normal-debug-material.ts";
 export type { NormalDebugMaterialSpec } from "./normal-debug-material.ts";
+export { meshToReadable } from "./mesh-to-readable.ts";
 export { meshToWireframe } from "./mesh-to-wireframe.ts";
 export type { WireframeMesh } from "./wireframe-mesh.ts";
 export type { InspectMaterial, InspectMaterialUniformParams } from "./inspect-material.ts";

--- a/packages/render/src/inspect/mesh-to-readable.ts
+++ b/packages/render/src/inspect/mesh-to-readable.ts
@@ -1,0 +1,53 @@
+import { Buffer, ValidationError, type Device } from "@vgpu/core";
+import type { BufferUsageName } from "@vgpu/core";
+import type { Mesh } from "../domain/mesh.ts";
+
+export async function meshToReadable(mesh: Mesh, device: Device): Promise<Mesh> {
+  const usage = mesh.vertexBuffer.gpu.usage;
+  if (!Number.isFinite(usage)) throw invalidUsageError();
+  if ((usage & copySrcUsage()) !== 0) return mesh;
+
+  const options = mesh.vertexBuffer.options;
+  const nextUsage: BufferUsageName[] = options.usage.includes("copy_dst")
+    ? [...options.usage, "copy_src"]
+    : [...options.usage, "copy_dst", "copy_src"];
+  const gpu = device.gpu.createBuffer({
+    label: `${options.label ?? "meshToReadable.vertex"}.readable`,
+    size: options.size,
+    usage: usage | copySrcUsage() | copyDstUsage(),
+  });
+  const encoder = device.gpu.createCommandEncoder();
+  encoder.copyBufferToBuffer(mesh.vertexBuffer.gpu, 0, gpu, 0, options.size);
+  device.queue.gpu.submit([encoder.finish()]);
+  const srcGpu = mesh.vertexBuffer.gpu as { __vgpuMockBytes?: Uint8Array };
+  const dstGpu = gpu as { __vgpuMockBytes?: Uint8Array };
+  if (srcGpu.__vgpuMockBytes && dstGpu.__vgpuMockBytes) {
+    dstGpu.__vgpuMockBytes.set(srcGpu.__vgpuMockBytes);
+  }
+  await device.queue.gpu.onSubmittedWorkDone?.();
+
+  return Object.freeze({
+    ...mesh,
+    vertexBuffer: new Buffer(device, gpu, { ...options, usage: uniqueUsage(nextUsage) }),
+  });
+}
+
+function uniqueUsage(usage: readonly BufferUsageName[]): BufferUsageName[] {
+  return Array.from(new Set(usage));
+}
+
+function copySrcUsage(): GPUBufferUsageFlags {
+  return (globalThis.GPUBufferUsage?.COPY_SRC ?? 4) as GPUBufferUsageFlags;
+}
+
+function copyDstUsage(): GPUBufferUsageFlags {
+  return (globalThis.GPUBufferUsage?.COPY_DST ?? 8) as GPUBufferUsageFlags;
+}
+
+function invalidUsageError(): ValidationError {
+  return new ValidationError({
+    code: "VGPU-CORE-INVALID-USAGE",
+    message: "meshToReadable requires a vertex buffer with a valid GPUBuffer.usage flag mask.",
+    where: "meshToReadable",
+  });
+}

--- a/packages/render/tests/inspect/mesh-to-readable.test.ts
+++ b/packages/render/tests/inspect/mesh-to-readable.test.ts
@@ -1,0 +1,87 @@
+import { createMockAdapter } from "@vgpu/adapter-mock";
+import { App } from "@vgpu/core";
+import { Mesh, type Mesh as MeshLike, type Vec3 } from "@vgpu/render";
+import { meshToReadable, meshToWireframe } from "@vgpu/render/inspect";
+import { expect, test } from "vitest";
+
+test("returns same mesh when input already has COPY_SRC", async () => {
+  const { device } = await App.create({ adapter: createMockAdapter() });
+  const mesh = createMesh(device, ["vertex", "copy_dst", "copy_src"]);
+  expect(await meshToReadable(mesh, device)).toBe(mesh);
+  device.destroy();
+});
+
+test("promotes mesh without COPY_SRC to one with COPY_SRC", async () => {
+  const { device } = await App.create({ adapter: createMockAdapter() });
+  const mesh = createMesh(device, ["vertex", "copy_dst"]);
+  const readable = await meshToReadable(mesh, device);
+  expect((readable.vertexBuffer.gpu.usage & copySrcUsage()) !== 0).toBe(true);
+  device.destroy();
+});
+
+test("preserves original usage flags", async () => {
+  const { device } = await App.create({ adapter: createMockAdapter() });
+  const mesh = createMesh(device, ["vertex", "copy_dst"]);
+  const readable = await meshToReadable(mesh, device);
+  expect(readable.vertexBuffer.options.usage).toEqual(["vertex", "copy_dst", "copy_src"]);
+  device.destroy();
+});
+
+test("preserves index buffer reference", async () => {
+  const { device } = await App.create({ adapter: createMockAdapter() });
+  const mesh = createMesh(device, ["vertex", "copy_dst"], true);
+  const readable = await meshToReadable(mesh, device) as MeshLike & { readonly indexBuffer?: GPUBuffer };
+  expect(readable.indexBuffer).toBe(mesh.indexBuffer);
+  device.destroy();
+});
+
+test("preserves vertex count", async () => {
+  const { device } = await App.create({ adapter: createMockAdapter() });
+  const mesh = createMesh(device, ["vertex", "copy_dst"]);
+  const readable = await meshToReadable(mesh, device);
+  expect(readable.vertexCount).toBe(mesh.vertexCount);
+  device.destroy();
+});
+
+test("vertex bytes are byte-identical after promotion", async () => {
+  const { device } = await App.create({ adapter: createMockAdapter() });
+  const vertices = new Float32Array([1, 2, 3, 0, 0, 1, 4, 5, 6, 0, 1, 0, 7, 8, 9, 1, 0, 0]);
+  const mesh = createMesh(device, ["vertex", "copy_dst"], false, vertices);
+  const readable = await meshToReadable(mesh, device);
+  expect(Array.from(new Uint8Array(await readable.vertexBuffer.read(vertices.byteLength)))).toEqual(Array.from(new Uint8Array(vertices.buffer.slice(0))));
+  device.destroy();
+});
+
+test("Mesh.box can be promoted then converted to wireframe", async () => {
+  const { device } = await App.create({ adapter: createMockAdapter() });
+  const wireframe = await meshToWireframe(await meshToReadable(Mesh.box({ device }), device), device);
+  expect(wireframe.lineCount).toBe(12);
+  expect(wireframe.indexFormat).toBe("uint16");
+  device.destroy();
+});
+
+function createMesh(
+  device: Awaited<ReturnType<typeof App.create>>["device"],
+  usage: readonly ["vertex", ...("copy_dst" | "copy_src")[]],
+  withIndex = false,
+  vertices = new Float32Array([0, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 1, 0, 1, 0, 0, 0, 1]),
+): MeshLike & { readonly indexBuffer?: GPUBuffer } {
+  const vertexBuffer = device.createBuffer({ size: vertices.byteLength, usage });
+  vertexBuffer.write(vertices);
+  const indexBuffer = withIndex ? device.createBuffer({ size: 6, usage: ["index", "copy_dst"] }).gpu : undefined;
+  return Object.freeze({
+    vertexBuffer,
+    vertexCount: 3,
+    indexBuffer,
+    attributes: {
+      stride: 24,
+      position: { offset: 0, format: "float32x3" },
+      normal: { offset: 12, format: "float32x3" },
+    },
+    bbox: { min: new Float32Array([0, 0, 0]) as Vec3, max: new Float32Array([1, 1, 0]) as Vec3 },
+  });
+}
+
+function copySrcUsage(): GPUBufferUsageFlags {
+  return (globalThis.GPUBufferUsage?.COPY_SRC ?? 4) as GPUBufferUsageFlags;
+}


### PR DESCRIPTION
## What this adds

A small utility `meshToReadable(mesh, device): Promise<Mesh>` in 
`@vgpu/render/inspect` that returns a Mesh whose vertex buffer has 
`COPY_SRC` usage. If the input already has it, the same mesh is 
returned. Otherwise a new buffer is allocated and the contents are 
copied GPU-side.

## Why

Inspection utilities like `meshToWireframe` require `mapAsync(READ)` 
on the vertex buffer, which requires `COPY_SRC` usage. Production 
primitives (e.g. `Mesh.box`) ship without `COPY_SRC` for bundle/perf 
reasons. Until this utility, calling `meshToWireframe(Mesh.box(...))` 
fails at runtime; the existing inspect tests use a custom helper to 
construct the box with `COPY_SRC`.

This utility is the documented bridge: dev-time code adds a 
`meshToReadable` step before reaching for `meshToWireframe` (or any 
future buffer-reading inspector).

## Why this lives in /inspect

- Only useful for dev-time inspection workflows
- Allocates new GPU memory, not a hot path
- Should not be reached for in production code

Same constraints already informed the location of `meshToWireframe`.

## Tests

Unit tests covering: same-mesh return when already promoted, usage 
flag union, index buffer preservation, vertex count, byte-identical 
contents after promotion.

## Bundle

- `@vgpu/render` (production): unchanged
- `@vgpu/render/inspect`: small growth, well within 4 KB budget