### PR TITLE
fix(test-infra): retry adapter init + widen pnpm install network retries

### DIFF
--- a/infra/test-docker/Dockerfile
+++ b/infra/test-docker/Dockerfile
@@ -21,7 +21,11 @@ RUN mkdir -p /tmp/xdg-runtime && chmod 700 /tmp/xdg-runtime
 WORKDIR /workspace
 COPY . .
 RUN corepack enable
-RUN pnpm install --frozen-lockfile
+RUN pnpm config set network-timeout 120000 \
+ && pnpm config set fetch-retries 5 \
+ && pnpm config set fetch-retry-mintimeout 10000 \
+ && pnpm config set fetch-retry-maxtimeout 60000 \
+ && pnpm install --frozen-lockfile
 RUN pnpm typecheck
 RUN Xvfb :99 -screen 0 1024x768x24 >/tmp/xvfb.log 2>&1 & \
     xvfb_pid=$!; \

--- a/packages/adapter-node/src/index.ts
+++ b/packages/adapter-node/src/index.ts
@@ -4,12 +4,15 @@ import { Device, VGPUError, type CreateDeviceOptions, type VGPUAdapter } from "@
 
 type WebGPUModule = { create(options: string[]): GPU; globals: Record<string, unknown> };
 type NodeAdapterFlags = { readonly backendFlags?: readonly string[] };
-type RequestDeviceOptions = CreateDeviceOptions & NodeAdapterFlags & { readonly backend?: "opengl" | "webgpu" };
+type NodeAdapterRetryOptions = { readonly adapterRequestRetryCount?: number; readonly adapterRequestRetryBaseDelayMs?: number };
+type RequestDeviceOptions = CreateDeviceOptions & NodeAdapterFlags & NodeAdapterRetryOptions & { readonly backend?: "opengl" | "webgpu" };
 type DawnAdapterOptions = GPURequestAdapterOptions & { readonly featureLevel?: "compatibility" };
 type BinaryLoadErrorOptions = { readonly detectedGlibcVersion?: string | null };
 
 const require = createRequire(import.meta.url);
 const dawnMinimumGlibcVersion = "2.38";
+const defaultAdapterRequestRetryCount = 3;
+const defaultAdapterRequestRetryBaseDelayMs = 100;
 let dawnGPU: GPU | null = null;
 let dawnFlagsUsed: readonly string[] | null = null;
 let loadedWebGPU: WebGPUModule | null = null;
@@ -26,11 +29,41 @@ export async function createNodeDevice(opts?: RequestDeviceOptions): Promise<Dev
 async function requestDevice(opts: RequestDeviceOptions = {}): Promise<Device> {
   const webgpu = await loadWebGPU();
   Object.assign(globalThis, webgpu.globals);
-  const adapter = await getDawnGPU(opts, webgpu).requestAdapter(adapterOptions(opts) as GPURequestAdapterOptions);
-  if (!adapter) throw new Error("No WebGPU adapter available for @vgpu/adapter-node.");
+  const adapter = await requestAdapterWithRetry(getDawnGPU(opts, webgpu), adapterOptions(opts) as GPURequestAdapterOptions, opts);
   const device = await adapter.requestDevice({ requiredFeatures: opts.requiredFeatures, requiredLimits: opts.requiredLimits });
   if (opts.label) device.label = opts.label;
   return new Device(device, adapter.info ?? null);
+}
+
+async function requestAdapterWithRetry(gpu: GPU, options: GPURequestAdapterOptions, retryOptions: NodeAdapterRetryOptions): Promise<GPUAdapter> {
+  let lastError: unknown = new Error("requestAdapter returned null");
+  const maxAttempts = Math.max(1, retryOptions.adapterRequestRetryCount ?? defaultAdapterRequestRetryCount);
+  const baseDelayMs = Math.max(0, retryOptions.adapterRequestRetryBaseDelayMs ?? defaultAdapterRequestRetryBaseDelayMs);
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    try {
+      const adapter = await gpu.requestAdapter(options);
+      if (adapter) return adapter;
+      lastError = new Error("requestAdapter returned null");
+    } catch (error) {
+      if (!shouldRetryAdapterRequestError(error)) throw error;
+      lastError = error;
+    }
+
+    if (attempt < maxAttempts) {
+      await sleep(baseDelayMs * 3 ** (attempt - 1));
+    }
+  }
+
+  throw new Error(`No WebGPU adapter available for @vgpu/adapter-node after ${maxAttempts} attempts: ${String(lastError)}`);
+}
+
+function shouldRetryAdapterRequestError(error: unknown): boolean {
+  return !/AbortError/i.test(String(error));
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 function getDawnGPU(opts: RequestDeviceOptions, webgpu: WebGPUModule): GPU {


### PR DESCRIPTION
## What

Two small fixes for recurring Docker test flakes documented in #61.

### Fix 1: Adapter init retry

`createNodeAdapter()` previously threw immediately if `navigator.gpu.requestAdapter()` returned null. Now retries up to 3 times with exponential backoff (100/300/900ms). `AbortError` is fast-failed (intentional cancellation). Retry count is configurable via factory option.

### Fix 2: pnpm install network retries in Dockerfile

Adds `network-timeout 120s` + `fetch-retries 5` config before `pnpm install --frozen-lockfile`. Widens retry window for transient DNS / registry CDN issues.

## Why

See #61 for context. Both flakes hit during the MRT B+C+D work session and added 3-5 min per retry to the agent loop. CI on real GitHub Actions runners doesn't exhibit either flake — only local `pnpm test:docker`.

## Closes #61
