### PR TITLE
chore: prepare v0.0.3 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## 0.0.3 — 2026-05-13
 
 ### Minor
 - @vgpu/render: BREAKING CHANGE (pre-1.0): `material()` no longer auto-prepends texture/sampler WGSL declarations by default. `wgslDeclarations(textures, textureBindings, samplerBindings, group?)` is also exported for lower-level declaration generation. Binding allocation order is now documented as uniforms → samplers → textures, each in insertion order.

--- a/packages/adapter-mock/package.json
+++ b/packages/adapter-mock/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vgpu/adapter-mock",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Mock GPU adapter for testing vgpu code without real WebGPU hardware.",
   "keywords": [
     "webgpu",

--- a/packages/adapter-node/package.json
+++ b/packages/adapter-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vgpu/adapter-node",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Node.js GPU adapter for vgpu, using Dawn-based WebGPU bindings.",
   "keywords": [
     "webgpu",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vgpu/core",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Core WebGPU runtime primitives (device, buffer, texture, shader, queue) for vgpu.",
   "keywords": [
     "webgpu",

--- a/packages/render/package.json
+++ b/packages/render/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vgpu/render",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Render pipeline + render pass abstractions for vgpu.",
   "keywords": [
     "webgpu",

--- a/packages/wgsl/package.json
+++ b/packages/wgsl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vgpu/wgsl",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "WGSL shader compilation, runtime resolution, and webpack/vite loaders for vgpu.",
   "keywords": [
     "webgpu",


### PR DESCRIPTION
## Summary

Prepare the manual v0.0.3 release PR for the WGSL loader work.

- Bumps all public `@vgpu/*` packages from `0.0.2` to `0.0.3` using the repository patch-bump convention (`pnpm bump:patch`).
  - `@vgpu/render` is version-bumped even though this PR is WGSL-loader release prep because the repo releases all public `@vgpu/*` packages together.
- Moves `CHANGELOG.md` from `## Unreleased` to `## 0.0.3 — 2026-05-13`.
- Does not add changesets; this repo uses manual release PRs.

## Release contents

Highlights included in the v0.0.3 changelog:

- `@vgpu/wgsl`: production-ready Webpack and Vite loader plumbing, including transitive WGSL dependency/watch tracking.
- `@vgpu/wgsl`: Turbopack dogfood via `examples/next-wgsl`.
- `@vgpu/wgsl`: loader docs/types polish, including `@vgpu/wgsl/wgsl-types` ambient type sub-export.
- `@vgpu/wgsl`: runtime HMR correctness via async file reads and removal of stale result caching.
- `@vgpu/render`: pre-1.0 material declaration behavior change already documented in the changelog.

## Checks

Local environment note: host `node -v` is `v20.20.0`, so pnpm emitted the existing workspace engine warning (`wanted: {"node":">=22 <23"}`), but the commands below completed successfully.

- `pnpm install --frozen-lockfile` — passed.
- `pnpm build` — passed before bump and after bump.
- `pnpm test:fast` — passed before bump (`79 passed | 13 skipped`, `380 passed | 55 skipped`) and after bump (`79 passed | 13 skipped`, `380 passed | 55 skipped`).
- `pnpm test:docker` — passed; final Docker run summary: `93 passed | 1 skipped`, `439 passed | 1 skipped`. The Docker build step also ran `pnpm typecheck` and an in-image `pnpm test` successfully (`81 passed | 13 skipped`, `385 passed | 55 skipped`).
- `pnpm test packages/wgsl/tests/cache-key.test.ts` — passed (`1 passed`, `10 passed`).
- `pnpm test packages/wgsl/tests/webpack-real.test.ts packages/wgsl/tests/vite-real.test.ts` — passed (`2 passed`, `6 passed`).
- Turbopack smoke: `pnpm --filter @vgpu/wgsl build && pnpm --filter @vgpu/example-next-wgsl exec next build --turbopack` — passed with Next.js 15.5.18/Turbopack.
- HMR smoke script: no dedicated package.json HMR smoke script found, so no additional HMR command was run.
- `pnpm bundle-check` — passed after bump:
  - `@vgpu/adapter-mock: 12774 B gzip / 20480 B budget`
  - `@vgpu/adapter-node: 16678 B gzip / 30720 B budget`
  - `@vgpu/core: 27084 B gzip / 51200 B budget`
  - `@vgpu/render: 24525 B gzip / 49152 B budget`
  - `@vgpu/render/inspect: 2506 B gzip / 4096 B budget`
  - `@vgpu/render/utils: 574 B gzip / 2048 B budget`
  - `@vgpu/render/edit: 12204 B gzip / 25600 B budget`
  - `@vgpu/render/passes: 2660 B gzip / 3584 B budget`
  - `@vgpu/wgsl: 688 B gzip / 25600 B budget`
  - `@vgpu/wgsl/runtime: 6562 B gzip / 204800 B budget`
  - `@vgpu/wgsl/loader-webpack: 6820 B gzip / 204800 B budget`
  - `@vgpu/wgsl/loader-vite: 6824 B gzip / 204800 B budget`

## Pack / publish smoke

Built `@vgpu/wgsl`, packed `packages/wgsl` to `/tmp/wgsl-release-pack/vgpu-wgsl-0.0.3.tgz`, and inspected the tarball.

Required tarball entries present:

- `package/dist/loader-webpack/index.js`
- `package/dist/loader-vite/index.js`
- `package/dist/runtime/resolveShader.js`
- `package/dist/wgsl-types.d.ts`
- `package/README.md`
- `package/package.json`

`packages/wgsl/package.json` exports include:

- `.`
- `./runtime`
- `./loader-webpack`
- `./loader-vite`
- `./wgsl-types`

Temp consumer smoke against the packed tarball passed:

- `require.resolve('@vgpu/wgsl/loader-webpack')` resolved to the packed package dist file.
- Dynamic imports succeeded for `@vgpu/wgsl/loader-webpack`, `@vgpu/wgsl/loader-vite`, and `@vgpu/wgsl/runtime`.
- TypeScript resolved `/// <reference types="@vgpu/wgsl/wgsl-types" />` with a local `*.wgsl` import using `pnpm exec tsc --noEmit --module NodeNext --moduleResolution NodeNext --target ES2022 --strict shader-types.ts`.

## Release instructions after merge

After this PR is merged, create a GitHub Release named/tagged `v0.0.3` targeting `main`. The existing release workflow publishes packages on the `release: published` event via `pnpm -r publish`.
