### PR TITLE
feat(wgsl): expose resolved shader dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+### Minor
+- @vgpu/wgsl: Add `deps` field to `resolveShader` result; add `onDependency` callback option to `transformWgsl`. Foundation for HMR / watch-mode support in webpack/vite loaders (PR2).
+
 ## 0.0.1 — 2026-05-07
 
 First public preview. API will shift before 0.1.0.

--- a/packages/wgsl/src/loader-vite/index.ts
+++ b/packages/wgsl/src/loader-vite/index.ts
@@ -2,10 +2,15 @@ import { resolveShader } from "../runtime/resolveShader.ts";
 import { hasTopLevelImport } from "../runtime/scanner.ts";
 
 export interface ViteLoadResult { readonly code: string; readonly map: null }
+export interface TransformWgslOptions { readonly source: string; readonly id: string; readonly onDependency?: (absPath: string) => void }
 
-export async function transformWgsl(source: string, id: string): Promise<ViteLoadResult> {
-  if (!hasTopLevelImport(source)) return { code: `export default ${JSON.stringify(source)};`, map: null };
-  const resolved = await resolveShader({ entry: id, validate: false });
+export function transformWgsl(source: string, id: string): Promise<ViteLoadResult>;
+export function transformWgsl(opts: TransformWgslOptions): Promise<ViteLoadResult>;
+export async function transformWgsl(sourceOrOpts: string | TransformWgslOptions, id?: string): Promise<ViteLoadResult> {
+  const opts = typeof sourceOrOpts === "string" ? { source: sourceOrOpts, id: id ?? "<vite>" } : sourceOrOpts;
+  if (!hasTopLevelImport(opts.source)) return { code: `export default ${JSON.stringify(opts.source)};`, map: null };
+  const resolved = await resolveShader({ entry: opts.id, validate: false });
+  for (const dep of resolved.deps) opts.onDependency?.(dep);
   return { code: `export default ${JSON.stringify(resolved.wgsl)};`, map: null };
 }
 

--- a/packages/wgsl/src/runtime/resolveShader.ts
+++ b/packages/wgsl/src/runtime/resolveShader.ts
@@ -15,7 +15,7 @@ export interface ResolveOptions { readonly entry: string; readonly rootDir?: str
 export interface WGSLModule { readonly path: string; readonly exports: readonly { readonly name: string; readonly localName: string; readonly sourcePath: string }[]; readonly imports: readonly { readonly from: string; readonly bindings: readonly { readonly local: string; readonly imported: string }[] }[]; readonly bytes: number; readonly hash8: string }
 export interface WGSLAst { readonly version: 1; readonly modules: readonly WGSLModule[]; readonly diagnostics: DiagnosticList; readonly sourceMap: SourceMap; readonly cacheKey: Record<string, string> }
 export interface SourceMap { readonly version: 3; readonly sources: readonly string[]; readonly mappings: string }
-export interface ResolvedShader { readonly wgsl: string; readonly cacheKey: Record<string, string>; readonly ast: WGSLAst; readonly sourceMap: SourceMap; readonly diagnostics: DiagnosticList; readonly reflection: Reflection }
+export interface ResolvedShader { readonly wgsl: string; readonly deps: readonly string[]; readonly cacheKey: Record<string, string>; readonly ast: WGSLAst; readonly sourceMap: SourceMap; readonly diagnostics: DiagnosticList; readonly reflection: Reflection }
 
 const scanCache = new Map<string, MangleModule>();
 const resolveCache = new Map<string, ResolvedShader>();
@@ -29,6 +29,7 @@ export async function resolveShader(opts: ResolveOptions): Promise<ResolvedShade
   const entry = canonicalEntry(opts.entry, opts);
   loadGraph(entry, opts, loaded, [], diagnostics);
   const modules = [...loaded.values()];
+  const deps = [...loaded.keys()].sort();
   assertNoMangleCollisions(modules.map((module) => module.path));
   assertNoJsVisibleDuplicates(modules);
   const exportsByPath = buildExports(modules);
@@ -39,7 +40,7 @@ export async function resolveShader(opts: ResolveOptions): Promise<ResolvedShade
   if (opts.validate !== false) await validateWGSL(wgsl);
   const cacheKey = cacheKeys(modules, reflection, opts.rootDir ?? dirname(entry));
   const ast: WGSLAst = { version: 1, modules: modules.map(toAstModule), diagnostics, sourceMap: map, cacheKey };
-  const resolved = { wgsl, cacheKey, ast, sourceMap: map, diagnostics, reflection };
+  const resolved = { wgsl, deps, cacheKey, ast, sourceMap: map, diagnostics, reflection };
   remember(resolveCache, key, resolved);
   return resolved;
 }

--- a/packages/wgsl/tests/resolve-deps.test.ts
+++ b/packages/wgsl/tests/resolve-deps.test.ts
@@ -1,0 +1,32 @@
+import { mkdtemp, mkdir, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { expect, test } from "vitest";
+import { resolveShader } from "@vgpu/wgsl/runtime";
+
+test("resolveShader deps include entry and transitive imports sorted and deduped", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "vgsl-"));
+  await mkdir(join(dir, "shaders"));
+  const entry = join(dir, "shaders", "main.wgsl");
+  const a = join(dir, "shaders", "a.wgsl");
+  const b = join(dir, "shaders", "b.wgsl");
+  const shared = join(dir, "shaders", "shared.wgsl");
+  await writeFile(entry, "import { b } from './b.wgsl'; import { a } from './a.wgsl'; fn main(){a();b();}");
+  await writeFile(a, "import { shared } from './shared.wgsl'; export fn a(){shared();}");
+  await writeFile(b, "import { shared } from './shared.wgsl'; export fn b(){shared();}");
+  await writeFile(shared, "export fn shared(){}");
+
+  const result = await resolveShader({ entry, validate: false });
+
+  expect(result.deps).toEqual([a, b, entry, shared].sort());
+});
+
+test("resolveShader deps contain only the entry for a leaf shader", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "vgsl-"));
+  const entry = join(dir, "leaf.wgsl");
+  await writeFile(entry, "fn main(){}");
+
+  const result = await resolveShader({ entry, validate: false });
+
+  expect(result.deps).toEqual([entry]);
+});

--- a/packages/wgsl/tests/transform-wgsl-callback.test.ts
+++ b/packages/wgsl/tests/transform-wgsl-callback.test.ts
@@ -1,0 +1,19 @@
+import { mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { expect, test, vi } from "vitest";
+import { transformWgsl } from "@vgpu/wgsl/loader-vite";
+
+test("transformWgsl calls onDependency for every resolved shader dependency", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "vgsl-"));
+  const entry = join(dir, "main.wgsl");
+  const imported = join(dir, "imported.wgsl");
+  await writeFile(entry, "import { imported } from './imported.wgsl'; fn main(){imported();}");
+  await writeFile(imported, "export fn imported(){}");
+  const onDependency = vi.fn();
+
+  await transformWgsl({ source: await readFile(entry, "utf8"), id: entry, onDependency });
+
+  expect(onDependency).toHaveBeenCalledTimes(2);
+  expect(onDependency.mock.calls.map(([dep]) => dep)).toEqual([entry, imported].sort());
+});


### PR DESCRIPTION
## PR0 — WGSL runtime API: `resolveShader` returns deps + `transformWgsl` accepts onDependency

Foundation for PR1 (real Webpack+Vite integration tests) and PR2 (webpack `addDependency` + vite `addWatchFile`).

### Changes
- `resolveShader` now returns `{wgsl, deps}` where `deps` is the sorted, deduped, absolute-path list of every file that contributed to the merged WGSL output (including the entry).
- `transformWgsl` accepts optional `onDependency?: (absPath: string) => void`. Existing positional callers remain supported.
- Tests cover dedup, sort, leaf-only, and the onDependency callback path.

### Breaking change
- `@vgpu/wgsl/runtime` `resolveShader` return type widens from `{wgsl}` to `{wgsl, deps}`. Pre-1.0 minor bump acceptable. Existing consumers using only `.wgsl` are unaffected.

### Bundle impact
- Baseline (`origin/main`):
  - `@vgpu/wgsl/runtime`: 6583 B gzip / 204800 B budget
  - `@vgpu/wgsl/loader-webpack`: 6809 B gzip / 204800 B budget
  - `@vgpu/wgsl/loader-vite`: 6744 B gzip / 204800 B budget
- This PR:
  - `@vgpu/wgsl/runtime`: 6600 B gzip / 204800 B budget (+17 B)
  - `@vgpu/wgsl/loader-webpack`: 6821 B gzip / 204800 B budget (+12 B)
  - `@vgpu/wgsl/loader-vite`: 6806 B gzip / 204800 B budget (+62 B)

### Tests
- New: `packages/wgsl/tests/resolve-deps.test.ts`
- New: `packages/wgsl/tests/transform-wgsl-callback.test.ts`
- Local:
  - `pnpm test packages/wgsl/`
  - `pnpm build`
  - `node scripts/check-bundle-size.mjs`

### CI
- Run ID: `25694815927`
- Created: `2026-05-11T20:16:38Z`
- `test-fast`: ✅
- `test-integration`: ✅
- `wgsl-cachekey-determinism` (ubuntu-24.04, ubuntu-24.04-arm, macos-14): ✅
- Bundle budget: within `./runtime` 204800-byte limit.

Refs: `~/projects/.vgpu-wip/plans/wgsl-loaders-production-ready.md` (PR0)
