### PR TITLE
chore(release): v0.0.1 publish prep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,15 @@
+## 0.0.1 — 2026-05-07
+
+First public preview. API will shift before 0.1.0.
+
+### Shipped
+- @vgpu/core: device, buffer, texture, shader, queue, app primitives
+- @vgpu/render: render pipeline + render pass + bind group helpers
+- @vgpu/wgsl: WGSL compile + runtime resolve + webpack/vite loaders
+- @vgpu/adapter-mock: mock GPU adapter for tests
+- @vgpu/adapter-node: Node.js GPU adapter (Dawn-backed, linux-arm64 prebuilts)
+
+### Known limitations
+- Single-color render targets only (MRT lands in 0.1.0)
+- No texture sampling helpers yet (lands in 0.1.0)
+- API is unstable; expect breaking changes before 0.1.0

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 matiasngf
+Copyright (c) 2025 Vercel, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,9 +1,104 @@
 # vgpu
 
-Agentic-first WebGPU library. Run the same code on Node (Dawn), the web (browser WebGPU), and serverless platforms (linux-arm64 prebuilt binaries).
+> ⚠️ **0.0.1 — early preview. API will shift before 0.1.0.**
 
-> 🚧 **Status:** in active development — bootstrapping. The architectural plan is captured in [issue #7 (decisions)](https://github.com/vercel-labs/vgpu/issues/7) and [issue #17 (API spec)](https://github.com/vercel-labs/vgpu/issues/17). PHASE-1 implementation begins next.
+Agentic-first WebGPU library. Run the same code on Node (Dawn), the web (browser WebGPU), and serverless platforms with linux-arm64 prebuilts. vgpu keeps the surface area small in 0.0.1: core device and resource primitives, a thin render layer, WGSL tooling, and adapters for real Node runtimes or deterministic tests.
+
+## Packages
+
+| Package | What it is |
+| --- | --- |
+| [`@vgpu/core`](./packages/core/README.md) | Core runtime primitives for devices, buffers, textures, shaders, queues, and app bootstrapping. |
+| [`@vgpu/render`](./packages/render/README.md) | Minimal render-pipeline and render-pass helpers built on top of `@vgpu/core`. |
+| [`@vgpu/wgsl`](./packages/wgsl/README.md) | WGSL compile helpers plus runtime resolution and webpack/vite integration points. |
+| [`@vgpu/adapter-mock`](./packages/adapter-mock/README.md) | Mock adapter for tests and local validation without real GPU hardware. |
+| [`@vgpu/adapter-node`](./packages/adapter-node/README.md) | Node.js adapter backed by Dawn WebGPU bindings, including linux-arm64 prebuilt support. |
+
+## Install
+
+```bash
+pnpm add @vgpu/core @vgpu/render @vgpu/wgsl
+# plus an adapter:
+pnpm add @vgpu/adapter-node    # Node.js / serverless
+# or @vgpu/adapter-mock for tests
+```
+
+## Quickstart
+
+```ts
+import { createNodeAdapter } from "@vgpu/adapter-node";
+import { App } from "@vgpu/core";
+import { createRenderPipeline, RenderPass } from "@vgpu/render";
+import { compile } from "@vgpu/wgsl";
+
+const TRIANGLE_WGSL = `
+struct VSOut {
+  @builtin(position) pos: vec4f,
+  @location(0) color: vec3f,
+};
+
+@vertex
+fn vs_main(@builtin(vertex_index) vi: u32) -> VSOut {
+  var positions = array<vec2f, 3>(vec2f(0.0, 0.5), vec2f(-0.5, -0.5), vec2f(0.5, -0.5));
+  var colors = array<vec3f, 3>(vec3f(1.0, 0.0, 0.0), vec3f(0.0, 1.0, 0.0), vec3f(0.0, 0.0, 1.0));
+  var out: VSOut;
+  out.pos = vec4f(positions[vi], 0.0, 1.0);
+  out.color = colors[vi];
+  return out;
+}
+
+@fragment
+fn fs_main(in: VSOut) -> @location(0) vec4f {
+  return vec4f(in.color, 1.0);
+}
+`;
+
+const { device } = await App.create({ adapter: createNodeAdapter() });
+const target = device.createTexture({
+  size: [256, 256],
+  format: "rgba8unorm",
+  usage: ["render_attachment", "copy_src"],
+});
+const shader = device.createShader(compile(TRIANGLE_WGSL));
+const pipeline = createRenderPipeline(device, {
+  shader,
+  vertex: { entry: "vs_main" },
+  fragment: { entry: "fs_main", targets: [{ format: "rgba8unorm" }] },
+  primitive: { topology: "triangle-list" },
+});
+const pass = new RenderPass(device, {
+  colorAttachments: [{ view: target, loadOp: "clear", storeOp: "store", clearValue: [0, 0, 0, 1] }],
+});
+
+pass.setPipeline(pipeline);
+pass.draw(3);
+pass.end();
+
+const pixels = await target.read();
+device.destroy();
+```
+
+## Capability matrix
+
+- ✅ **In 0.0.1**
+  - device / buffer / texture / shader primitives
+  - render pipeline + render pass
+  - WGSL compile + loaders for webpack and vite
+  - node and mock adapters
+- 🚧 **Coming in 0.1.0**
+  - MRT (multiple render targets)
+  - texture sampling helpers
+  - post-process passes
+  - mesh edit operators
+  - geometry primitives library
+- ❌ **Not yet planned**
+  - examples gallery
+  - full typedoc site
 
 ## License
 
-See [LICENSE](./LICENSE).
+MIT — see [LICENSE](./LICENSE).
+
+## Status & roadmap
+
+Track the early architecture and API work in [issue #7](https://github.com/vercel-labs/vgpu/issues/7) and [issue #17](https://github.com/vercel-labs/vgpu/issues/17).

--- a/packages/adapter-mock/LICENSE
+++ b/packages/adapter-mock/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 matiasngf
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/adapter-mock/LICENSE
+++ b/packages/adapter-mock/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 matiasngf
+Copyright (c) 2025 Vercel, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/adapter-mock/README.md
+++ b/packages/adapter-mock/README.md
@@ -1,0 +1,33 @@
+# @vgpu/adapter-mock
+
+> 0.0.1 — early preview
+
+`@vgpu/adapter-mock` provides a `VGPUAdapter` implementation for tests, snapshots, and development workflows where you want the vgpu API surface without a real GPU backend. It pairs well with `App.create()` from `@vgpu/core` and supports the same high-level device, buffer, and texture flows used in fast unit tests across the repository.
+
+## Install
+
+```bash
+pnpm add @vgpu/adapter-mock
+```
+
+## Exports
+
+### Runtime
+- `createMockAdapter`
+
+## Usage
+
+```ts
+import { App } from "@vgpu/core";
+import { createMockAdapter } from "@vgpu/adapter-mock";
+
+const { device } = await App.create({ adapter: createMockAdapter() });
+const buffer = device.createBuffer({ size: 16, usage: ["copy_dst", "copy_src", "storage"] });
+buffer.write(new Float32Array([1, 2, 3, 4]));
+const bytes = await buffer.read(16);
+device.destroy();
+```
+
+## License
+
+MIT.

--- a/packages/adapter-mock/package.json
+++ b/packages/adapter-mock/package.json
@@ -1,10 +1,27 @@
 {
   "name": "@vgpu/adapter-mock",
-  "version": "0.0.0",
-  "type": "module",
+  "version": "0.0.1",
+  "description": "Mock GPU adapter for testing vgpu code without real WebGPU hardware.",
+  "keywords": ["webgpu", "graphics", "rendering", "mock", "testing", "adapter"],
+  "homepage": "https://github.com/vercel-labs/vgpu#readme",
+  "bugs": {
+    "url": "https://github.com/vercel-labs/vgpu/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/vercel-labs/vgpu.git",
+    "directory": "packages/adapter-mock"
+  },
+  "license": "MIT",
+  "author": "Matias Gonzalez <matiasngf@hotmail.com>",
+  "private": false,
+  "publishConfig": {
+    "access": "public"
+  },
   "sideEffects": false,
+  "type": "module",
   "exports": { ".": { "types": "./dist/index.d.ts", "import": "./dist/index.js" } },
-  "files": ["dist", "src/**/*.docs.md"],
+  "files": ["dist", "src/**/*.docs.md", "README.md", "LICENSE"],
   "scripts": { "build": "tsc -b" },
   "dependencies": { "@vgpu/core": "workspace:*" },
   "vgpuBundleBudgetGzipBytes": 20480

--- a/packages/adapter-node/LICENSE
+++ b/packages/adapter-node/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 matiasngf
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/adapter-node/LICENSE
+++ b/packages/adapter-node/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 matiasngf
+Copyright (c) 2025 Vercel, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/adapter-node/README.md
+++ b/packages/adapter-node/README.md
@@ -1,0 +1,37 @@
+# @vgpu/adapter-node
+
+> 0.0.1 — early preview
+
+`@vgpu/adapter-node` connects vgpu to Node.js runtimes through Dawn-based WebGPU bindings. It exposes both a reusable adapter for `App.create()` and a convenience helper that creates a `Device` directly, making it the package to use for server-side rendering, CI image generation, and serverless deployments. This package depends on `webgpu@0.4.0`, and the release target includes linux-arm64 prebuilt support.
+
+## Install
+
+```bash
+pnpm add @vgpu/adapter-node
+```
+
+## Exports
+
+### Runtime
+- `createNodeAdapter`
+- `createNodeDevice`
+
+## Usage
+
+```ts
+import { createNodeDevice } from "@vgpu/adapter-node";
+
+const device = await createNodeDevice({ backend: "webgpu" });
+const texture = device.createTexture({
+  size: [64, 64],
+  format: "rgba8unorm",
+  usage: ["render_attachment", "copy_src"],
+});
+
+const bytes = await texture.read();
+device.destroy();
+```
+
+## License
+
+MIT.

--- a/packages/adapter-node/package.json
+++ b/packages/adapter-node/package.json
@@ -1,10 +1,27 @@
 {
   "name": "@vgpu/adapter-node",
-  "version": "0.0.0",
-  "type": "module",
+  "version": "0.0.1",
+  "description": "Node.js GPU adapter for vgpu, using Dawn-based WebGPU bindings.",
+  "keywords": ["webgpu", "graphics", "rendering", "node", "dawn", "adapter", "server-side"],
+  "homepage": "https://github.com/vercel-labs/vgpu#readme",
+  "bugs": {
+    "url": "https://github.com/vercel-labs/vgpu/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/vercel-labs/vgpu.git",
+    "directory": "packages/adapter-node"
+  },
+  "license": "MIT",
+  "author": "Matias Gonzalez <matiasngf@hotmail.com>",
+  "private": false,
+  "publishConfig": {
+    "access": "public"
+  },
   "sideEffects": false,
+  "type": "module",
   "exports": { ".": { "types": "./dist/index.d.ts", "import": "./dist/index.js" } },
-  "files": ["dist", "src/**/*.docs.md"],
+  "files": ["dist", "src/**/*.docs.md", "README.md", "LICENSE"],
   "scripts": { "build": "tsc -b" },
   "dependencies": { "@vgpu/core": "workspace:*", "webgpu": "0.4.0" },
   "vgpuBundleBudgetGzipBytes": 30720

--- a/packages/core/LICENSE
+++ b/packages/core/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 matiasngf
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/core/LICENSE
+++ b/packages/core/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 matiasngf
+Copyright (c) 2025 Vercel, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,0 +1,60 @@
+# @vgpu/core
+
+> 0.0.1 — early preview
+
+`@vgpu/core` is the runtime foundation for vgpu. It gives you a small wrapper layer around WebGPU devices, queues, buffers, textures, and shader modules, plus an `App.create()` entry point that asks an adapter for a device and returns a compact app instance. In 0.0.1 the goal is portability and a minimal public surface, not a fully opinionated engine.
+
+## Install
+
+```bash
+pnpm add @vgpu/core
+```
+
+## Exports
+
+### Classes
+- `App`
+- `Buffer`
+- `Device`
+- `Queue`
+- `Shader`
+- `Texture`
+- `VGPUError`
+- `ValidationError`
+
+### Functions
+- `createMockGPUDevice`
+
+### Types
+- `AppCreateOptions`
+- `AppInstance`
+- `VGPUAdapter`
+- `BufferOptions`
+- `BufferUsageName`
+- `BufferWriteData`
+- `TextureOptions`
+- `TextureUsageName`
+- `CreateDeviceOptions`
+- `ShaderInput`
+
+## Usage
+
+```ts
+import { App } from "@vgpu/core";
+import { createMockAdapter } from "@vgpu/adapter-mock";
+
+const { device } = await App.create({ adapter: createMockAdapter() });
+const data = new Float32Array([1, 2, 3, 4]);
+const buffer = device.createBuffer({
+  size: data.byteLength,
+  usage: ["copy_dst", "copy_src", "storage"],
+});
+
+buffer.write(data);
+const copy = new Float32Array(await buffer.read(data.byteLength));
+device.destroy();
+```
+
+## License
+
+MIT.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,8 +1,25 @@
 {
   "name": "@vgpu/core",
-  "version": "0.0.0",
-  "type": "module",
+  "version": "0.0.1",
+  "description": "Core WebGPU runtime primitives (device, buffer, texture, shader, queue) for vgpu.",
+  "keywords": ["webgpu", "graphics", "rendering", "core", "device", "buffer", "shader"],
+  "homepage": "https://github.com/vercel-labs/vgpu#readme",
+  "bugs": {
+    "url": "https://github.com/vercel-labs/vgpu/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/vercel-labs/vgpu.git",
+    "directory": "packages/core"
+  },
+  "license": "MIT",
+  "author": "Matias Gonzalez <matiasngf@hotmail.com>",
+  "private": false,
+  "publishConfig": {
+    "access": "public"
+  },
   "sideEffects": false,
+  "type": "module",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
@@ -11,7 +28,9 @@
   },
   "files": [
     "dist",
-    "src/**/*.docs.md"
+    "src/**/*.docs.md",
+    "README.md",
+    "LICENSE"
   ],
   "scripts": {
     "build": "tsc -b"

--- a/packages/render/LICENSE
+++ b/packages/render/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 matiasngf
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/render/LICENSE
+++ b/packages/render/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 matiasngf
+Copyright (c) 2025 Vercel, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/render/README.md
+++ b/packages/render/README.md
@@ -1,0 +1,55 @@
+# @vgpu/render
+
+> 0.0.1 — early preview
+
+`@vgpu/render` is the small rendering layer on top of `@vgpu/core`. It currently focuses on two public building blocks: creating a render pipeline from a vgpu shader wrapper, and issuing a render pass against a texture or texture view. The package is intentionally narrow in 0.0.1 and leaves higher-level scene helpers for later releases.
+
+## Install
+
+```bash
+pnpm add @vgpu/render
+```
+
+## Exports
+
+### Runtime
+- `createRenderPipeline`
+- `RenderPass`
+
+### Types
+- `RenderPipelineOptions`
+- `ColorAttachment`
+- `RenderPassOptions`
+
+## Usage
+
+```ts
+import { App } from "@vgpu/core";
+import { createMockAdapter } from "@vgpu/adapter-mock";
+import { createRenderPipeline, RenderPass } from "@vgpu/render";
+
+const { device } = await App.create({ adapter: createMockAdapter() });
+const shader = device.createShader(`
+@vertex fn vs_main(@builtin(vertex_index) i: u32) -> @builtin(position) vec4f {
+  var p = array<vec2f, 3>(vec2f(0.0, 0.5), vec2f(-0.5, -0.5), vec2f(0.5, -0.5));
+  return vec4f(p[i], 0.0, 1.0);
+}
+@fragment fn fs_main() -> @location(0) vec4f { return vec4f(0.2, 0.6, 1.0, 1.0); }
+`);
+const target = device.createTexture({ size: [64, 64], format: "rgba8unorm", usage: ["render_attachment", "copy_src"] });
+const pipeline = createRenderPipeline(device, {
+  shader,
+  vertex: { entry: "vs_main" },
+  fragment: { entry: "fs_main", targets: [{ format: "rgba8unorm" }] },
+});
+const pass = new RenderPass(device, {
+  colorAttachments: [{ view: target, loadOp: "clear", storeOp: "store", clearValue: [0, 0, 0, 1] }],
+});
+pass.setPipeline(pipeline);
+pass.draw(3);
+pass.end();
+```
+
+## License
+
+MIT.

--- a/packages/render/package.json
+++ b/packages/render/package.json
@@ -1,15 +1,32 @@
 {
   "name": "@vgpu/render",
-  "version": "0.0.0",
-  "type": "module",
+  "version": "0.0.1",
+  "description": "Render pipeline + render pass abstractions for vgpu.",
+  "keywords": ["webgpu", "graphics", "rendering", "render", "pipeline", "render-pass"],
+  "homepage": "https://github.com/vercel-labs/vgpu#readme",
+  "bugs": {
+    "url": "https://github.com/vercel-labs/vgpu/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/vercel-labs/vgpu.git",
+    "directory": "packages/render"
+  },
+  "license": "MIT",
+  "author": "Matias Gonzalez <matiasngf@hotmail.com>",
+  "private": false,
+  "publishConfig": {
+    "access": "public"
+  },
   "sideEffects": false,
+  "type": "module",
   "exports": {
     ".": { "types": "./dist/index.d.ts", "import": "./dist/index.js" },
     "./inspect": { "types": "./dist/inspect/index.d.ts", "import": "./dist/inspect/index.js" },
     "./utils": { "types": "./dist/utils/index.d.ts", "import": "./dist/utils/index.js" },
     "./edit": { "types": "./dist/edit/index.d.ts", "import": "./dist/edit/index.js" }
   },
-  "files": ["dist", "!dist/tsconfig.tsbuildinfo", "src/**/*.docs.md"],
+  "files": ["dist", "!dist/tsconfig.tsbuildinfo", "src/**/*.docs.md", "README.md", "LICENSE"],
   "scripts": {
     "build": "tsc -b",
     "typecheck": "tsc -b",

--- a/packages/render/package.json
+++ b/packages/render/package.json
@@ -2,7 +2,14 @@
   "name": "@vgpu/render",
   "version": "0.0.1",
   "description": "Render pipeline + render pass abstractions for vgpu.",
-  "keywords": ["webgpu", "graphics", "rendering", "render", "pipeline", "render-pass"],
+  "keywords": [
+    "webgpu",
+    "graphics",
+    "rendering",
+    "render",
+    "pipeline",
+    "render-pass"
+  ],
   "homepage": "https://github.com/vercel-labs/vgpu#readme",
   "bugs": {
     "url": "https://github.com/vercel-labs/vgpu/issues"
@@ -21,23 +28,49 @@
   "sideEffects": false,
   "type": "module",
   "exports": {
-    ".": { "types": "./dist/index.d.ts", "import": "./dist/index.js" },
-    "./inspect": { "types": "./dist/inspect/index.d.ts", "import": "./dist/inspect/index.js" },
-    "./utils": { "types": "./dist/utils/index.d.ts", "import": "./dist/utils/index.js" },
-    "./edit": { "types": "./dist/edit/index.d.ts", "import": "./dist/edit/index.js" }
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    },
+    "./inspect": {
+      "types": "./dist/inspect/index.d.ts",
+      "import": "./dist/inspect/index.js"
+    },
+    "./utils": {
+      "types": "./dist/utils/index.d.ts",
+      "import": "./dist/utils/index.js"
+    },
+    "./edit": {
+      "types": "./dist/edit/index.d.ts",
+      "import": "./dist/edit/index.js"
+    },
+    "./passes": {
+      "types": "./dist/passes/index.d.ts",
+      "import": "./dist/passes/index.js"
+    }
   },
-  "files": ["dist", "!dist/tsconfig.tsbuildinfo", "src/**/*.docs.md", "README.md", "LICENSE"],
+  "files": [
+    "dist",
+    "!dist/tsconfig.tsbuildinfo",
+    "src/**/*.docs.md",
+    "README.md",
+    "LICENSE"
+  ],
   "scripts": {
     "build": "tsc -b",
     "typecheck": "tsc -b",
     "lint": "tsc -b --pretty false",
     "test": "cd ../.. && vitest run packages/render"
   },
-  "dependencies": { "@vgpu/core": "workspace:*", "wgpu-matrix": "^3.4.2" },
+  "dependencies": {
+    "@vgpu/core": "workspace:*",
+    "wgpu-matrix": "^3.4.2"
+  },
   "vgpuExportBundleBudgetsGzipBytes": {
     ".": 49152,
     "./inspect": 4096,
     "./utils": 2048,
-    "./edit": 25600
+    "./edit": 25600,
+    "./passes": 3584
   }
 }

--- a/packages/wgsl/LICENSE
+++ b/packages/wgsl/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 matiasngf
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/wgsl/LICENSE
+++ b/packages/wgsl/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 matiasngf
+Copyright (c) 2025 Vercel, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/wgsl/README.md
+++ b/packages/wgsl/README.md
@@ -1,0 +1,81 @@
+# @vgpu/wgsl
+
+> 0.0.1 — early preview
+
+`@vgpu/wgsl` packages the shader-side utilities in vgpu. The top-level entry handles direct WGSL compilation for plain source strings, while sub-exports cover import resolution at runtime and integration points for webpack and vite. In 0.0.1 this package is the bridge between raw WGSL text and the shader modules consumed by `@vgpu/core` and `@vgpu/render`.
+
+## Install
+
+```bash
+pnpm add @vgpu/wgsl
+```
+
+## Exports
+
+### `@vgpu/wgsl`
+- `compile`
+- types: `ResolvedShader`, `SourceMap`, `WGSLAst`, `WGSLSource`
+
+### `@vgpu/wgsl/runtime`
+- `resolveShader`
+- types: `ResolveOptions`, `WGSLModule`, `WGSLAst`, `SourceMap`, `ResolvedShader`
+
+### `@vgpu/wgsl/loader-webpack`
+- default export: `wgslWebpackLoader`
+
+### `@vgpu/wgsl/loader-vite`
+- `transformWgsl`
+- default export: `wgslVitePlugin`
+- type: `ViteLoadResult`
+
+## Usage
+
+### `@vgpu/wgsl`
+
+```ts
+import { compile } from "@vgpu/wgsl";
+
+const shader = compile(`@compute @workgroup_size(1) fn main() {}`);
+console.log(shader.kind, shader.entryPoints);
+```
+
+### `@vgpu/wgsl/runtime`
+
+```ts
+import { resolveShader } from "@vgpu/wgsl/runtime";
+
+const resolved = await resolveShader({
+  entry: "/triangle.wgsl",
+  modules: {
+    "/triangle.wgsl": `@vertex fn vs_main(@builtin(vertex_index) i: u32) -> @builtin(position) vec4f {
+      var p = array<vec2f, 3>(vec2f(0.0, 0.5), vec2f(-0.5, -0.5), vec2f(0.5, -0.5));
+      return vec4f(p[i], 0.0, 1.0);
+    }`,
+  },
+  validate: false,
+});
+```
+
+### `@vgpu/wgsl/loader-webpack`
+
+```ts
+import wgslWebpackLoader from "@vgpu/wgsl/loader-webpack";
+
+// Add wgslWebpackLoader to your webpack rule for .wgsl files.
+void wgslWebpackLoader;
+```
+
+### `@vgpu/wgsl/loader-vite`
+
+```ts
+import wgslVitePlugin, { transformWgsl } from "@vgpu/wgsl/loader-vite";
+
+const plugin = wgslVitePlugin();
+const result = await transformWgsl("@compute @workgroup_size(1) fn main() {}", "/shader.wgsl");
+void plugin;
+void result;
+```
+
+## License
+
+MIT.

--- a/packages/wgsl/package.json
+++ b/packages/wgsl/package.json
@@ -1,15 +1,32 @@
 {
   "name": "@vgpu/wgsl",
-  "version": "0.0.0",
-  "type": "module",
+  "version": "0.0.1",
+  "description": "WGSL shader compilation, runtime resolution, and webpack/vite loaders for vgpu.",
+  "keywords": ["webgpu", "graphics", "rendering", "wgsl", "shader", "webpack-loader", "vite-plugin"],
+  "homepage": "https://github.com/vercel-labs/vgpu#readme",
+  "bugs": {
+    "url": "https://github.com/vercel-labs/vgpu/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/vercel-labs/vgpu.git",
+    "directory": "packages/wgsl"
+  },
+  "license": "MIT",
+  "author": "Matias Gonzalez <matiasngf@hotmail.com>",
+  "private": false,
+  "publishConfig": {
+    "access": "public"
+  },
   "sideEffects": false,
+  "type": "module",
   "exports": {
     ".": { "types": "./dist/index.d.ts", "import": "./dist/index.js" },
     "./runtime": { "types": "./dist/runtime/resolveShader.d.ts", "import": "./dist/runtime/resolveShader.js" },
     "./loader-webpack": { "types": "./dist/loader-webpack/index.d.ts", "import": "./dist/loader-webpack/index.js" },
     "./loader-vite": { "types": "./dist/loader-vite/index.d.ts", "import": "./dist/loader-vite/index.js" }
   },
-  "files": ["dist", "src/**/*.docs.md"],
+  "files": ["dist", "src/**/*.docs.md", "README.md", "LICENSE"],
   "scripts": { "build": "tsc -b" },
   "vgpuExportBundleBudgetsGzipBytes": {
     ".": 25600,


### PR DESCRIPTION
v0.0.1 publish-prep PR. Metadata + docs only — no source changes.

## What this does
- Bumps all 5 packages: `@vgpu/core`, `@vgpu/render`, `@vgpu/wgsl`, `@vgpu/adapter-mock`, `@vgpu/adapter-node` from `0.0.0` → `0.0.1`
- Adds publish metadata: description, keywords, repository, homepage, bugs, license, author, `publishConfig.access: public`
- Adds per-package LICENSE files (MIT)
- Adds per-package READMEs + refreshed root README with quickstart + capability matrix
- Adds root CHANGELOG.md with 0.0.1 entry

## What this does NOT do
- No source changes (`packages/*/src/**` untouched)
- No actual publish (run `pnpm publish` manually after merge)
- No git tag (tag manually after merge)
- No examples / typedoc site (deferred)

## In-flight branches
This PR is independent from `feat/mrt-bcd` and `feat/material-textures-chunk-1` — different files, no conflicts. Those branches stay at 0.0.0 internally; once they land they'll bump us toward 0.1.0.

## Verification
- `pnpm publish --dry-run` per package: tarballs clean
- `pnpm bundle-check`: no regressions (no source changes)
- `pnpm typecheck` + `pnpm test:fast`: green