### PR TITLE
feat(render): material textures Chunk 2 — WGSL declaration emission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,23 @@
 ## Unreleased
 
 ### Minor
+- @vgpu/render: BREAKING CHANGE (pre-1.0): `material()` no longer auto-prepends texture/sampler WGSL declarations by default. `wgslDeclarations(textures, textureBindings, samplerBindings, group?)` is also exported for lower-level declaration generation. Binding allocation order is now documented as uniforms → samplers → textures, each in insertion order.
+
+  Migration paths:
+  1. Add `autoDeclarations: true` to keep the previous PR #63 draft behavior:
+     ```ts
+     material({ ..., textures, samplers, autoDeclarations: true });
+     ```
+  2. Write declarations explicitly in shader source:
+     ```wgsl
+     @group(0) @binding(0) var materialSampler: sampler;
+     @group(0) @binding(1) var albedo: texture_2d<f32>;
+     ```
+  3. Let the library compute declarations and prepend them manually:
+     ```ts
+     const decls = getMaterialDeclarations(spec);
+     const mat = material({ ...spec, fragment: `${decls}\n${fragment}` });
+     ```
 - @vgpu/wgsl: Add `deps` field to `resolveShader` result; add `onDependency` callback option to `transformWgsl`. Foundation for HMR / watch-mode support in webpack/vite loaders (PR2).
 
 ## 0.0.1 — 2026-05-07

--- a/packages/render/src/domain/index.ts
+++ b/packages/render/src/domain/index.ts
@@ -16,6 +16,7 @@ export { sphere } from "./mesh-sphere.ts";
 export { tetrahedron } from "./mesh-tetrahedron.ts";
 export { torus } from "./mesh-torus.ts";
 export { octahedron } from "./mesh-octahedron.ts";
+export { getMaterialDeclarations, wgslDeclarations } from "./material-bindings.ts";
 export { material } from "./material-factory.ts";
 export { sampler } from "./material-sampler.ts";
 export { perspectiveCamera } from "./perspective-camera.ts";

--- a/packages/render/src/domain/material-bindings.ts
+++ b/packages/render/src/domain/material-bindings.ts
@@ -1,0 +1,110 @@
+import { invalidUsage } from "../uniform-pool-internals.ts";
+import { DEFAULT_MATERIAL_SAMPLER, isTextureKind, textureWgslType, type MaterialSamplerSpec, type MaterialTextureSpec } from "./material-textures-schema.ts";
+import type { MaterialSpec } from "./material-factory.ts";
+import type { WgslUniformType } from "./wgsl-alignment.ts";
+
+export interface MaterialBindingAllocation<T extends Record<string, MaterialTextureSpec>> {
+  readonly textureBindings: Readonly<Record<keyof T, number>>;
+  readonly samplerBindings: Readonly<Record<string, number>>;
+}
+
+/**
+ * Allocates material binding numbers without touching GPU state.
+ *
+ * Binding allocation order is a public stability contract: uniforms first
+ * (binding 0 when present), then samplers, then textures, each in insertion
+ * order. When an implicit `materialSampler` is needed, it is allocated before
+ * explicit sampler keys so existing implicit-texture materials keep binding 0.
+ */
+export function allocateMaterialBindings<T extends Record<string, MaterialTextureSpec>, S extends Record<string, MaterialSamplerSpec>>(
+  textures: T | undefined,
+  samplers: S | undefined,
+  firstBinding: number,
+): MaterialBindingAllocation<T> {
+  const samplerBindings = Object.fromEntries(samplerNames(textures, samplers).map((name, index) => [name, firstBinding + index]));
+  const textureFirst = firstBinding + Object.keys(samplerBindings).length;
+  const textureBindings = Object.fromEntries(Object.keys(textures ?? {}).map((name, index) => [name, textureFirst + index])) as Readonly<Record<keyof T, number>>;
+  return { textureBindings, samplerBindings };
+}
+
+/**
+ * Returns the WGSL `@group/@binding var ...` lines that `material()` prepends
+ * when `autoDeclarations: true`, without creating GPU resources.
+ *
+ * The returned string covers textures and samplers only, not the `Uniforms`
+ * struct. Binding allocation order is uniforms → samplers → textures, each in
+ * insertion order. Textures that omit a sampler key use the implicit
+ * `materialSampler`, which is allocated before explicit sampler keys to
+ * preserve Chunk 2 numbering. The string is byte-identical to what `material()`
+ * prepends for the same spec when `autoDeclarations: true`.
+ *
+ * @example
+ * ```ts
+ * const decls = getMaterialDeclarations(spec);
+ * const mat = material({ ...spec, fragment: `${decls}\n${spec.fragment}` });
+ * ```
+ */
+export function getMaterialDeclarations<
+  U extends Record<string, WgslUniformType>,
+  T extends Record<string, MaterialTextureSpec>,
+  S extends Record<string, MaterialSamplerSpec>,
+>(spec: Pick<MaterialSpec<U, T, S>, "uniforms" | "textures" | "samplers">): string {
+  const firstBinding = Object.keys(spec.uniforms ?? {}).length === 0 ? 0 : 1;
+  const allocation = allocateMaterialBindings(spec.textures, spec.samplers, firstBinding);
+  return wgslDeclarations(spec.textures, allocation.textureBindings, allocation.samplerBindings);
+}
+
+/**
+ * Emits WGSL texture and sampler declarations from pre-computed binding maps.
+ *
+ * Use this lower-level helper when you already have binding maps, for example
+ * from `mat.textureBindings` and `mat.samplerBindings`. Binding allocation order
+ * for maps produced by `material()` / `getMaterialDeclarations()` is uniforms →
+ * samplers → textures, each in insertion order.
+ *
+ * @example
+ * ```ts
+ * const decls = wgslDeclarations(spec.textures, mat.textureBindings, mat.samplerBindings);
+ * const visibleFragment = `${decls}\n${fragment}`;
+ * ```
+ */
+export function wgslDeclarations<T extends Record<string, MaterialTextureSpec>>(
+  textures: T | undefined,
+  textureBindings: Readonly<Record<keyof T, number>>,
+  samplerBindings: Readonly<Record<string, number>>,
+  group = 0,
+): string {
+  const fields = Object.entries(textures ?? {}).map(([name, spec]) => textureField(name, spec, textureBindings[name]));
+  if (fields.length === 0) return "";
+  const emitted = new Set<string>();
+  const lines: string[] = [];
+  for (const field of fields) {
+    lines.push(`@group(${group}) @binding(${field.binding}) var ${field.name}: ${textureWgslType(field.kind)};`);
+    const sampler = field.sampler ?? (DEFAULT_MATERIAL_SAMPLER in samplerBindings ? DEFAULT_MATERIAL_SAMPLER : undefined);
+    if (sampler && !emitted.has(sampler)) emitSampler(lines, emitted, sampler, samplerBindings, group);
+  }
+  for (const sampler of Object.keys(samplerBindings)) emitSampler(lines, emitted, sampler, samplerBindings, group);
+  return lines.join("\n");
+}
+
+export function samplerNames(textures: unknown, samplers: Record<string, MaterialSamplerSpec> | undefined): readonly string[] {
+  return [...(needsDefaultSampler(textures, samplers) ? [DEFAULT_MATERIAL_SAMPLER] : []), ...Object.keys(samplers ?? {})];
+}
+
+function emitSampler(lines: string[], emitted: Set<string>, name: string, bindings: Readonly<Record<string, number>>, group: number): void {
+  const binding = bindings[name];
+  if (binding === undefined || emitted.has(name)) return;
+  lines.push(`@group(${group}) @binding(${binding}) var ${name}: sampler;`);
+  emitted.add(name);
+}
+
+function textureField(name: string, spec: MaterialTextureSpec, binding: number | undefined) {
+  const kind = typeof spec === "string" ? spec : spec?.kind;
+  if (!isTextureKind(kind)) throw invalidUsage("material", `Unsupported texture kind for '${name}'.`);
+  if (binding === undefined) throw invalidUsage("material", `Missing texture binding for '${name}'.`);
+  return { name, kind, binding, sampler: typeof spec === "string" ? undefined : spec.sampler };
+}
+
+function needsDefaultSampler(textures: unknown, samplers: Record<string, MaterialSamplerSpec> | undefined): boolean {
+  return Object.values((textures ?? {}) as Record<string, MaterialTextureSpec>).some((spec) => typeof spec !== "object" || spec === null || !spec.sampler) && !(DEFAULT_MATERIAL_SAMPLER in (samplers ?? {}));
+}

--- a/packages/render/src/domain/material-factory.docs.md
+++ b/packages/render/src/domain/material-factory.docs.md
@@ -32,6 +32,34 @@ struct Uniforms {
 
 Your shader reads fields as `uniforms.fieldName`. Provide `vs_main` and `fs_main` entry points.
 
+Texture and sampler declarations are not injected by default. If your material
+uses `textures` / `samplers`, either write the `@group/@binding var` lines in
+your WGSL source, prepend `getMaterialDeclarations(spec)` yourself, or pass
+`autoDeclarations: true` to keep the generated declarations hidden in the
+runtime shader string. Enabling `autoDeclarations: true` while also writing the
+same declarations manually will fail shader compilation with a WGSL redeclare
+error.
+
+Binding allocation order is a public contract: uniforms first, then samplers,
+then textures, each in insertion order. Binding 0 is the uniform buffer when
+`uniforms` has fields; otherwise samplers start at 0. When a texture needs the
+implicit `materialSampler`, that sampler is allocated before explicit sampler
+keys. Texture declarations produced by `getMaterialDeclarations()` and
+`wgslDeclarations()` never include the `Uniforms` struct.
+
+```ts
+const spec = {
+  device,
+  vertex,
+  fragment,
+  uniforms: {},
+  textures: { albedo: "texture_2d_f32" },
+  vertexLayout: "position-uv",
+} as const;
+const declarations = getMaterialDeclarations(spec);
+const mat = material({ ...spec, fragment: `${declarations}\n${fragment}` });
+```
+
 ## Example
 
 ```ts

--- a/packages/render/src/domain/material-factory.ts
+++ b/packages/render/src/domain/material-factory.ts
@@ -2,6 +2,7 @@ import type { Device } from "@vgpu/core";
 import { invalidUsage, shaderVisibility } from "../uniform-pool-internals.ts";
 import type { Material, MaterialGpu } from "./material.ts";
 import { alignUniforms, isWgslUniformType, wgslType, type UniformField, type WgslUniformType } from "./wgsl-alignment.ts";
+import { wgslDeclarations } from "./material-bindings.ts";
 import { materialTextureState } from "./material-textures.ts";
 import type { MaterialSamplerSpec, MaterialTextureSpec, WriteTextureValues } from "./material-textures-schema.ts";
 import { vertexBufferLayout } from "./vertex-layout.ts";
@@ -26,6 +27,13 @@ export interface MaterialSpec<
   readonly vertexLayout: VertexLayoutKind;
   readonly targetFormat?: GPUTextureFormat;
   readonly depthFormat?: GPUTextureFormat | null;
+  /**
+   * When `true`, `material()` prepends generated texture/sampler WGSL declarations.
+   * Defaults to `false`; write declarations manually or prepend `getMaterialDeclarations(spec)`.
+   * The `Uniforms` struct is still injected whenever `uniforms` is non-empty.
+   * @default false
+   */
+  readonly autoDeclarations?: boolean;
 }
 
 export interface FactoryMaterial<
@@ -52,7 +60,9 @@ export function material<
   validateSchema(spec.uniforms);
   const layout = alignUniforms(spec.uniforms);
   const textures = materialTextureState(spec.device, spec.textures, spec.samplers, layout.byteSize === 0 ? 0 : 1);
-  const code = `${header(layout.fields)}\n${spec.vertex}\n${spec.fragment}`;
+  const combinedWgsl = `${header(layout.fields)}\n${spec.vertex}\n${spec.fragment}`;
+  const textureWgsl = spec.autoDeclarations === true ? wgslDeclarations(spec.textures, textures.textureBindings, textures.samplerBindings) : "";
+  const code = textureWgsl === "" ? combinedWgsl : `${textureWgsl}\n${combinedWgsl}`;
   const shader = createShader(spec.device, code);
   const bindGroupLayout = spec.device.gpu.createBindGroupLayout({
     label: "material.bgl",

--- a/packages/render/src/domain/material-textures.ts
+++ b/packages/render/src/domain/material-textures.ts
@@ -1,6 +1,7 @@
 import type { Device, Texture } from "@vgpu/core";
 import { invalidUsage, shaderVisibility } from "../uniform-pool-internals.ts";
-import { DEFAULT_MATERIAL_SAMPLER, isTextureKind, samplerDescriptor, textureWgslType, type MaterialSamplerSpec, type MaterialTextureSpec, type TextureKind, type WriteTextureValues } from "./material-textures-schema.ts";
+import { allocateMaterialBindings, samplerNames } from "./material-bindings.ts";
+import { DEFAULT_MATERIAL_SAMPLER, isTextureKind, samplerDescriptor, type MaterialSamplerSpec, type MaterialTextureSpec, type TextureKind, type WriteTextureValues } from "./material-textures-schema.ts";
 
 export interface MaterialTextureState<T extends Record<string, MaterialTextureSpec>, S extends Record<string, MaterialSamplerSpec>> {
   readonly layoutEntries: readonly GPUBindGroupLayoutEntry[];
@@ -12,7 +13,7 @@ export interface MaterialTextureState<T extends Record<string, MaterialTextureSp
   readonly dispose: () => void;
 }
 
-interface TextureField { readonly name: string; readonly kind: TextureKind; readonly binding: number; }
+interface TextureField { readonly name: string; readonly kind: TextureKind; readonly binding: number; readonly sampler?: string; }
 
 export function materialTextureState<T extends Record<string, MaterialTextureSpec>, S extends Record<string, MaterialSamplerSpec>>(
   device: Device,
@@ -20,52 +21,47 @@ export function materialTextureState<T extends Record<string, MaterialTextureSpe
   samplers: S | undefined,
   firstBinding: number,
 ): MaterialTextureState<T, S> {
-  const textureFields = textureFieldsOf(textures ?? {}, firstBinding + samplerCount(textures, samplers));
-  const samplerEntries = samplersOf(device, textures, samplers, firstBinding);
-  validateSamplerRefs(textures ?? {}, Object.keys(samplerEntries.byName));
+  const bindings = allocateMaterialBindings(textures, samplers, firstBinding);
+  const textureFields = textureFieldsOf(textures ?? {}, bindings.textureBindings);
+  const samplerEntries = samplersOf(device, textures, samplers, bindings.samplerBindings);
+  validateSamplerRefs(textures ?? {}, Object.keys(bindings.samplerBindings));
   const placeholders = textureFields.map((field) => placeholder(device, field.kind));
   const entries = [...samplerEntries.entries, ...textureFields.map((field, i) => ({ binding: field.binding, resource: placeholders[i]!.view }))];
   return {
     layoutEntries: [...samplerEntries.layoutEntries, ...textureFields.map(textureLayoutEntry)],
     entries,
-    textureBindings: Object.fromEntries(textureFields.map((field) => [field.name, field.binding])) as Readonly<Record<keyof T, number>>,
-    samplerBindings: samplerEntries.byName,
+    textureBindings: bindings.textureBindings,
+    samplerBindings: bindings.samplerBindings,
     defaultSampler: samplerEntries.defaultSampler,
     writeTextures: (values) => [...samplerEntries.entries, ...textureEntries(textureFields, values)],
     dispose: () => placeholders.forEach((value) => value.texture.destroy()),
   };
 }
 
-function samplerCount(textures: unknown, samplers: Record<string, MaterialSamplerSpec> | undefined): number {
-  const explicit = Object.keys(samplers ?? {}).length;
-  return explicit > 0 ? explicit : Object.keys((textures ?? {}) as object).length > 0 ? 1 : 0;
-}
-
-function samplersOf(device: Device, textures: unknown, samplers: Record<string, MaterialSamplerSpec> | undefined, first: number) {
-  const raw = Object.entries(samplers ?? {}) as [string, MaterialSamplerSpec][];
-  const specs: [string, MaterialSamplerSpec][] = raw.length > 0 ? raw : Object.keys((textures ?? {}) as object).length > 0 ? [[DEFAULT_MATERIAL_SAMPLER, { mag: "linear", min: "linear", mip: "linear" }]] : [];
-  const byName: Record<string, number> = {};
-  const gpuSamplers = specs.map(([name, spec], index) => {
+function samplersOf(device: Device, textures: unknown, samplers: Record<string, MaterialSamplerSpec> | undefined, bindings: Readonly<Record<string, number>>) {
+  const gpuSamplers = samplerNames(textures, samplers).map((name) => {
     try {
+      const spec = name === DEFAULT_MATERIAL_SAMPLER ? { mag: "linear", min: "linear", mip: "linear" } : samplers?.[name];
       const gpu = device.gpu.createSampler(samplerDescriptor(spec as MaterialSamplerSpec));
-      byName[name] = first + index;
-      return { name, gpu, binding: first + index };
+      return { name, gpu, binding: bindings[name]! };
     } catch (error) { throw invalidUsage("material", `Invalid sampler '${name}': ${messageOf(error)}`); }
   });
   return {
-    byName,
-    defaultSampler: raw.length === 0 && gpuSamplers.length > 0 ? gpuSamplers[0]!.gpu : undefined,
+    defaultSampler: gpuSamplers.find((entry) => entry.name === DEFAULT_MATERIAL_SAMPLER)?.gpu,
     entries: gpuSamplers.map(({ binding, gpu }) => ({ binding, resource: gpu })),
     layoutEntries: gpuSamplers.map(({ binding }) => ({ binding, visibility: shaderVisibility(), sampler: { type: "filtering" as const } })),
   };
 }
 
-function textureFieldsOf(schema: Record<string, MaterialTextureSpec>, first: number): readonly TextureField[] {
-  return Object.entries(schema).map(([name, spec], index) => {
-    const kind = typeof spec === "string" ? spec : spec?.kind;
-    if (!isTextureKind(kind)) throw invalidUsage("material", `Unsupported texture kind for '${name}'.`);
-    return { name, kind, binding: first + index };
-  });
+function textureFieldsOf(schema: Record<string, MaterialTextureSpec>, bindings: Readonly<Record<string, number>>): readonly TextureField[] {
+  return Object.entries(schema).map(([name, spec]) => textureField(name, spec, bindings[name]));
+}
+
+function textureField(name: string, spec: MaterialTextureSpec, binding: number | undefined): TextureField {
+  const kind = typeof spec === "string" ? spec : spec?.kind;
+  if (!isTextureKind(kind)) throw invalidUsage("material", `Unsupported texture kind for '${name}'.`);
+  if (binding === undefined) throw invalidUsage("material", `Missing texture binding for '${name}'.`);
+  return { name, kind, binding, sampler: typeof spec === "string" ? undefined : spec.sampler };
 }
 
 function validateSamplerRefs(textures: Record<string, MaterialTextureSpec>, samplerNames: readonly string[]): void {

--- a/packages/render/src/index.ts
+++ b/packages/render/src/index.ts
@@ -11,5 +11,5 @@ export type {
   RenderPassDynamicOffsets,
   RenderPassOptions,
 } from "./render-pass.ts";
-export { box, capsule, cone, cylinder, degToRad, disk, dodecahedron, fullscreenQuad, icosahedron, icosphere, material, Mesh, octahedron, orthographicCamera, perspectiveCamera, plane, ring, sampler, sphere, srgb, tetrahedron, torus } from "./domain/index.ts";
+export { box, capsule, cone, cylinder, degToRad, disk, dodecahedron, fullscreenQuad, getMaterialDeclarations, icosahedron, icosphere, material, Mesh, octahedron, orthographicCamera, perspectiveCamera, plane, ring, sampler, sphere, srgb, tetrahedron, torus, wgslDeclarations } from "./domain/index.ts";
 export type { BoxSpec, Camera, CapsuleSpec, ConeSpec, CylinderSpec, DiskSpec, FullscreenQuadSpec, IcosphereSpec, Material, MaterialSamplerSpec, MaterialSpec, MaterialTextureSpec, MaterialUniformValue, Mat4, MeshGpu, MeshPrimitive, PlaneSpec, PolyhedronSpec, RingSpec, Sampler, SamplerSpec, SphereSpec, TextureKind, TextureSpec, TextureValue, TorusSpec, Vec3, VertexAttributes, VertexLayoutKind, WgslUniformType, WriteTextureValues } from "./domain/index.ts";

--- a/packages/render/tests/material-declarations.test.ts
+++ b/packages/render/tests/material-declarations.test.ts
@@ -1,0 +1,97 @@
+import { expect, test } from "vitest";
+import { createMockAdapter } from "@vgpu/adapter-mock";
+import { createNodeAdapter } from "@vgpu/adapter-node";
+import { App, type Device, type VGPUAdapter } from "@vgpu/core";
+import { getMaterialDeclarations, material, wgslDeclarations, type MaterialSamplerSpec, type MaterialTextureSpec } from "@vgpu/render";
+
+const vertex = `
+struct VertexIn { @location(0) position: vec3<f32> };
+@vertex fn vs_main(in: VertexIn) -> @builtin(position) vec4<f32> { return vec4<f32>(in.position, 1.0); }
+`;
+const uvVertex = `
+struct VertexIn { @location(0) position: vec3<f32>, @location(1) uv: vec2<f32> };
+struct VertexOut { @builtin(position) position: vec4<f32>, @location(0) uv: vec2<f32> };
+@vertex fn vs_main(in: VertexIn) -> VertexOut {
+  var out: VertexOut;
+  out.position = vec4<f32>(in.position, 1.0);
+  out.uv = in.uv;
+  return out;
+}
+`;
+const fragment = `@fragment fn fs_main() -> @location(0) vec4<f32> { return vec4<f32>(1.0); }`;
+
+test("material does not prepend texture declarations by default", async () => {
+  const { device } = await testDevice();
+  const mat = material({ device, vertex, fragment, uniforms: {}, textures: { albedo: "texture_2d_f32" }, vertexLayout: "position-only", targetFormat: "rgba8unorm" });
+  expect(mat.shader.code).toBe(`\n${vertex}\n${fragment}`);
+  expect(mat.shader.code).not.toContain("var albedo:");
+  expect(mat.shader.code).not.toContain("var materialSampler:");
+  expect(mat.samplerBindings.materialSampler).toBe(0);
+  expect(mat.textureBindings.albedo).toBe(1);
+  device.destroy();
+});
+
+test("default opt-out allows user-authored texture declarations", async () => {
+  const { device } = await testDevice();
+  const manualFragment = `
+@group(0) @binding(0) var materialSampler: sampler;
+@group(0) @binding(1) var albedo: texture_2d<f32>;
+@fragment fn fs_main(@location(0) uv: vec2<f32>) -> @location(0) vec4<f32> {
+  return textureSample(albedo, materialSampler, uv);
+}`;
+  const mat = material({ device, vertex: uvVertex, fragment: manualFragment, uniforms: {}, textures: { albedo: "texture_2d_f32" }, vertexLayout: "position-uv", targetFormat: "rgba8unorm" });
+  expect(mat.shader.code).toBe(`\n${uvVertex}\n${manualFragment}`);
+  expect(mat.shader.code.match(/var albedo:/g)).toHaveLength(1);
+  expect(mat.textureBindings.albedo).toBe(1);
+  device.destroy();
+});
+
+test("getMaterialDeclarations matches the autoDeclarations prepend", async () => {
+  const { device } = await testDevice();
+  for (const { textures, samplers, declarations } of declarationCases()) {
+    const spec = { uniforms: {}, textures, samplers };
+    const decls = getMaterialDeclarations(spec);
+    const mat = material({ device, vertex, fragment, uniforms: {}, textures, samplers, vertexLayout: "position-only", targetFormat: "rgba8unorm", autoDeclarations: true });
+    expect(decls).toBe(declarations);
+    expect(mat.shader.code).toBe(`${decls}\n\n${vertex}\n${fragment}`);
+  }
+  device.destroy();
+});
+
+test("binding maps are identical with and without autoDeclarations", async () => {
+  const { device } = await testDevice();
+  const textures = { albedo: "texture_2d_f32", normal: { kind: "texture_2d_f32", sampler: "nearestSampler" } } as const;
+  const samplers = { nearestSampler: "nearest-clamp" } as const;
+  const off = material({ device, vertex, fragment, uniforms: {}, textures, samplers, vertexLayout: "position-only", targetFormat: "rgba8unorm" });
+  const on = material({ device, vertex, fragment, uniforms: {}, textures, samplers, vertexLayout: "position-only", targetFormat: "rgba8unorm", autoDeclarations: true });
+  expect(on.textureBindings).toEqual(off.textureBindings);
+  expect(on.samplerBindings).toEqual(off.samplerBindings);
+  device.destroy();
+});
+
+test("wgslDeclarations matches getMaterialDeclarations and supports custom groups", () => {
+  const textures = { albedo: "texture_2d_f32" } as const;
+  const matDecls = getMaterialDeclarations({ uniforms: {}, textures, samplers: undefined });
+  expect(wgslDeclarations(textures, { albedo: 1 }, { materialSampler: 0 })).toBe(matDecls);
+  expect(wgslDeclarations(textures, { albedo: 1 }, { materialSampler: 0 }, 2)).toBe("@group(2) @binding(1) var albedo: texture_2d<f32>;\n@group(2) @binding(0) var materialSampler: sampler;");
+  expect(getMaterialDeclarations({ uniforms: {}, textures: {}, samplers: undefined })).toBe("");
+  expect(getMaterialDeclarations({ uniforms: {}, textures: undefined, samplers: undefined })).toBe("");
+});
+
+function declarationCases(): readonly { readonly textures: Record<string, MaterialTextureSpec>; readonly samplers?: Record<string, MaterialSamplerSpec>; readonly declarations: string }[] {
+  return [
+    { textures: { albedo: "texture_2d_f32" }, declarations: "@group(0) @binding(1) var albedo: texture_2d<f32>;\n@group(0) @binding(0) var materialSampler: sampler;" },
+    { textures: { albedo: { kind: "texture_2d_f32", sampler: "albedoSampler" } }, samplers: { albedoSampler: "nearest-clamp" }, declarations: "@group(0) @binding(1) var albedo: texture_2d<f32>;\n@group(0) @binding(0) var albedoSampler: sampler;" },
+    { textures: { envMap: "texture_cube_f32" }, declarations: "@group(0) @binding(1) var envMap: texture_cube<f32>;\n@group(0) @binding(0) var materialSampler: sampler;" },
+    { textures: { tiles: "texture_2d_array_f32" }, declarations: "@group(0) @binding(1) var tiles: texture_2d_array<f32>;\n@group(0) @binding(0) var materialSampler: sampler;" },
+    { textures: { albedo: "texture_2d_f32", normal: { kind: "texture_2d_f32", sampler: "nearestSampler" }, envMap: "texture_cube_f32" }, samplers: { nearestSampler: "nearest-clamp" }, declarations: "@group(0) @binding(2) var albedo: texture_2d<f32>;\n@group(0) @binding(0) var materialSampler: sampler;\n@group(0) @binding(3) var normal: texture_2d<f32>;\n@group(0) @binding(1) var nearestSampler: sampler;\n@group(0) @binding(4) var envMap: texture_cube<f32>;" },
+  ];
+}
+
+function testDevice(): Promise<{ readonly device: Device }> {
+  return App.create({ adapter: adapter() });
+}
+
+function adapter(): VGPUAdapter {
+  return process.env.VGPU_DOCKER_TEST === "1" ? createNodeAdapter() : createMockAdapter();
+}

--- a/packages/render/tests/material-factory.test.ts
+++ b/packages/render/tests/material-factory.test.ts
@@ -107,18 +107,33 @@ test("material.shader.code exposes the WGSL string", async () => {
   device.destroy();
 });
 
-test("empty textures spec preserves no-texture material shape", async () => {
+test("empty textures spec preserves no-texture material shape and WGSL byte-for-byte", async () => {
   const { device } = await testDevice();
   const mat = material({ device, vertex, fragment, uniforms: {}, textures: {}, vertexLayout: "position-only", targetFormat: "rgba8unorm" });
   expect(mat.samplerBindings).toEqual({});
   expect(mat.textureBindings).toEqual({});
   expect(mat.gpu.defaultSampler).toBeUndefined();
+  expect(mat.shader.code).toBe(`\n${vertex}\n${fragment}`);
   device.destroy();
 });
 
-function make(device: Device, uniforms: Record<string, WgslUniformType>): Material {
-  return material({ device, vertex, fragment, uniforms, vertexLayout: "position-only", targetFormat: "rgba8unorm" });
-}
+test("material emits WGSL declarations for texture kinds and samplers", async () => {
+  const { device } = await testDevice();
+  const cases = [
+    ["implicit materialSampler", { albedo: "texture_2d_f32" }, undefined, `@group(0) @binding(1) var albedo: texture_2d<f32>;\n@group(0) @binding(0) var materialSampler: sampler;`],
+    ["explicit user sampler", { albedo: { kind: "texture_2d_f32", sampler: "albedoSampler" } }, { albedoSampler: "nearest-clamp" }, `@group(0) @binding(1) var albedo: texture_2d<f32>;\n@group(0) @binding(0) var albedoSampler: sampler;`],
+    ["cube texture", { envMap: "texture_cube_f32" }, undefined, `@group(0) @binding(1) var envMap: texture_cube<f32>;\n@group(0) @binding(0) var materialSampler: sampler;`],
+    ["2D array texture", { tiles: "texture_2d_array_f32" }, undefined, `@group(0) @binding(1) var tiles: texture_2d_array<f32>;\n@group(0) @binding(0) var materialSampler: sampler;`],
+    ["mixed textures", { albedo: "texture_2d_f32", normal: { kind: "texture_2d_f32", sampler: "nearestSampler" }, envMap: "texture_cube_f32" }, { nearestSampler: "nearest-clamp" }, `@group(0) @binding(2) var albedo: texture_2d<f32>;\n@group(0) @binding(0) var materialSampler: sampler;\n@group(0) @binding(3) var normal: texture_2d<f32>;\n@group(0) @binding(1) var nearestSampler: sampler;\n@group(0) @binding(4) var envMap: texture_cube<f32>;`],
+  ] as const;
+  for (const [name, textures, samplers, declarations] of cases) {
+    const mat = material({ device, vertex, fragment, uniforms: {}, textures, samplers, vertexLayout: "position-only", targetFormat: "rgba8unorm", autoDeclarations: true });
+    expect(mat.shader.code, name).toBe(`${declarations}\n\n${vertex}\n${fragment}`);
+  }
+  device.destroy();
+});
+
+function make(device: Device, uniforms: Record<string, WgslUniformType>): Material { return material({ device, vertex, fragment, uniforms, vertexLayout: "position-only", targetFormat: "rgba8unorm" }); }
 
 function testDevice(): Promise<{ readonly device: Device }> {
   return App.create({ adapter: adapter() });


### PR DESCRIPTION
## Motivation

Chunk 2 originally made `material({ textures, samplers })` auto-prepend WGSL `@group/@binding` declarations by default. Review flagged two concerns: injected lines are invisible when an agent or human reads the authored shader source, and advanced users need control over binding placement and optimization. This PR has been iterated to ship texture/sampler declaration generation as opt-in while exporting the declaration helpers for manual use.

## API surface diff

Before:

```ts
const mat = material({
  device,
  vertex,
  fragment,
  uniforms: {},
  textures: { albedo: "texture_2d_f32" },
  samplers: { nearestSampler: "nearest-clamp" },
  vertexLayout: "position-uv",
});
// material() auto-prepends generated @group/@binding declarations.
```

After:

```ts
const mat = material({
  device,
  vertex,
  fragment,
  uniforms: {},
  textures: { albedo: "texture_2d_f32" },
  vertexLayout: "position-uv",
});
// default: no texture/sampler declaration prepend.

const auto = material({ ...spec, autoDeclarations: true });
const manual = material({ ...spec, fragment: `${getMaterialDeclarations(spec)}\n${fragment}` });
```

## Migration guide

### Path A — keep the old auto-prepend behavior

```ts
const mat = material({
  device, vertex, fragment, uniforms: {},
  textures: { albedo: "texture_2d_f32" },
  vertexLayout: "position-only",
  autoDeclarations: true,
});
```

### Path B — write declarations explicitly in shader source

```ts
const fragment = `
@group(0) @binding(0) var materialSampler: sampler;
@group(0) @binding(1) var albedo: texture_2d<f32>;

@fragment fn fs_main(@location(0) uv: vec2<f32>) -> @location(0) vec4<f32> {
  return textureSample(albedo, materialSampler, uv);
}`;

const mat = material({
  device, vertex, fragment, uniforms: {},
  textures: { albedo: "texture_2d_f32" },
  vertexLayout: "position-uv",
});
```

### Path C — let the library compute declarations and prepend manually

```ts
const spec = {
  device,
  vertex, fragment, uniforms: {},
  textures: { albedo: "texture_2d_f32", normal: "texture_2d_f32" },
  vertexLayout: "position-normal-uv",
} as const;

const decls = getMaterialDeclarations(spec);
const mat = material({
  ...spec,
  fragment: `${decls}\n${fragment}`,
});
```

## Binding allocation order

Public contract: uniforms → samplers → textures, each in insertion order. Stable across versions.

The uniform buffer uses binding 0 when `uniforms` has fields. If an implicit `materialSampler` is needed, it is allocated in the sampler section before explicit sampler keys, preserving the Chunk 2 binding shape.

## Test coverage summary

- T1: default `autoDeclarations` omitted keeps shader code exactly `header + vertex + fragment` with no texture/sampler declarations.
- T2: `autoDeclarations: true` preserves the prior auto-prepend behavior for 2D, cube, 2D-array, explicit sampler, and mixed cases.
- T3: default opt-out with user-written declarations has no duplicate generated declarations and supports sampling.
- T4: `getMaterialDeclarations(spec)` is byte-equivalent to the prefix used by `material({ ...spec, autoDeclarations: true })`.
- T5: `textureBindings` and `samplerBindings` are identical whether `autoDeclarations` is omitted or `true`.

## BREAKING CHANGE

Pre-1.0, the default behavior of `material()` flipped relative to the previous PR #63 draft: texture/sampler declarations are no longer prepended unless `autoDeclarations: true` is set. The shipped behavior matches user feedback. No external consumers are affected because the previous default only existed in the unmerged PR #63 draft.

## Bundle impact

`pnpm bundle-check` on this branch:

```text
@vgpu/adapter-mock: 12774 B gzip / 20480 B budget
@vgpu/adapter-node: 16678 B gzip / 30720 B budget
@vgpu/core: 27084 B gzip / 51200 B budget
@vgpu/render: 24525 B gzip / 49152 B budget
@vgpu/render/inspect: 2506 B gzip / 4096 B budget
@vgpu/render/utils: 574 B gzip / 2048 B budget
@vgpu/render/edit: 12204 B gzip / 25600 B budget
@vgpu/render/passes: 2660 B gzip / 3584 B budget
@vgpu/wgsl: 688 B gzip / 25600 B budget
@vgpu/wgsl/runtime: 6600 B gzip / 204800 B budget
@vgpu/wgsl/loader-webpack: 6821 B gzip / 204800 B budget
@vgpu/wgsl/loader-vite: 6806 B gzip / 204800 B budget
```

`@vgpu/render` is +380 B gzip vs `origin/main` (24145 B → 24525 B), well within the 49152 B budget.

## Local verification

- `pnpm build`
- `pnpm test packages/render/tests/material-factory.test.ts packages/render/tests/material-declarations.test.ts`
- `pnpm bundle-check`
