### PR TITLE
chore: prepare v0.0.4 release

### DIFF
--- a/packages/adapter-mock/package.json
+++ b/packages/adapter-mock/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vgpu/adapter-mock",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "Mock GPU adapter for testing vgpu code without real WebGPU hardware.",
   "keywords": [
     "webgpu",

--- a/packages/adapter-node/package.json
+++ b/packages/adapter-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vgpu/adapter-node",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "Node.js GPU adapter for vgpu, using Dawn-based WebGPU bindings.",
   "keywords": [
     "webgpu",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vgpu/core",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "Core WebGPU runtime primitives (device, buffer, texture, shader, queue) for vgpu.",
   "keywords": [
     "webgpu",

--- a/packages/render/package.json
+++ b/packages/render/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vgpu/render",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "Render pipeline + render pass abstractions for vgpu.",
   "keywords": [
     "webgpu",

--- a/packages/wgsl/package.json
+++ b/packages/wgsl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vgpu/wgsl",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "WGSL shader compilation, runtime resolution, and webpack/vite loaders for vgpu.",
   "keywords": [
     "webgpu",


### PR DESCRIPTION
## Summary

Prepare the follow-up patch release metadata bump after PR #72.

Confirmed base:
- `origin/main` is `3477c941ac8d14bef5c630ab14ff500a44f6b349`
- Latest main commit: `3477c94 feat(wgsl): add loader minify option (#72)`

Version changes:
- `@vgpu/wgsl`: `0.0.3` -> `0.0.4`
- `@vgpu/core`: `0.0.3` -> `0.0.4`
- `@vgpu/render`: `0.0.3` -> `0.0.4`
- `@vgpu/adapter-mock`: `0.0.3` -> `0.0.4`
- `@vgpu/adapter-node`: `0.0.3` -> `0.0.4`

Caveat: the release request noted an earlier audit where non-wgsl packages were expected to be `0.0.2`; the actual current `origin/main` at `3477c94` has all public packages at `0.0.3`. I used the repo-wide `pnpm bump:patch` script, then reverted the private example package metadata change so this PR stays scoped to public package version metadata.

## Files changed

- `packages/wgsl/package.json`
- `packages/core/package.json`
- `packages/render/package.json`
- `packages/adapter-mock/package.json`
- `packages/adapter-node/package.json`

## Validation

- `pnpm install --frozen-lockfile` ✅ lockfile up to date
- `pnpm build` ✅
- `pnpm test:fast` ✅ 81 passed / 14 skipped test files; 422 passed / 61 skipped tests
- `pnpm bundle-check` ✅ all bundle budgets under limits
- `git diff --check` ✅
- `npm pack --dry-run --json` from `packages/wgsl` ✅ package id `@vgpu/wgsl@0.0.4`; tarball includes `package.json`, `README.md`, `LICENSE`, `dist/index.*`, `dist/runtime/resolveShader.*`, `dist/loader-webpack/index.*`, `dist/loader-vite/index.*`, and `dist/wgsl-types.d.ts`

Note: local validation emitted the existing engine warning because this environment is Node `v20.20.0` while the repo declares `>=22 <23`; commands completed successfully.

## Release instructions after merge

After this PR merges, create and publish GitHub Release tag `v0.0.4` targeting `main` so the `release.published` workflow builds, tests, and publishes the packages. Do not create the tag before this PR is merged.
