### PR TITLE
fix(ci): use NPM_TOKEN auth instead of OIDC for publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      id-token: write # Required for npm Trusted Publishing OIDC
 
     steps:
       - name: Checkout release tag
@@ -37,6 +36,7 @@ jobs:
       - name: Run fast tests
         run: pnpm test:fast
 
-
       - name: Publish to npm
-        run: pnpm -r publish --access public --provenance --no-git-checks
+        run: pnpm -r publish --access public --no-git-checks
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## What

Switches the release workflow's npm authentication from **OIDC Trusted Publishing** to **`NPM_TOKEN` repo secret**.

## Why

The v0.0.2 release workflow run failed at the publish step:

https://github.com/vercel-labs/vgpu/actions/runs/25524663799

```
npm error code E404
npm error 404 Not Found - PUT https://registry.npmjs.org/@vgpu%2fwgsl
```

Root cause: each `@vgpu/*` package on npm has the per-package setting **"Require two-factor authentication or a granular access token with bypass 2fa enabled"** turned ON. This setting cannot be turned OFF in the npm UI for these packages. OIDC tokens from Trusted Publishing don't satisfy that requirement, so npm rejects the publish with a misleading 404.

## Fix

- `id-token: write` permission removed (no longer needed without OIDC)
- `--provenance` flag removed (provenance requires OIDC)
- `NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}` env added on the publish step

`NPM_TOKEN` is a granular access token already in repo secrets, scoped to `@vgpu/*` with bypass-2FA enabled — which satisfies the per-package gate.

## Tradeoff

- ❌ Lose the **"Built and signed on GitHub Actions"** provenance badge on npmjs.com
- ✅ Publish pipeline works end-to-end

If npm changes the per-package setting in the future to allow disabling it (or accepts OIDC as satisfying the gate), we can revert to OIDC.

## How to retest after merge

1. Delete the `v0.0.2` release on GitHub (already failed — never reached npm)
2. Delete the `v0.0.2` tag (`gh release delete v0.0.2 --cleanup-tag`)
3. Re-create the v0.0.2 release on GitHub UI to retrigger the workflow
4. Workflow should now publish successfully with `NPM_TOKEN`

## Verification

After successful publish:
```bash
npm view @vgpu/wgsl version          # → 0.0.2
npm view @vgpu/core version          # → 0.0.2
npm view @vgpu/adapter-mock version  # → 0.0.2
npm view @vgpu/adapter-node version  # → 0.0.2
npm view @vgpu/render version        # → 0.0.2
```

(No provenance badge expected.)
