### PR TITLE
docs(adapter-node): document GLIBC Docker requirements

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 ## Prerequisites
 
-- Node.js 20+
+- Node.js 22 (the workspace engine is `>=22 <23`)
 - pnpm
 
 ## Making changes

--- a/packages/adapter-node/README.md
+++ b/packages/adapter-node/README.md
@@ -1,14 +1,37 @@
 # @vgpu/adapter-node
 
-> 0.0.1 — early preview
+> 0.0.5 — early preview
 
-`@vgpu/adapter-node` connects vgpu to Node.js runtimes through Dawn-based WebGPU bindings. It exposes both a reusable adapter for `App.create()` and a convenience helper that creates a `Device` directly, making it the package to use for server-side rendering, CI image generation, and serverless deployments. This package depends on `webgpu@0.4.0`, and the release target includes linux-arm64 prebuilt support.
+`@vgpu/adapter-node` connects vgpu to Node.js runtimes through the `webgpu` package's Dawn native prebuild. It exposes both a reusable adapter for `App.create()` and a convenience helper that creates a `Device` directly, making it the package to use for server-side rendering, CI image generation, and serverless deployments. This package depends on `webgpu@0.4.0`, and the release target includes linux-arm64 prebuilt support.
 
 ## Install
 
 ```bash
 pnpm add @vgpu/adapter-node
 ```
+
+## System requirements
+
+- Node.js 22+
+- Linux hosts using the Dawn prebuilt binary from `webgpu@0.4.0` must provide GLIBC 2.38 or newer.
+  This currently matters for the linux-arm64 Dawn prebuild (`webgpu/dist/linux-arm64.dawn.node`).
+- For CI, visual snapshot agents, and other reproducible Linux runs, prefer the pinned Docker environment:
+  `pnpm test:docker`. The image uses Node 22 on Debian trixie with the Xvfb and Mesa/OpenGL software stack needed by
+  Dawn.
+
+Debian 12/bookworm and similar hosts with GLIBC 2.36 can install the package but fail when the native Dawn binary is
+loaded. Use Ubuntu 24.04+, Debian trixie, another GLIBC >= 2.38 environment, or the Docker runner above.
+
+For headless or software-rendered Linux runs, the Docker environment sets these variables:
+
+```bash
+LIBGL_ALWAYS_SOFTWARE=1
+DISPLAY=:99
+XDG_RUNTIME_DIR=/tmp/xdg-runtime
+```
+
+`VGPU_DAWN_FLAGS` may be set to space-separated Dawn flags and overrides the adapter's default backend flags, for example
+`VGPU_DAWN_FLAGS=backend=opengl`.
 
 ## Exports
 
@@ -31,6 +54,19 @@ const texture = device.createTexture({
 const bytes = await texture.read();
 device.destroy();
 ```
+
+## Troubleshooting native Dawn binary loading
+
+If loading `@vgpu/adapter-node` fails with a GLIBC error like this:
+
+```text
+/lib/aarch64-linux-gnu/libc.so.6: version 'GLIBC_2.38' not found
+```
+
+then the host is older than the linux-arm64 Dawn prebuild bundled by `webgpu@0.4.0`.
+This is a native environment compatibility issue, not a shader, scene, or rendering issue.
+Re-run the job in the Docker environment with `pnpm test:docker`, or move the agent to a GLIBC 2.38+ host such as Debian trixie or Ubuntu 24.04+.
+Snapshot updates can be run with `VGPU_WRITE_SNAPSHOTS=1 pnpm test:docker`, and Docker test containers/images can be cleaned with `pnpm test:docker:cleanup`.
 
 ## License
 

--- a/packages/adapter-node/src/createNodeAdapter.docs.md
+++ b/packages/adapter-node/src/createNodeAdapter.docs.md
@@ -6,3 +6,17 @@ lets this adapter use the official Dawn prebuilt binary. On Linux the adapter us
 the OpenGL software backend by default (`backend=opengl` plus Dawn compatibility
 feature level) and keeps a process-wide singleton GPU instance; conflicting later
 flags are warned and ignored because Dawn re-init can SIGSEGV.
+
+On Linux, the `webgpu@0.4.0` Dawn linux-arm64 prebuild may require GLIBC 2.38+
+when the native binary is loaded. Debian 12/bookworm (GLIBC 2.36) and similar
+hosts can fail with `/lib/aarch64-linux-gnu/libc.so.6: version 'GLIBC_2.38' not
+found`. This is a native environment compatibility issue, not a shader or
+rendering issue. Use the pinned Docker test environment (`pnpm test:docker`) or
+another Node 22 host based on Debian trixie, Ubuntu 24.04+, or equivalent GLIBC
+2.38+ runtime.
+
+For headless/software rendering, match the Docker environment variables
+`LIBGL_ALWAYS_SOFTWARE=1`, `DISPLAY=:99`, and
+`XDG_RUNTIME_DIR=/tmp/xdg-runtime`. `VGPU_DAWN_FLAGS` may be set to
+space-separated Dawn flags, such as `VGPU_DAWN_FLAGS=backend=opengl`, and
+replaces the adapter's default backend flag selection.

--- a/packages/adapter-node/tests/glibc-error.test.ts
+++ b/packages/adapter-node/tests/glibc-error.test.ts
@@ -3,8 +3,12 @@ import { formatBinaryLoadError } from "../src/index";
 
 describe("formatBinaryLoadError", () => {
   test("reports glibc workaround for older linux hosts", () => {
-    const error = formatBinaryLoadError(new Error("libc.so.6: version `GLIBC_2.38' not found"), "2.36");
+    const error = formatBinaryLoadError(new Error("libc.so.6: version `GLIBC_2.38' not found"), {
+      detectedGlibcVersion: "2.36",
+    });
+    expect(error.code).toBe("VGPU-ADAPTER-NODE-BINARY-LOAD");
     expect(error.message).toContain("requires GLIBC 2.38 or newer");
+    expect(error.message).toContain("This host reports GLIBC 2.36");
     expect(error.fix).toContain("pnpm test:docker");
     expect(String(error.cause)).toContain("GLIBC_2.38");
   });


### PR DESCRIPTION
## Root cause

On Debian 12/aarch64 hosts with GLIBC 2.36, `@vgpu/adapter-node` can fail while loading the `webgpu@0.4.0` Dawn native prebuild (`webgpu/dist/linux-arm64.dawn.node`) with:

```text
/lib/aarch64-linux-gnu/libc.so.6: version 'GLIBC_2.38' not found
```

The current linux-arm64 Dawn prebuild may require GLIBC 2.38+. This is a native environment compatibility issue, not a shader/rendering issue. A newer-glibc environment such as Debian trixie or Ubuntu 24.04+ is the intended workaround; the VGPU Docker test image uses Node 22 on Debian trixie.

## Summary

- Updated `@vgpu/adapter-node` README from the stale version banner and documented that it uses the `webgpu` Dawn native prebuild.
- Added system requirements/troubleshooting for GLIBC 2.38+, the known `GLIBC_2.38 not found` failure, `pnpm test:docker`, `pnpm test:docker:cleanup`, and `VGPU_WRITE_SNAPSHOTS=1 pnpm test:docker`.
- Documented verified headless/software environment variables: `LIBGL_ALWAYS_SOFTWARE=1`, `DISPLAY=:99`, `XDG_RUNTIME_DIR=/tmp/xdg-runtime`, plus `VGPU_DAWN_FLAGS` as space-separated Dawn flags (for example `VGPU_DAWN_FLAGS=backend=opengl`).
- Added the same concise GLIBC/Docker guidance to `createNodeAdapter` docs.
- Fixed the GLIBC binary-load unit test to call `formatBinaryLoadError()` with `{ detectedGlibcVersion: "2.36" }` and assert the reported version/code.
- Updated contributing prerequisites from Node 20+ to Node 22 (`>=22 <23`) to match the workspace engine.

This is docs/test/runtime guidance only. No runtime logic changes, Dawn rebuilds, or native packaging changes are included.

## Validation

- `PATH=/home/user/.local/node22/bin:$PATH node -v` → `v22.12.0`
- `PATH=/home/user/.local/node22/bin:$PATH pnpm typecheck`
- `PATH=/home/user/.local/node22/bin:$PATH pnpm test:fast`
- `PATH=/home/user/.local/node22/bin:$PATH pnpm exec vitest run packages/adapter-node/tests/glibc-error.test.ts`
- `git diff --check`
- `pnpm test:docker` (Docker image build ran `pnpm typecheck` and full `pnpm test`: 96 passed, 1 skipped)

## Caveats

- The Docker run emits Dawn limit warnings during render tests; tests pass.
- No release is required for these docs/test changes unless maintainers want the README/test updates included in a package patch.
