### PR TITLE
chore(scripts): exclude node_modules from test:docker bind-mount

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "typecheck": "tsc -b",
     "test": "vitest run",
     "test:fast": "vitest run packages/adapter-mock packages/core packages/wgsl packages/render",
-    "test:docker": "docker build --platform linux/arm64 -t vgpu-test:s2 -f infra/test-docker/Dockerfile . && docker run --rm -v $(pwd):/workspace -e VGPU_WRITE_SNAPSHOTS=${VGPU_WRITE_SNAPSHOTS:-} vgpu-test:s2 sh -lc 'Xvfb :99 -screen 0 1024x768x24 >/tmp/xvfb.log 2>&1 & xvfb_pid=$!; VGPU_DOCKER_TEST=1 pnpm test; status=$?; kill $xvfb_pid; exit $status'",
+    "test:docker": "docker build --platform linux/arm64 -t vgpu-test:s2 -f infra/test-docker/Dockerfile . && docker run --rm -v $(pwd)/packages/render/tests/__snapshots__:/workspace/packages/render/tests/__snapshots__ -v $(pwd)/packages/render/tests/inspect/__snapshots__:/workspace/packages/render/tests/inspect/__snapshots__ -v $(pwd)/packages/render/tests/poc/__snapshots__:/workspace/packages/render/tests/poc/__snapshots__ -v $(pwd)/packages/render/tests/primitives/__snapshots__:/workspace/packages/render/tests/primitives/__snapshots__ -e VGPU_WRITE_SNAPSHOTS=${VGPU_WRITE_SNAPSHOTS:-} vgpu-test:s2 sh -lc 'Xvfb :99 -screen 0 1024x768x24 >/tmp/xvfb.log 2>&1 & xvfb_pid=$!; VGPU_DOCKER_TEST=1 pnpm test; status=$?; kill $xvfb_pid; exit $status'",
     "generate-lit-cube-snapshot": "pnpm exec esbuild scripts/generate-lit-cube-snapshot.ts --bundle --platform=node --format=esm --external:pngjs --external:webgpu --outfile=packages/adapter-node/dist/generate-lit-cube-snapshot.mjs && node packages/adapter-node/dist/generate-lit-cube-snapshot.mjs",
     "bundle-check": "node scripts/check-bundle-size.mjs"
   },


### PR DESCRIPTION
## Summary
- fix the `pnpm test:docker` regression introduced by #47
- preserve snapshot write-back by mounting only snapshot directories into `/workspace`
- keep the container image's preinstalled `node_modules` visible during docker test runs

## Details
PR #47 added a full `-v $(pwd):/workspace` bind-mount so `VGPU_WRITE_SNAPSHOTS=1` writes would persist on the host. That solved snapshot regeneration, but it also shadowed the container's preinstalled `node_modules/` with the host's `node_modules/`. On hosts without a compatible native `webgpu` binding for the container GLIBC, `pnpm test:docker` then failed with:

```txt
Error: Cannot find module 'webgpu'
Require stack:
- /workspace/packages/wgsl/src/runtime/validation.ts
```

This change keeps the write-back behavior from #47, but narrows the bind-mount to the snapshot directories that actually need persistence:

- `packages/render/tests/__snapshots__`
- `packages/render/tests/inspect/__snapshots__`
- `packages/render/tests/poc/__snapshots__`
- `packages/render/tests/primitives/__snapshots__`

That avoids shadowing `/workspace/node_modules` and preserves the image-baked dependencies during test execution.

Regression from #47; discovered during the #43 bug fix loop.

0-delta on `@vgpu/*` packages.

## Verification
- `pnpm typecheck`
- `pnpm test:docker -- packages/render/tests/inspect`
