### PR TITLE
fix(wgsl): keep resolver fresh across shader edits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@
      ```
 - @vgpu/wgsl: Add `deps` field to `resolveShader` result; add `onDependency` callback option to `transformWgsl`. Foundation for HMR / watch-mode support in webpack/vite loaders (PR2).
 - @vgpu/wgsl: Production-grade loader plumbing: webpack now tracks transitively-imported `.wgsl` files via `addDependency`, Vite/Rollup via `addWatchFile`, and CJS configs can `require.resolve('@vgpu/wgsl/loader-webpack')` / `require.resolve('@vgpu/wgsl/loader-vite')` through new `default` export conditions.
+- @vgpu/wgsl: Runtime: production HMR correctness — resolver uses async file reads + removes stale-result entry-level cache.
+  - `resolveShader` now reads `.wgsl` source via async `fs/promises.readFile`. Turbopack's webpack-loader bridge tracks transitive `.wgsl` reads via this path; sync reads previously bypassed interception.
+  - `resolveShader` no longer caches resolved results across calls. Existing dependency-registration wiring (`addDependency` in webpack, `addWatchFile` in vite, async-fs interception in Turbopack) now actually triggers fresh resolution on file changes. Direct-runtime hot-loop callers should memoize at their call site if performance becomes a concern (the per-file `scanCache` is still active).
 
 ## 0.0.1 — 2026-05-07
 

--- a/packages/wgsl/src/runtime/packageResolution.ts
+++ b/packages/wgsl/src/runtime/packageResolution.ts
@@ -1,4 +1,5 @@
 import { existsSync, readFileSync, statSync } from "node:fs";
+import { readFile } from "node:fs/promises";
 import { dirname, extname, join, normalize, resolve } from "node:path";
 import { wgslError, wgslWarning } from "./errors.ts";
 import type { Diagnostic } from "./diagnosticTypes.ts";
@@ -15,10 +16,10 @@ export function resolveImport(spec: string, from: string, opts: PackageResolveOp
   return packageImport(spec, from, diagnostics);
 }
 
-export function readModule(path: string, opts: PackageResolveOptions): string {
+export async function readModule(path: string, opts: PackageResolveOptions): Promise<string> {
   const text = opts.modules?.[path];
   if (text !== undefined) return text;
-  if (existsSync(path)) return readFileSync(path, "utf8");
+  if (existsSync(path)) return await readFile(path, "utf8");
   throw wgslError("VGPU-WGSL-RES-NOTFOUND", `WGSL module ${path} was not found`);
 }
 

--- a/packages/wgsl/src/runtime/resolveShader.ts
+++ b/packages/wgsl/src/runtime/resolveShader.ts
@@ -18,16 +18,12 @@ export interface SourceMap { readonly version: 3; readonly sources: readonly str
 export interface ResolvedShader { readonly wgsl: string; readonly deps: readonly string[]; readonly cacheKey: Record<string, string>; readonly ast: WGSLAst; readonly sourceMap: SourceMap; readonly diagnostics: DiagnosticList; readonly reflection: Reflection }
 
 const scanCache = new Map<string, MangleModule>();
-const resolveCache = new Map<string, ResolvedShader>();
 
 export async function resolveShader(opts: ResolveOptions): Promise<ResolvedShader> {
-  const key = JSON.stringify({ entry: opts.entry, rootDir: opts.rootDir, packageMap: opts.packageMap, modules: opts.modules });
-  const cached = resolveCache.get(key);
-  if (cached) return cached;
   const loaded = new Map<string, MangleModule>();
   const diagnostics: DiagnosticList[number][] = [];
   const entry = canonicalEntry(opts.entry, opts);
-  loadGraph(entry, opts, loaded, [], diagnostics);
+  await loadGraph(entry, opts, loaded, [], diagnostics);
   const modules = [...loaded.values()];
   const deps = [...loaded.keys()].sort();
   assertNoMangleCollisions(modules.map((module) => module.path));
@@ -40,21 +36,19 @@ export async function resolveShader(opts: ResolveOptions): Promise<ResolvedShade
   if (opts.validate !== false) await validateWGSL(wgsl);
   const cacheKey = cacheKeys(modules, reflection, opts.rootDir ?? dirname(entry));
   const ast: WGSLAst = { version: 1, modules: modules.map(toAstModule), diagnostics, sourceMap: map, cacheKey };
-  const resolved = { wgsl, deps, cacheKey, ast, sourceMap: map, diagnostics, reflection };
-  remember(resolveCache, key, resolved);
-  return resolved;
+  return { wgsl, deps, cacheKey, ast, sourceMap: map, diagnostics, reflection };
 }
 
-function loadGraph(path: string, opts: ResolveOptions, loaded: Map<string, MangleModule>, stack: string[], diagnostics: DiagnosticList[number][]): void {
+async function loadGraph(path: string, opts: ResolveOptions, loaded: Map<string, MangleModule>, stack: string[], diagnostics: DiagnosticList[number][]): Promise<void> {
   if (stack.includes(path)) throw wgslError("VGPU-WGSL-IMP-SELF", `Import cycle: ${[...stack, path].join(" -> ")}`);
   if (loaded.has(path)) return;
-  const source = readModule(path, opts);
+  const source = await readModule(path, opts);
   const cacheKey = `${path}:${source}`;
   let module = scanCache.get(cacheKey);
   if (!module) { const tokens = scan(source); module = { path, source, tokens, parsed: parseModule(tokens) }; remember(scanCache, cacheKey, module); }
   loaded.set(path, module);
   stack.push(path);
-  for (const imp of module.parsed.imports) loadGraph(resolvePath(imp.from, path, opts, diagnostics), opts, loaded, stack, diagnostics);
+  for (const imp of module.parsed.imports) await loadGraph(resolvePath(imp.from, path, opts, diagnostics), opts, loaded, stack, diagnostics);
   stack.pop();
 }
 

--- a/packages/wgsl/tests/runtime-freshness.test.ts
+++ b/packages/wgsl/tests/runtime-freshness.test.ts
@@ -1,0 +1,57 @@
+import { mkdtemp, writeFile } from "node:fs/promises";
+import { readFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it, vi } from "vitest";
+import { resolveShader } from "@vgpu/wgsl/runtime";
+
+vi.mock("node:fs/promises", async (importActual) => {
+  const actual = await importActual<typeof import("node:fs/promises")>();
+  return { ...actual, readFile: vi.fn(actual.readFile) };
+});
+
+describe("resolveShader runtime freshness", () => {
+  it("re-reads a mutated transitive .wgsl file on a second resolveShader call", async () => {
+    const { entry, helper } = await writeFreshnessFixture();
+
+    const first = await resolveShader({ entry, validate: false });
+    await writeFile(helper, helperSource("0.9, 0.8, 0.7, 1.0"));
+    const second = await resolveShader({ entry, validate: false });
+
+    expect(second.wgsl).not.toBe(first.wgsl);
+    expect(second.wgsl).toContain("0.9, 0.8, 0.7, 1.0");
+  });
+
+  it("reads imported .wgsl modules through fs/promises.readFile", async () => {
+    const { entry, helper } = await writeFreshnessFixture();
+    const readFileMock = vi.mocked(readFile);
+    readFileMock.mockClear();
+
+    await resolveShader({ entry, validate: false });
+
+    expect(readFileMock).toHaveBeenCalledWith(helper, "utf8");
+  });
+
+  it("preserves clear cycle detection with async sequential recursion", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "vgsl-cycle-"));
+    const a = join(dir, "a.wgsl");
+    const b = join(dir, "b.wgsl");
+    await writeFile(a, "import { b } from './b.wgsl'; export fn a(){b();}");
+    await writeFile(b, "import { a } from './a.wgsl'; export fn b(){a();}");
+
+    await expect(resolveShader({ entry: a, validate: false })).rejects.toMatchObject({ code: "VGPU-WGSL-IMP-SELF" });
+  });
+});
+
+async function writeFreshnessFixture(): Promise<{ entry: string; helper: string }> {
+  const dir = await mkdtemp(join(tmpdir(), "vgsl-fresh-"));
+  const entry = join(dir, "entry.wgsl");
+  const helper = join(dir, "helper.wgsl");
+  await writeFile(helper, helperSource("0.1, 0.2, 0.3, 1.0"));
+  await writeFile(entry, "import { helper_color } from './helper.wgsl';\nfn main_color() -> vec4f { return helper_color(); }");
+  return { entry, helper };
+}
+
+function helperSource(channels: string): string {
+  return `export fn helper_color() -> vec4f { return vec4f(${channels}); }`;
+}

--- a/packages/wgsl/tests/transform-wgsl-callback.test.ts
+++ b/packages/wgsl/tests/transform-wgsl-callback.test.ts
@@ -18,3 +18,19 @@ test("transformWgsl calls onDependency for transitive shader dependencies", asyn
   expect(onDependency.mock.calls.map(([dep]) => dep)).toEqual([imported]);
   expect(onDependency).not.toHaveBeenCalledWith(entry);
 });
+
+test("transformWgsl re-reads a mutated transitive .wgsl file on the second transform", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "vgsl-transform-fresh-"));
+  const entry = join(dir, "main.wgsl");
+  const imported = join(dir, "imported.wgsl");
+  const source = "import { imported_color } from './imported.wgsl'; fn main_color() -> vec4f { return imported_color(); }";
+  await writeFile(entry, source);
+  await writeFile(imported, "export fn imported_color() -> vec4f { return vec4f(0.1, 0.2, 0.3, 1.0); }");
+
+  const first = await transformWgsl({ source, id: entry });
+  await writeFile(imported, "export fn imported_color() -> vec4f { return vec4f(0.9, 0.8, 0.7, 1.0); }");
+  const second = await transformWgsl({ source, id: entry });
+
+  expect(second.code).not.toBe(first.code);
+  expect(second.code).toContain("0.9, 0.8, 0.7, 1.0");
+});

--- a/packages/wgsl/tests/webpack-real.test.ts
+++ b/packages/wgsl/tests/webpack-real.test.ts
@@ -40,6 +40,28 @@ describe("wgslWebpackLoader (real webpack 5)", () => {
 
     expect(stats.compilation.fileDependencies.has(helperWgsl)).toBe(true);
   });
+
+  it("emits fresh bundled WGSL when a transitive import changes between builds", async () => {
+    const { entryJs, outDir, helperWgsl } = await writeFixture();
+    const config: Configuration = {
+      mode: "development",
+      target: "node",
+      entry: entryJs,
+      output: { path: outDir, filename: "bundle.cjs", libraryTarget: "commonjs2" },
+      module: { rules: [{ test: /\.wgsl$/, loader: resolveWebpackLoader() }] },
+      optimization: { minimize: false },
+    };
+
+    await runWebpack(config);
+    const first = await readFile(join(outDir, "bundle.cjs"), "utf8");
+    await writeFile(helperWgsl, "export fn helper_color() -> vec4f { return vec4f(0.9, 0.8, 0.7, 1.0); }");
+    await runWebpack(config);
+    const second = await readFile(join(outDir, "bundle.cjs"), "utf8");
+
+    expect(first).toContain("0.1, 0.2, 0.3, 1.0");
+    expect(second).not.toBe(first);
+    expect(second).toContain("0.9, 0.8, 0.7, 1.0");
+  });
 });
 
 async function writeFixture(): Promise<{ entryJs: string; outDir: string; helperWgsl: string }> {


### PR DESCRIPTION
## PR3a — WGSL runtime: async .wgsl reads + remove stale-result cache

Production HMR correctness fix. Q5 explorer + reason agent uncovered that `resolveShader`'s module-level `resolveCache` was returning cached results across HMR rebuilds, defeating PR2's `addDependency`/`addWatchFile` wiring on all three bundlers (Webpack, Vite, Turbopack). Additionally, sync `readFileSync` for `.wgsl` content meant Turbopack's webpack-loader bridge couldn't track transitive reads via its patched async-fs interception.

### Changes
- `src/runtime/packageResolution.ts`: `readModule` now uses async `fs/promises.readFile` for `.wgsl` source. `package.json` reads + path probes stay sync (not part of HMR edit loop).
- `src/runtime/resolveShader.ts`: removed `resolveCache` Map + early return + `remember` write. `scanCache` (content-keyed, safe under mutation) kept.
- `loadGraph` recursion is sequential `for...of await` — NOT `Promise.all` (would break cycle detection via `stack.includes(path)`).
- 5 new regression tests: mutation freshness (direct runtime, transformWgsl, webpack loader), async-fs spy proving Turbopack-relevant IO path, cycle detection guard under async.

### Pre-fix verification
Empirical pre-fix check in a clean worktree at `origin/main` @ `73bc904` with this PR's `runtime-freshness.test.ts` copied in:

```text
❯ packages/wgsl/tests/runtime-freshness.test.ts (3 tests | 2 failed) 14ms
  × resolveShader runtime freshness > re-reads a mutated transitive .wgsl file on a second resolveShader call 10ms
    → expected '// vgsl-module: /tmp/vgsl-fresh-LhR13…' not to be '// vgsl-module: /tmp/vgsl-fresh-LhR13…' // Object.is equality
  × resolveShader runtime freshness > reads imported .wgsl modules through fs/promises.readFile 3ms
    → expected "readFile" to be called with arguments: [ …(2) ]

Number of calls: 0

AssertionError: expected '// vgsl-module: /tmp/vgsl-fresh-LhR13…' not to be '// vgsl-module: /tmp/vgsl-fresh-LhR13…' // Object.is equality
 ❯ packages/wgsl/tests/runtime-freshness.test.ts:21:29
```

The same test passes on this branch:

```text
✓ packages/wgsl/tests/runtime-freshness.test.ts (3 tests) 17ms
Test Files  1 passed (1)
Tests  3 passed (3)
```

### Public API
**No new public API.** Internal map deletion only.

### Behavioral note
`resolveShader` no longer caches entire resolved results across calls. Direct-runtime hot-loop callers (rare; no first-party callers do this) should memoize at the call site. The per-file `scanCache` is still active.

### Bundle impact
`node scripts/check-bundle-size.mjs`:

```text
@vgpu/wgsl: 688 B gzip / 25600 B budget
@vgpu/wgsl/runtime: 6562 B gzip / 204800 B budget
@vgpu/wgsl/loader-webpack: 6820 B gzip / 204800 B budget
@vgpu/wgsl/loader-vite: 6805 B gzip / 204800 B budget
```

No perf regression expected: `scanCache` retained; validation disabled on loader path; benchmark deferred.

### Local validation
- `pnpm install`
- `pnpm build`
- `pnpm test packages/wgsl/`
- `node scripts/check-bundle-size.mjs`

Refs: `~/projects/.vgpu-wip/plans/wgsl-loaders-production-ready.md` (PR3a), `~/.agents/reason/wgsl-resolve-cache-strategy.md`
