### PR TITLE
chore: add vgpu placeholder package

### DIFF
--- a/packages/vgpu/LICENSE
+++ b/packages/vgpu/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Vercel, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/vgpu/README.md
+++ b/packages/vgpu/README.md
@@ -1,0 +1,51 @@
+# vgpu
+
+Official VGPU CLI placeholder.
+
+This package reserves the unscoped `vgpu` npm package name for the official VGPU CLI. It is intentionally small today and does not provide runtime APIs.
+
+## Use the runtime packages
+
+Use the published `@vgpu/*` packages directly for runtime functionality:
+
+- `@vgpu/core`
+- `@vgpu/render`
+- `@vgpu/wgsl`
+- adapters such as `@vgpu/adapter-mock` and `@vgpu/adapter-node`
+
+For example:
+
+```bash
+pnpm add @vgpu/core @vgpu/render @vgpu/wgsl
+```
+
+## CLI behavior
+
+A tiny `vgpu` binary is included so `npx vgpu` and `npx vgpu --help` show the official placeholder message instead of failing.
+
+```bash
+npx vgpu
+npx vgpu --help
+npx vgpu --version
+```
+
+Exit codes:
+
+- `vgpu`, `vgpu --help`, and `vgpu -h` print help to stdout and exit `0`.
+- `vgpu --version` and `vgpu -v` print `0.0.5` to stdout and exit `0`.
+- `vgpu docs`, `vgpu doctor`, and `vgpu wgsl` print a coming-soon message to stderr and exit `1`.
+- Unknown commands print an error plus help to stderr and exit `1`.
+
+## Planned CLI surface
+
+Future versions may expose commands such as:
+
+- `vgpu docs`
+- `vgpu doctor`
+- WGSL utilities
+
+These commands are not implemented yet. For now, install and use the `@vgpu/*` packages directly.
+
+## License
+
+MIT.

--- a/packages/vgpu/bin/vgpu.js
+++ b/packages/vgpu/bin/vgpu.js
@@ -1,0 +1,49 @@
+#!/usr/bin/env node
+
+const VERSION = "0.0.5";
+
+const help = `vgpu ${VERSION}
+
+Official VGPU CLI placeholder.
+
+The VGPU runtime libraries are available today under @vgpu/*:
+  - @vgpu/core
+  - @vgpu/render
+  - @vgpu/wgsl
+  - @vgpu/adapter-mock
+  - @vgpu/adapter-node
+
+Future CLI commands may include:
+  - vgpu docs
+  - vgpu doctor
+  - WGSL utilities
+
+For now, install and use the @vgpu/* packages directly.
+`;
+
+const comingSoon = (command) => `vgpu ${command} is coming soon.
+
+This package currently reserves the official VGPU CLI name. For now, use the @vgpu/* runtime libraries directly.
+Run \`vgpu --help\` for details.
+`;
+
+const args = process.argv.slice(2);
+const command = args[0];
+
+if (command === undefined || command === "--help" || command === "-h") {
+  process.stdout.write(help);
+  process.exit(0);
+}
+
+if (command === "--version" || command === "-v") {
+  process.stdout.write(`${VERSION}\n`);
+  process.exit(0);
+}
+
+if (command === "docs" || command === "doctor" || command === "wgsl") {
+  process.stderr.write(comingSoon(command));
+  process.exit(1);
+}
+
+process.stderr.write(`Unknown vgpu command: ${command}\n\n${help}`);
+process.exit(1);

--- a/packages/vgpu/package.json
+++ b/packages/vgpu/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "vgpu",
+  "version": "0.0.5",
+  "description": "Official VGPU CLI placeholder for future docs, doctor, and WGSL utilities.",
+  "keywords": [
+    "webgpu",
+    "graphics",
+    "rendering",
+    "cli",
+    "wgsl",
+    "vgpu"
+  ],
+  "homepage": "https://github.com/vercel-labs/vgpu#readme",
+  "bugs": {
+    "url": "https://github.com/vercel-labs/vgpu/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/vercel-labs/vgpu.git",
+    "directory": "packages/vgpu"
+  },
+  "license": "MIT",
+  "author": "Matias Gonzalez <matiasngf@hotmail.com>",
+  "private": false,
+  "publishConfig": {
+    "access": "public"
+  },
+  "type": "module",
+  "bin": {
+    "vgpu": "./bin/vgpu.js"
+  },
+  "files": [
+    "bin",
+    "README.md",
+    "LICENSE"
+  ]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -85,6 +85,8 @@ importers:
         specifier: ^3.4.2
         version: 3.4.2
 
+  packages/vgpu: {}
+
   packages/wgsl:
     devDependencies:
       vite:


### PR DESCRIPTION
## Summary

- Add a new publishable workspace package at `packages/vgpu` with npm name `vgpu` and version `0.0.5`.
- Include a tiny official placeholder `vgpu` bin so `npx vgpu` / `npx vgpu --help` show an honest official message.
- Document that runtime libraries live under `@vgpu/*` today and future CLI commands may include `vgpu docs`, `vgpu doctor`, and WGSL utilities.

## CLI behavior

- `vgpu`, `vgpu --help`, `vgpu -h`: print placeholder help to stdout, exit `0`.
- `vgpu --version`, `vgpu -v`: print `0.0.5` to stdout, exit `0`.
- `vgpu docs`, `vgpu doctor`, `vgpu wgsl`: print coming-soon message to stderr, exit `1`.
- Unknown commands: print an error plus help to stderr, exit `1`.

## Validation

- `pnpm install --frozen-lockfile`
  - Passed. Note: local shell uses Node `v20.20.0`, so pnpm emitted the repo engine warning: wanted Node `>=22 <23`.
- `pnpm typecheck`
  - Passed. Same local Node engine warning as above.
- Local bin smoke:
  - `node packages/vgpu/bin/vgpu.js --help` -> exit `0`.
  - `node packages/vgpu/bin/vgpu.js` -> exit `0`.
  - `node packages/vgpu/bin/vgpu.js docs` -> exit `1` with coming-soon stderr.
  - `node packages/vgpu/bin/vgpu.js --version` -> exit `0`, prints `0.0.5`.
- `cd packages/vgpu && npm pack --dry-run --json`
  - Passed. Confirmed package `vgpu@0.0.5` with only `LICENSE`, `README.md`, `bin/vgpu.js`, and `package.json`.
- `pnpm test:fast`
  - Passed: 81 files passed, 14 skipped; 427 tests passed, 63 skipped. Same local Node engine warning as above.
- `git diff --check`
  - Passed.

## Publishing note

After merge, this should use the normal release workflow. The package is included in the existing `packages/*` workspace and has no build step, so the current recursive publish workflow should include it once a release tag is published.
