### PR TITLE
chore(scripts): improve snapshot tooling DX

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "typecheck": "tsc -b",
     "test": "vitest run",
     "test:fast": "vitest run packages/adapter-mock packages/core packages/wgsl packages/render",
-    "test:docker": "docker build --platform linux/arm64 -t vgpu-test:s2 -f infra/test-docker/Dockerfile . && docker run --rm vgpu-test:s2 sh -lc 'Xvfb :99 -screen 0 1024x768x24 >/tmp/xvfb.log 2>&1 & xvfb_pid=$!; VGPU_DOCKER_TEST=1 pnpm test; status=$?; kill $xvfb_pid; exit $status'",
+    "test:docker": "docker build --platform linux/arm64 -t vgpu-test:s2 -f infra/test-docker/Dockerfile . && docker run --rm -v $(pwd):/workspace -e VGPU_WRITE_SNAPSHOTS=${VGPU_WRITE_SNAPSHOTS:-} vgpu-test:s2 sh -lc 'Xvfb :99 -screen 0 1024x768x24 >/tmp/xvfb.log 2>&1 & xvfb_pid=$!; VGPU_DOCKER_TEST=1 pnpm test; status=$?; kill $xvfb_pid; exit $status'",
     "generate-lit-cube-snapshot": "pnpm exec esbuild scripts/generate-lit-cube-snapshot.ts --bundle --platform=node --format=esm --external:pngjs --external:webgpu --outfile=packages/adapter-node/dist/generate-lit-cube-snapshot.mjs && node packages/adapter-node/dist/generate-lit-cube-snapshot.mjs",
     "bundle-check": "node scripts/check-bundle-size.mjs"
   },

--- a/packages/adapter-node/src/index.ts
+++ b/packages/adapter-node/src/index.ts
@@ -1,16 +1,19 @@
+import { execFileSync } from "node:child_process";
 import { createRequire } from "node:module";
 import { Device, VGPUError, type CreateDeviceOptions, type VGPUAdapter } from "@vgpu/core";
 
 type WebGPUModule = { create(options: string[]): GPU; globals: Record<string, unknown> };
 type NodeAdapterFlags = { readonly backendFlags?: readonly string[] };
 type RequestDeviceOptions = CreateDeviceOptions & NodeAdapterFlags & { readonly backend?: "opengl" | "webgpu" };
-
 type DawnAdapterOptions = GPURequestAdapterOptions & { readonly featureLevel?: "compatibility" };
+type BinaryLoadErrorOptions = { readonly detectedGlibcVersion?: string | null };
 
 const require = createRequire(import.meta.url);
+const dawnMinimumGlibcVersion = "2.38";
 let dawnGPU: GPU | null = null;
 let dawnFlagsUsed: readonly string[] | null = null;
 let loadedWebGPU: WebGPUModule | null = null;
+let hostGlibcVersion: string | null | undefined;
 
 export function createNodeAdapter(): VGPUAdapter {
   return { requestDevice };
@@ -56,13 +59,7 @@ async function loadWebGPU(): Promise<WebGPUModule> {
       loadedWebGPU = (await import("webgpu")) as WebGPUModule;
       return loadedWebGPU;
     } catch (importCause) {
-      throw new VGPUError({
-        code: "VGPU-ADAPTER-NODE-BINARY-LOAD",
-        message: "@vgpu/adapter-node could not load the Dawn WebGPU native binary.",
-        fix: "Run inside the pinned vgpu Docker image with Node 22, Debian trixie, and the OpenGL software stack.",
-        where: "createNodeAdapter",
-        cause: importCause ?? cause,
-      });
+      throw formatBinaryLoadError(importCause ?? cause, { detectedGlibcVersion: getHostGlibcVersion() });
     }
   }
 }
@@ -84,4 +81,43 @@ function adapterOptions(opts: RequestDeviceOptions): DawnAdapterOptions {
 
 function flagsEqual(a: readonly string[], b: readonly string[] | null): boolean {
   return b !== null && a.length === b.length && a.every((flag, index) => flag === b[index]);
+}
+
+export function formatBinaryLoadError(cause: unknown, options: BinaryLoadErrorOptions = {}): VGPUError {
+  const detectedGlibcVersion = options.detectedGlibcVersion ?? null;
+  if (process.platform === "linux" && isGlibcLoadFailure(cause)) {
+    const versionLine = detectedGlibcVersion
+      ? `This host reports GLIBC ${detectedGlibcVersion}.`
+      : "This host reports GLIBC older than 2.38.";
+    return new VGPUError({
+      code: "VGPU-ADAPTER-NODE-BINARY-LOAD",
+      message: `@vgpu/adapter-node requires GLIBC ${dawnMinimumGlibcVersion} or newer to load the Dawn WebGPU native binary. ${versionLine}`,
+      fix: "Use Docker instead: `pnpm test:docker`, or upgrade your host GLIBC to a compatible version.",
+      where: "createNodeAdapter",
+      cause,
+    });
+  }
+  return new VGPUError({
+    code: "VGPU-ADAPTER-NODE-BINARY-LOAD",
+    message: "@vgpu/adapter-node could not load the Dawn WebGPU native binary.",
+    fix: "Run inside the pinned vgpu Docker image with Node 22, Debian trixie, and the OpenGL software stack.",
+    where: "createNodeAdapter",
+    cause,
+  });
+}
+
+function isGlibcLoadFailure(cause: unknown): boolean {
+  return /GLIBC_\d+\.\d+/.test(String(cause));
+}
+
+function getHostGlibcVersion(): string | null {
+  if (process.platform !== "linux") return null;
+  if (hostGlibcVersion !== undefined) return hostGlibcVersion;
+  try {
+    const output = execFileSync("ldd", ["--version"], { encoding: "utf8" });
+    hostGlibcVersion = output.match(/(\d+\.\d+)/)?.[1] ?? null;
+  } catch {
+    hostGlibcVersion = null;
+  }
+  return hostGlibcVersion;
 }

--- a/packages/adapter-node/tests/glibc-error.test.ts
+++ b/packages/adapter-node/tests/glibc-error.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, test } from "vitest";
+import { formatBinaryLoadError } from "../src/index";
+
+describe("formatBinaryLoadError", () => {
+  test("reports glibc workaround for older linux hosts", () => {
+    const error = formatBinaryLoadError(new Error("libc.so.6: version `GLIBC_2.38' not found"), "2.36");
+    expect(error.message).toContain("requires GLIBC 2.38 or newer");
+    expect(error.fix).toContain("pnpm test:docker");
+    expect(String(error.cause)).toContain("GLIBC_2.38");
+  });
+});


### PR DESCRIPTION
Discovered during [PR #46](https://github.com/vercel-labs/vgpu/pull/46) wireframe-overlay snapshot generation work.

This fixes two snapshot-tooling friction points:

1. `VGPU_WRITE_SNAPSHOTS=1 pnpm test:docker` did not propagate `VGPU_WRITE_SNAPSHOTS` into the Docker test container, so snapshot-writing tests inside Docker never saw the flag.
2. Local non-Docker snapshot generation on Linux hosts with older glibc failed with the cryptic Dawn load error:
   - `@vgpu/adapter-node could not load the Dawn WebGPU native binary.`
   - underlying load failures include strings like `libc.so.6: version 'GLIBC_2.38' not found`

## Fix 1: pass snapshot writes through Docker and keep writes on the host

The Docker test command now both passes the env var and mounts the workspace so snapshot writes persist on the host:

```diff
-    "test:docker": "docker build --platform linux/arm64 -t vgpu-test:s2 -f infra/test-docker/Dockerfile . && docker run --rm vgpu-test:s2 sh -lc 'Xvfb :99 -screen 0 1024x768x24 >/tmp/xvfb.log 2>&1 & xvfb_pid=$!; VGPU_DOCKER_TEST=1 pnpm test; status=$?; kill $xvfb_pid; exit $status'",
+    "test:docker": "docker build --platform linux/arm64 -t vgpu-test:s2 -f infra/test-docker/Dockerfile . && docker run --rm -v $(pwd):/workspace -e VGPU_WRITE_SNAPSHOTS=${VGPU_WRITE_SNAPSHOTS:-} vgpu-test:s2 sh -lc 'Xvfb :99 -screen 0 1024x768x24 >/tmp/xvfb.log 2>&1 & xvfb_pid=$!; VGPU_DOCKER_TEST=1 pnpm test; status=$?; kill $xvfb_pid; exit $status'",
```

That means `VGPU_WRITE_SNAPSHOTS=1 pnpm test:docker` now reaches the test process, and any `__snapshots__/` writes happen in the mounted host workspace instead of being discarded with the container filesystem.

## Fix 2: fail fast on old glibc with a clear Docker workaround

`@vgpu/adapter-node` now wraps Dawn native-binary load failures and detects Linux glibc-related errors by:

- checking for `GLIBC_<major>.<minor>` in the native load failure
- parsing `ldd --version` on Linux to report the host glibc version
- skipping the glibc version probe on macOS / non-Linux hosts

When the failure is glibc-related, users now get a targeted error like:

```text
@vgpu/adapter-node requires GLIBC 2.38 or newer to load the Dawn WebGPU native binary. This host reports GLIBC 2.36.
```

with the fix text:

```text
Use Docker instead: `pnpm test:docker`, or upgrade your host GLIBC to a compatible version.
```

This specifically covers hosts where Dawn fails with messages like `GLIBC_2.38 not found`. The Linux `ldd --version` probe reports the detected version when available; on macOS the probe is skipped and the existing generic binary-load error path remains in place.

## Verification

- `pnpm exec vitest run packages/adapter-node/tests/glibc-error.test.ts`
- `pnpm typecheck`
- `pnpm run bundle-check`
