### PR TITLE
chore: prepare v0.0.5 release

### DIFF
--- a/packages/adapter-mock/package.json
+++ b/packages/adapter-mock/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vgpu/adapter-mock",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Mock GPU adapter for testing vgpu code without real WebGPU hardware.",
   "keywords": [
     "webgpu",

--- a/packages/adapter-node/package.json
+++ b/packages/adapter-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vgpu/adapter-node",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Node.js GPU adapter for vgpu, using Dawn-based WebGPU bindings.",
   "keywords": [
     "webgpu",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vgpu/core",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Core WebGPU runtime primitives (device, buffer, texture, shader, queue) for vgpu.",
   "keywords": [
     "webgpu",

--- a/packages/render/package.json
+++ b/packages/render/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vgpu/render",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Render pipeline + render pass abstractions for vgpu.",
   "keywords": [
     "webgpu",

--- a/packages/wgsl/package.json
+++ b/packages/wgsl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vgpu/wgsl",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "WGSL shader compilation, runtime resolution, and webpack/vite loaders for vgpu.",
   "keywords": [
     "webgpu",


### PR DESCRIPTION
## Summary

Prepare the v0.0.5 patch release after PR #74 merged into main.

Base main: `2138d8b73138f575be21c9f8555f507ebcef7457` — fix(wgsl): preserve signed exponent literals when minifying (#74)

PR #74 confirmation: origin/main is one commit ahead of v0.0.4 and contains `fix(wgsl): preserve signed exponent literals when minifying (#74)`.

## Version bump

Public packages bumped from 0.0.4 to 0.0.5:

- `@vgpu/adapter-mock`: 0.0.4 -> 0.0.5
- `@vgpu/adapter-node`: 0.0.4 -> 0.0.5
- `@vgpu/core`: 0.0.4 -> 0.0.5
- `@vgpu/render`: 0.0.4 -> 0.0.5
- `@vgpu/wgsl`: 0.0.4 -> 0.0.5

## Files changed

- `packages/adapter-mock/package.json`
- `packages/adapter-node/package.json`
- `packages/core/package.json`
- `packages/render/package.json`
- `packages/wgsl/package.json`

No code changes. The private example workspace was not included in the final diff.

## Validation

- `pnpm install --frozen-lockfile` — passed; lockfile already up to date. Note: local Node emitted existing engine warning because the shell is Node v20.20.0 while the repo requests >=22 <23.
- `pnpm build` — passed.
- `pnpm test:fast` — passed: 81 files passed, 14 skipped; 427 tests passed, 63 skipped.
- `pnpm bundle-check` — passed:
  - @vgpu/adapter-mock: 12774 B gzip / 20480 B budget
  - @vgpu/adapter-node: 16678 B gzip / 30720 B budget
  - @vgpu/core: 27084 B gzip / 51200 B budget
  - @vgpu/render: 24525 B gzip / 49152 B budget
  - @vgpu/render/inspect: 2506 B gzip / 4096 B budget
  - @vgpu/render/utils: 574 B gzip / 2048 B budget
  - @vgpu/render/edit: 12204 B gzip / 25600 B budget
  - @vgpu/render/passes: 2660 B gzip / 3584 B budget
  - @vgpu/wgsl: 688 B gzip / 25600 B budget
  - @vgpu/wgsl/runtime: 12739 B gzip / 204800 B budget
  - @vgpu/wgsl/loader-webpack: 13013 B gzip / 204800 B budget
  - @vgpu/wgsl/loader-vite: 13001 B gzip / 204800 B budget
- `git diff --check` — passed.
- `npm pack --dry-run --json` in `packages/wgsl` — passed, package id `@vgpu/wgsl@0.0.5`; confirmed key contents include README, LICENSE, package.json, `dist/loader-webpack/index.js`, `dist/loader-vite/index.js`, `dist/runtime/resolveShader.js`, and `dist/wgsl-types.d.ts`.

## Caveats

- The canonical checkout was intentionally not used because it is stale; this PR was prepared in a fresh worktree under `~/worktrees-vgpu/release-v0.0.5/` based on `origin/main`.
- `pnpm bump:patch` temporarily added `0.0.1` to the private example package; that private package change was reverted and is not part of this PR.

## After merge

Create/publish GitHub Release `v0.0.5` targeting `main` to trigger the release workflow. Do not create a tag or publish before this PR is merged.
