### PR TITLE
chore(release): bump to v0.0.2

### DIFF
--- a/packages/adapter-mock/package.json
+++ b/packages/adapter-mock/package.json
@@ -1,8 +1,15 @@
 {
   "name": "@vgpu/adapter-mock",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Mock GPU adapter for testing vgpu code without real WebGPU hardware.",
-  "keywords": ["webgpu", "graphics", "rendering", "mock", "testing", "adapter"],
+  "keywords": [
+    "webgpu",
+    "graphics",
+    "rendering",
+    "mock",
+    "testing",
+    "adapter"
+  ],
   "homepage": "https://github.com/vercel-labs/vgpu#readme",
   "bugs": {
     "url": "https://github.com/vercel-labs/vgpu/issues"
@@ -20,9 +27,23 @@
   },
   "sideEffects": false,
   "type": "module",
-  "exports": { ".": { "types": "./dist/index.d.ts", "import": "./dist/index.js" } },
-  "files": ["dist", "src/**/*.docs.md", "README.md", "LICENSE"],
-  "scripts": { "build": "tsc -b" },
-  "dependencies": { "@vgpu/core": "workspace:*" },
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist",
+    "src/**/*.docs.md",
+    "README.md",
+    "LICENSE"
+  ],
+  "scripts": {
+    "build": "tsc -b"
+  },
+  "dependencies": {
+    "@vgpu/core": "workspace:*"
+  },
   "vgpuBundleBudgetGzipBytes": 20480
 }

--- a/packages/adapter-node/package.json
+++ b/packages/adapter-node/package.json
@@ -1,8 +1,16 @@
 {
   "name": "@vgpu/adapter-node",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Node.js GPU adapter for vgpu, using Dawn-based WebGPU bindings.",
-  "keywords": ["webgpu", "graphics", "rendering", "node", "dawn", "adapter", "server-side"],
+  "keywords": [
+    "webgpu",
+    "graphics",
+    "rendering",
+    "node",
+    "dawn",
+    "adapter",
+    "server-side"
+  ],
   "homepage": "https://github.com/vercel-labs/vgpu#readme",
   "bugs": {
     "url": "https://github.com/vercel-labs/vgpu/issues"
@@ -20,9 +28,24 @@
   },
   "sideEffects": false,
   "type": "module",
-  "exports": { ".": { "types": "./dist/index.d.ts", "import": "./dist/index.js" } },
-  "files": ["dist", "src/**/*.docs.md", "README.md", "LICENSE"],
-  "scripts": { "build": "tsc -b" },
-  "dependencies": { "@vgpu/core": "workspace:*", "webgpu": "0.4.0" },
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist",
+    "src/**/*.docs.md",
+    "README.md",
+    "LICENSE"
+  ],
+  "scripts": {
+    "build": "tsc -b"
+  },
+  "dependencies": {
+    "@vgpu/core": "workspace:*",
+    "webgpu": "0.4.0"
+  },
   "vgpuBundleBudgetGzipBytes": 30720
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,8 +1,16 @@
 {
   "name": "@vgpu/core",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Core WebGPU runtime primitives (device, buffer, texture, shader, queue) for vgpu.",
-  "keywords": ["webgpu", "graphics", "rendering", "core", "device", "buffer", "shader"],
+  "keywords": [
+    "webgpu",
+    "graphics",
+    "rendering",
+    "core",
+    "device",
+    "buffer",
+    "shader"
+  ],
   "homepage": "https://github.com/vercel-labs/vgpu#readme",
   "bugs": {
     "url": "https://github.com/vercel-labs/vgpu/issues"

--- a/packages/render/package.json
+++ b/packages/render/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vgpu/render",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Render pipeline + render pass abstractions for vgpu.",
   "keywords": [
     "webgpu",

--- a/packages/wgsl/package.json
+++ b/packages/wgsl/package.json
@@ -1,8 +1,16 @@
 {
   "name": "@vgpu/wgsl",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "WGSL shader compilation, runtime resolution, and webpack/vite loaders for vgpu.",
-  "keywords": ["webgpu", "graphics", "rendering", "wgsl", "shader", "webpack-loader", "vite-plugin"],
+  "keywords": [
+    "webgpu",
+    "graphics",
+    "rendering",
+    "wgsl",
+    "shader",
+    "webpack-loader",
+    "vite-plugin"
+  ],
   "homepage": "https://github.com/vercel-labs/vgpu#readme",
   "bugs": {
     "url": "https://github.com/vercel-labs/vgpu/issues"
@@ -21,13 +29,32 @@
   "sideEffects": false,
   "type": "module",
   "exports": {
-    ".": { "types": "./dist/index.d.ts", "import": "./dist/index.js" },
-    "./runtime": { "types": "./dist/runtime/resolveShader.d.ts", "import": "./dist/runtime/resolveShader.js" },
-    "./loader-webpack": { "types": "./dist/loader-webpack/index.d.ts", "import": "./dist/loader-webpack/index.js" },
-    "./loader-vite": { "types": "./dist/loader-vite/index.d.ts", "import": "./dist/loader-vite/index.js" }
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    },
+    "./runtime": {
+      "types": "./dist/runtime/resolveShader.d.ts",
+      "import": "./dist/runtime/resolveShader.js"
+    },
+    "./loader-webpack": {
+      "types": "./dist/loader-webpack/index.d.ts",
+      "import": "./dist/loader-webpack/index.js"
+    },
+    "./loader-vite": {
+      "types": "./dist/loader-vite/index.d.ts",
+      "import": "./dist/loader-vite/index.js"
+    }
   },
-  "files": ["dist", "src/**/*.docs.md", "README.md", "LICENSE"],
-  "scripts": { "build": "tsc -b" },
+  "files": [
+    "dist",
+    "src/**/*.docs.md",
+    "README.md",
+    "LICENSE"
+  ],
+  "scripts": {
+    "build": "tsc -b"
+  },
   "vgpuExportBundleBudgetsGzipBytes": {
     ".": 25600,
     "./runtime": 204800,


### PR DESCRIPTION
## What

Bumps all 5 packages from `0.0.1` → `0.0.2` to smoke-test the release-driven publish workflow introduced in #55.

## Verification post-merge

After this PR merges, the user will:

1. Go to https://github.com/vercel-labs/vgpu/releases/new
2. Choose tag: `v0.0.2` (create new tag on publish, target main)
3. Title: `v0.0.2`
4. Notes: click **Generate release notes** to auto-draft from merged PRs since v0.0.1
5. Click **Publish release**

The workflow will:
- Check out tag `v0.0.2`
- Install + build + test
- Run `pnpm -r publish --access public --provenance --no-git-checks`
- npm OIDC validates against the Trusted Publisher config (workflow `release.yml`, repo `vercel-labs/vgpu`)
- All 5 packages publish at `0.0.2` with **provenance attestation**

## What this validates

| Check | How |
|---|---|
| Workflow triggers on `release: published` | New run appears in Actions tab |
| OIDC token mint succeeds | No `403` from npm |
| Provenance attestation | "Built and signed on GitHub Actions" badge on each package's npm page |
| `pnpm -r publish` skips already-published packages | If any package is already at 0.0.2, it's skipped (only an issue if a previous run partially succeeded) |

## What's in this PR

Only `packages/*/package.json` version bumps (5 files), plus possibly `pnpm-lock.yaml` if internal `workspace:*` references it. No source changes.

## Bundle delta

Zero — no source changes. CI's bundle-check should pass unchanged.
