### PR TITLE
fix(wgsl): preserve signed exponent literals when minifying

### DIFF
--- a/packages/wgsl/src/runtime/scanner.ts
+++ b/packages/wgsl/src/runtime/scanner.ts
@@ -62,7 +62,14 @@ export function scan(source: string): Token[] {
       push(WGSL_KEYWORDS.has(text) ? "keyword" : "ident", start, i, atLine, atColumn); continue;
     }
     if (/[0-9]/.test(ch)) {
-      while (i < source.length && /[A-Za-z0-9_.]/.test(source[i]!)) step();
+      while (i < source.length) {
+        const current = source[i]!;
+        if (/[A-Za-z0-9_.]/.test(current)) { step(); continue; }
+        if ((current === "+" || current === "-") && isExponentMarker(source[i - 1]) && /[0-9]/.test(source[i + 1] ?? "")) {
+          step(); continue;
+        }
+        break;
+      }
       push("number", start, i, atLine, atColumn); continue;
     }
     step(); push("punct", start, i, atLine, atColumn);
@@ -85,6 +92,10 @@ export function hasTopLevelImport(source: string): boolean {
 }
 
 const topLevelDirectiveKeywords = new Set(["enable", "requires", "diagnostic"]);
+
+function isExponentMarker(char: string | undefined): boolean {
+  return char === "e" || char === "E" || char === "p" || char === "P";
+}
 
 function isTopLevelDirectiveKeyword(text: string): boolean {
   return topLevelDirectiveKeywords.has(text);

--- a/packages/wgsl/tests/minify-execution.test.ts
+++ b/packages/wgsl/tests/minify-execution.test.ts
@@ -239,6 +239,28 @@ fn main(@builtin(global_invocation_id) global_id: vec3u) {
   });
 });
 
+test.skipIf(!dockerTest)("minified signed exponent literals match baseline execution", async () => {
+  const modules = {
+    "/main.wgsl": `struct Out { values: array<u32, 2> }
+@group(0) @binding(0) var<storage, read_write> out: Out;
+
+@compute @workgroup_size(1)
+fn main() {
+  let decimal_positive = 1e-8 > 0.0;
+  let hex_positive = 0x1p-8 > 0.0;
+  out.values[0] = select(0u, 1u, decimal_positive);
+  out.values[1] = select(0u, 1u, hex_positive);
+}`,
+  };
+
+  await expectSameExecution({ modules, outputU32Length: 2 }, [1, 1], ({ minified }) => {
+    expect(minified).toContain("1e-8");
+    expect(minified).toContain("0x1p-8");
+    expect(minified).not.toContain("1e -8");
+    expect(minified).not.toContain("0x1p -8");
+  });
+});
+
 test.skipIf(!dockerTest)("minified override constants match baseline execution", async () => {
   const modules = {
     "/main.wgsl": `override SCALE: u32 = 1u;

--- a/packages/wgsl/tests/minify.test.ts
+++ b/packages/wgsl/tests/minify.test.ts
@@ -44,6 +44,22 @@ test("minify preserves hex-float exponent token boundaries across comments and w
   expect(minified).toBe("let hp=0x1p +3;let hn=0x1.8P -2;");
 });
 
+test("minify preserves signed decimal exponent literals", () => {
+  const source = "fn repro() -> bool { return 1e-8 > 0.0 && 1e+8 > 0.0 && 1E-8 > 0.0 && 1E+8 > 0.0 && 1.0e-8 > 0.0 && 1.0e+8 > 0.0 && 1.e-8 > 0.0; }";
+  const expected = "fn repro()-> bool{return 1e-8>0.0&&1e+8>0.0&&1E-8>0.0&&1E+8>0.0&&1.0e-8>0.0&&1.0e+8>0.0&&1.e-8>0.0;}";
+  expect(minifyWgsl(source)).toBe(expected);
+  expect(applyMinifyWgsl(source, { identifiers: "none" })).toBe(expected);
+  expect(applyMinifyWgsl(source, { identifiers: "safe" })).toBe(expected);
+});
+
+test("minify preserves signed hex exponent literals", () => {
+  const source = "fn repro() -> bool { return 0x1p-8 > 0.0 && 0x1p+8 > 0.0 && 0x1P-8 > 0.0 && 0x1P+8 > 0.0 && 0x1.8p-2 > 0.0; }";
+  const expected = "fn repro()-> bool{return 0x1p-8>0.0&&0x1p+8>0.0&&0x1P-8>0.0&&0x1P+8>0.0&&0x1.8p-2>0.0;}";
+  expect(minifyWgsl(source)).toBe(expected);
+  expect(applyMinifyWgsl(source, { identifiers: "none" })).toBe(expected);
+  expect(applyMinifyWgsl(source, { identifiers: "safe" })).toBe(expected);
+});
+
 test("minify preserves token boundaries around attributes templates and operators", () => {
   const minified = minifyWgsl("@compute /* comment */ @workgroup_size(1) fn main(){ var p: ptr<function, array<vec4<f32>, 4> >; let y = x - -z; if (a & & b) {} }");
   expect(minified).toContain("@compute @workgroup_size(1) fn main()");

--- a/packages/wgsl/tests/scanner.test.ts
+++ b/packages/wgsl/tests/scanner.test.ts
@@ -11,6 +11,16 @@ test("scanner emits comments atomically", () => {
   expect(tokens.map((token) => token.text)).toContain("color");
 });
 
+test("scanner keeps signed decimal exponents in one number token", () => {
+  expect(scan("let x = 1e-8 + 1E+8 + 1.0e-8 + 1.e+8;").filter((token) => token.kind === "number").map((token) => token.text))
+    .toEqual(["1e-8", "1E+8", "1.0e-8", "1.e+8"]);
+});
+
+test("scanner keeps signed hex exponents in one number token", () => {
+  expect(scan("let x = 0x1p-8 + 0x1p+8 + 0x1P-8 + 0x1P+8 + 0x1.8p-2;").filter((token) => token.kind === "number").map((token) => token.text))
+    .toEqual(["0x1p-8", "0x1p+8", "0x1P-8", "0x1P+8", "0x1.8p-2"]);
+});
+
 test("hasTopLevelImport skips top-level WGSL directives before imports", () => {
   expect(hasTopLevelImport("enable f16;\nrequires readonly_and_readwrite_storage_textures;\nimport { helper } from './helper.wgsl';")).toBe(true);
   expect(hasTopLevelImport("diagnostic(off, derivative_uniformity);\nimport { helper } from './helper.wgsl';")).toBe(true);

--- a/packages/wgsl/tests/transform-wgsl-callback.test.ts
+++ b/packages/wgsl/tests/transform-wgsl-callback.test.ts
@@ -4,6 +4,21 @@ import { join } from "node:path";
 import { expect, test, vi } from "vitest";
 import { transformWgsl } from "@vgpu/wgsl/loader-vite";
 
+test("transformWgsl preserves signed exponent literals when minifying leaf shaders", async () => {
+  for (const minify of [true, { identifiers: "none" as const }, { identifiers: "safe" as const }]) {
+    const result = await transformWgsl({
+      source: "fn repro() -> bool { return 1e-8 > 0.0 && 0x1p+8 > 0.0; }",
+      id: "/tmp/repro.wgsl",
+      minify,
+    });
+
+    expect(result.code).toContain("1e-8");
+    expect(result.code).toContain("0x1p+8");
+    expect(result.code).not.toContain("1e -8");
+    expect(result.code).not.toContain("0x1p +8");
+  }
+});
+
 test("transformWgsl calls onDependency for transitive shader dependencies", async () => {
   const dir = await mkdtemp(join(tmpdir(), "vgsl-"));
   const entry = join(dir, "main.wgsl");

--- a/packages/wgsl/tests/validation.test.ts
+++ b/packages/wgsl/tests/validation.test.ts
@@ -8,6 +8,14 @@ test.skipIf(!validation)("validation handles emitted fallback", async () => awai
 test("validate false skips validation", async () => await expect(resolveShader({ entry: "/a.wgsl", modules: { "/a.wgsl": "fn bad( {" }, validate: false })).resolves.toHaveProperty("wgsl"));
 test.skipIf(!validation)("approximate diagnostic tagged", async () => await expect(resolveShader({ entry: "/m.wgsl", modules: { "/m.wgsl": "import { f } from './f.wgsl'; fn main(){ let x: u32 = f(); }", "/f.wgsl": "export fn f() -> f32 { return 1.0; }" } })).rejects.toMatchObject({ code: "VGPU-WGSL-NAGA-UNKNOWN", columnPrecise: false, relatedDiagnostics: [expect.objectContaining({ code: "VGPU-WGSL-COL-APPROX" })] }));
 test.skipIf(!validation)("precise diagnostic before substitution", async () => { try { await resolveShader({ entry: "/m.wgsl", modules: { "/m.wgsl": "@compute @workgroup_size(1) fn main(){ let x: u32 = 1.0; }" } }); throw new Error("expected validation failure"); } catch (error) { expect(error).toMatchObject({ code: "VGPU-WGSL-NAGA-UNKNOWN", range: { file: "m.wgsl" }, columnPrecise: true }); expect(JSON.stringify(error)).not.toContain("VGPU-WGSL-COL-APPROX"); } });
+test.skipIf(!validation)("minified signed exponent literals validate after minifying", async () => {
+  await expect(resolveShader({
+    entry: "/m.wgsl",
+    minify: true,
+    modules: { "/m.wgsl": "@compute @workgroup_size(1) fn main(){ let a = 1e-8; let b = 1e+8; let c = 1E-8; let d = 1E+8; let e = 1.0e-8; let f = 1.0e+8; let g = 0x1p-8; let h = 0x1p+8; let i = 0x1P-8; let j = 0x1P+8; let k = 0x1.8p-2; }" },
+  })).resolves.toHaveProperty("wgsl");
+});
+
 test.skipIf(!validation)("minified resolve validates emitted shader before minifying return output", async () => {
   try {
     await resolveShader({ entry: "/m.wgsl", minify: true, modules: { "/m.wgsl": "@compute @workgroup_size(1) fn main(){ let x: u32 = 1.0; }" } });


### PR DESCRIPTION
## Summary

Fixes the WGSL minifier regression where signed exponent literals such as `1e-8` and `0x1p+8` were emitted as invalid token sequences like `1e -8`.

## Root cause

The scanner's numeric token loop accepted letters, digits, `_`, and `.`, but not the sign immediately following decimal (`e`/`E`) or hexadecimal (`p`/`P`) exponent markers. As a result, valid literals were split into `number`, `punct`, `number` tokens (`1e`, `-`, `8`). The token printer then correctly preserved the split-token boundary by adding whitespace after exponent markers, producing `1e -8` instead of the original literal.

## Fix

- Teach the WGSL scanner to keep an immediate `+`/`-` followed by a digit inside the current number token when it follows `e`, `E`, `p`, or `P`.
- Preserve existing safety for separated tokens such as `1e /* comment */ + 2`, which still minify with a separator instead of accidentally forming a literal.

## Tests

Added regression coverage for:

- scanner tokenization of signed decimal and hexadecimal exponent literals
- `minifyWgsl` and `applyMinifyWgsl` in whitespace-only and `identifiers: "safe"` modes
- `transformWgsl` loader output in minified modes
- Docker-gated validation of minified exponent literal shaders
- Docker-gated compute execution using decimal and hex exponent literals

Validation run locally:

```sh
PATH=/home/user/.local/node22/bin:$PATH pnpm --filter @vgpu/wgsl build
PATH=/home/user/.local/node22/bin:$PATH pnpm vitest run packages/wgsl/tests/scanner.test.ts packages/wgsl/tests/minify.test.ts packages/wgsl/tests/transform-wgsl-callback.test.ts --reporter=dot
PATH=/home/user/.local/node22/bin:$PATH pnpm vitest run packages/wgsl --reporter=dot
cd packages/wgsl && PATH=/home/user/.local/node22/bin:$PATH pnpm pack --pack-destination /tmp/vgpu-wgsl-pack-smoke
```

`git diff --check` passes.

Docker-gated native validation/execution was attempted but is blocked in this environment by the existing native WebGPU dependency load failure:

```text
/lib/aarch64-linux-gnu/libc.so.6: version `GLIBC_2.38' not found (required by .../node_modules/webgpu/dist/linux-arm64.dawn.node)
ReferenceError: Cannot access 'globals' before initialization
```

## Release note

`@vgpu/wgsl`: fix minification of signed decimal and hexadecimal exponent literals. A v0.0.5 patch release is recommended after merge because v0.0.4 can emit invalid WGSL for valid exponent literals.
