### PR TITLE
feat(passes): MRT Chunk A — variadic colors tuple + colorAttachments alias

### DIFF
--- a/packages/render/src/passes/pass.ts
+++ b/packages/render/src/passes/pass.ts
@@ -18,11 +18,11 @@ type DeviceCarrier = { readonly device?: Device };
 /** Records and optionally submits one material+mesh draw into a pass target. */
 export function pass(spec: PassSpec): void {
   void spec.bindings;
-  const colorAttachment = colorAttachmentFor(spec.target, spec);
+  const colorAttachments = colorAttachmentsFor(spec.target, spec);
   const depthStencilAttachment = depthAttachmentFor(spec.target, spec);
   const device = spec.encoder ? undefined : deviceFrom(spec.mesh);
   const encoder = spec.encoder ?? (device as Device).gpu.createCommandEncoder();
-  const renderPass = encoder.beginRenderPass({ colorAttachments: [colorAttachment], depthStencilAttachment });
+  const renderPass = encoder.beginRenderPass({ colorAttachments, depthStencilAttachment });
 
   if (spec.viewport) renderPass.setViewport(spec.viewport[0], spec.viewport[1], spec.viewport[2], spec.viewport[3], 0, 1);
   if (spec.scissor) renderPass.setScissorRect(spec.scissor[0], spec.scissor[1], spec.scissor[2], spec.scissor[3]);
@@ -43,20 +43,18 @@ export function pass(spec: PassSpec): void {
   if (device) device.queue.gpu.submit([encoder.finish()]);
 }
 
-function colorAttachmentFor(target: PassTarget, spec: PassSpec): GPURenderPassColorAttachment {
+function colorAttachmentsFor(target: PassTarget, spec: PassSpec): readonly GPURenderPassColorAttachment[] {
   const loadOp = spec.colorLoadOp ?? "clear";
   if (isRenderTarget(target)) {
-    const attachment = { ...target.gpu.colorAttachment };
-    attachment.loadOp = spec.colorLoadOp ?? attachment.loadOp;
-    attachment.clearValue = spec.clearColor ? colorDict(spec.clearColor) : attachment.clearValue;
-    return attachment;
+    return target.gpu.colorAttachments.map((source) => {
+      const attachment = { ...source };
+      attachment.loadOp = spec.colorLoadOp ?? attachment.loadOp;
+      attachment.clearValue = spec.clearColor ? colorDict(spec.clearColor) : attachment.clearValue;
+      return attachment;
+    });
   }
-  if (isTexture(target)) {
-    return { view: target.createView(), loadOp, storeOp: "store", clearValue: colorDict(spec.clearColor) };
-  }
-  if (isTextureView(target)) {
-    return { view: target, loadOp, storeOp: "store", clearValue: colorDict(spec.clearColor) };
-  }
+  if (isTexture(target)) return [{ view: target.createView(), loadOp, storeOp: "store", clearValue: colorDict(spec.clearColor) }];
+  if (isTextureView(target)) return [{ view: target, loadOp, storeOp: "store", clearValue: colorDict(spec.clearColor) }];
   throw invalidTarget();
 }
 
@@ -89,7 +87,7 @@ function deviceFrom(mesh: Mesh): Device {
 
 function isRenderTarget(value: unknown): value is RenderTarget {
   const gpu = (value as { gpu?: unknown } | undefined)?.gpu;
-  return isObject(gpu) && "colorAttachment" in gpu;
+  return isObject(gpu) && "colorAttachments" in gpu;
 }
 
 function isTexture(value: unknown): value is Texture {

--- a/packages/render/src/render-target/render-target-canvas.ts
+++ b/packages/render/src/render-target/render-target-canvas.ts
@@ -21,7 +21,7 @@ export function renderTargetForCanvas(context: GPUCanvasContext, options: Canvas
   const clearColor = colorDict(options.clearColor);
   const target = {
     get color(): Texture { return canvasTexture(context, options.label); },
-    get colors(): readonly [Texture] { return Object.freeze([this.color]) as readonly [Texture]; },
+    get colors(): readonly [Texture, ...Texture[]] { return Object.freeze([this.color]) as readonly [Texture, ...Texture[]]; },
     get depth(): undefined { return undefined; },
     get size(): readonly [number, number] { return canvasSize(context); },
     get format(): GPUTextureFormat { return canvasFormat(context); },
@@ -29,9 +29,12 @@ export function renderTargetForCanvas(context: GPUCanvasContext, options: Canvas
     get label(): string { return options.label ?? "canvas"; },
     get gpu(): RenderTargetGpu {
       const texture = context.getCurrentTexture();
+      const colorAttachment = { view: texture.createView(), loadOp: "clear" as const, storeOp: "store" as const, clearValue: clearColor };
       return Object.freeze({
-        colorAttachment: { view: texture.createView(), loadOp: "clear" as const, storeOp: "store" as const, clearValue: clearColor },
+        colorAttachments: Object.freeze([colorAttachment]),
+        colorAttachment,
         colorTexture: texture,
+        colorTextures: Object.freeze([texture]),
       });
     },
   } satisfies RenderTarget;

--- a/packages/render/src/render-target/render-target.ts
+++ b/packages/render/src/render-target/render-target.ts
@@ -61,14 +61,18 @@ export async function renderTarget(spec: RenderTargetSpec): Promise<RenderTarget
     depthStoreOp: "store" as const,
     depthClearValue: 1,
   } : undefined;
+  const colorAttachments = Object.freeze([colorAttachment]);
+  const colorTextures = Object.freeze([color.gpu]);
   const gpu: RenderTargetGpu = Object.freeze({
+    colorAttachments,
     colorAttachment,
     depthStencilAttachment,
     colorTexture: color.gpu,
+    colorTextures,
     resolveTexture: resolve?.gpu,
     depthTexture: depth?.gpu,
   });
-  const colors = Object.freeze([sampleableColor]) as readonly [Texture];
+  const colors = Object.freeze([sampleableColor]) as readonly [Texture, ...Texture[]];
   return Object.freeze({ color: sampleableColor, colors, depth, size, format, sampleCount, label: spec.label, gpu });
 }
 

--- a/packages/render/src/render-target/types.ts
+++ b/packages/render/src/render-target/types.ts
@@ -5,7 +5,7 @@ import type { Mesh } from "../domain/mesh.ts";
 /** Render target wrapper for color, depth, and optional MSAA attachments. */
 export interface RenderTarget {
   readonly color: Texture;
-  readonly colors: readonly [Texture];
+  readonly colors: readonly [Texture, ...Texture[]];
   readonly depth?: Texture;
   readonly size: readonly [number, number];
   readonly format: GPUTextureFormat;
@@ -16,9 +16,12 @@ export interface RenderTarget {
 
 /** Raw GPU attachments and pass descriptor fragments owned by a render target. */
 export interface RenderTargetGpu {
+  readonly colorAttachments: readonly GPURenderPassColorAttachment[];
+  /** @deprecated use `colorAttachments[0]`; alias retained for one deprecation cycle. */
   readonly colorAttachment: GPURenderPassColorAttachment;
   readonly depthStencilAttachment?: GPURenderPassDepthStencilAttachment;
   readonly colorTexture: GPUTexture;
+  readonly colorTextures: readonly GPUTexture[];
   readonly resolveTexture?: GPUTexture;
   readonly depthTexture?: GPUTexture;
 }


### PR DESCRIPTION
Refs https://github.com/vercel-labs/vgpu/issues/49

Chunk A: type evolution only, behavior unchanged, sets stage for renderTargetMulti factory in Chunk B.

Validation:
- pnpm typecheck
- pnpm test:fast
- pnpm bundle-check

Notes:
- Full `pnpm test` fails locally on adapter-node GLIBC 2.38 native binary requirement; CI docker path should cover integration.