### PR TITLE
feat(core): add explicit binding helpers

### DIFF
--- a/docs/allowlist.txt
+++ b/docs/allowlist.txt
@@ -16,6 +16,16 @@
 @vgpu/core VGPUError packages/core/src/VGPUError.docs.md
 @vgpu/core ValidationError packages/core/src/VGPUError.docs.md
 @vgpu/core VGPUAdapter packages/core/src/VGPUAdapter.docs.md
+@vgpu/core bind packages/core/src/bind.docs.md
+@vgpu/core createBindGroupLayout packages/core/src/bind.docs.md
+@vgpu/core createPipelineLayout packages/core/src/bind.docs.md
+@vgpu/core createBindGroup packages/core/src/bind.docs.md
+@vgpu/core createSampler packages/core/src/bind.docs.md
+@vgpu/core BindVisibility packages/core/src/bind.docs.md
+@vgpu/core CreateBindGroupLayoutOptions packages/core/src/bind.docs.md
+@vgpu/core CreatePipelineLayoutOptions packages/core/src/bind.docs.md
+@vgpu/core CreateBindGroupOptions packages/core/src/bind.docs.md
+@vgpu/core DeviceLike packages/core/src/bind.docs.md
 @vgpu/core createMockGPUDevice packages/core/src/createMockGPUDevice.docs.md
 @vgpu/adapter-mock createMockAdapter packages/adapter-mock/src/createMockAdapter.docs.md
 @vgpu/adapter-node createNodeAdapter packages/adapter-node/src/createNodeAdapter.docs.md

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -23,6 +23,11 @@ pnpm add @vgpu/core
 - `ValidationError`
 
 ### Functions
+- `bind`
+- `createBindGroupLayout`
+- `createPipelineLayout`
+- `createBindGroup`
+- `createSampler`
 - `createMockGPUDevice`
 
 ### Types
@@ -35,6 +40,11 @@ pnpm add @vgpu/core
 - `TextureOptions`
 - `TextureUsageName`
 - `CreateDeviceOptions`
+- `BindVisibility`
+- `CreateBindGroupLayoutOptions`
+- `CreatePipelineLayoutOptions`
+- `CreateBindGroupOptions`
+- `DeviceLike`
 - `ShaderInput`
 
 ## Usage
@@ -54,6 +64,21 @@ buffer.write(data);
 const copy = new Float32Array(await buffer.read(data.byteLength));
 device.destroy();
 ```
+
+Explicit binding helpers keep layout control in user code without WGSL reflection or
+`layout: "auto"`:
+
+```ts
+import { bind, createBindGroupLayout } from "@vgpu/core";
+
+const sceneLayout = createBindGroupLayout(device, {
+  entries: [bind.uniform(0, "vertex|fragment")],
+});
+```
+
+The `.gpu` property is an unmanaged raw WebGPU escape hatch for APIs that VGPU
+does not wrap yet. Prefer wrapper lifecycle methods (`buffer.destroy()`,
+`texture.destroy()`, `device.destroy()`) instead of destroying `.gpu` directly.
 
 ## License
 

--- a/packages/core/src/bind.docs.md
+++ b/packages/core/src/bind.docs.md
@@ -1,0 +1,79 @@
+# Explicit binding helpers
+
+`bind`, `createBindGroupLayout`, `createPipelineLayout`, `createBindGroup`, and
+`createSampler` are thin core helpers for explicit WebGPU resource binding. They
+return raw WebGPU objects and never infer layouts from WGSL, reflect shaders, or
+force `layout: "auto"`.
+
+Use explicit numeric bindings to keep control over shader ABI, pipeline layout
+compatibility, and performance-sensitive bind group reuse. This implementation is
+positional/array-only; named binding maps are intentionally deferred in this
+slice, so there is no `bind.named()` helper and every entry keeps an explicit
+numeric `binding`.
+
+Sampler creation is also intentionally explicit. This slice does not add sampler
+presets such as `linear-clamp`; pass the full descriptor you want to
+`createSampler(...)` (or `device.createSampler(...)`) instead.
+
+## Native WebGPU
+
+```ts
+const sampler = device.createSampler({ minFilter: "linear", magFilter: "linear" });
+const sceneLayout = device.createBindGroupLayout({
+  label: "scene.bindings",
+  entries: [
+    { binding: 0, visibility: GPUShaderStage.VERTEX | GPUShaderStage.FRAGMENT, buffer: { type: "uniform" } },
+    { binding: 1, visibility: GPUShaderStage.FRAGMENT, texture: { sampleType: "float" } },
+    { binding: 2, visibility: GPUShaderStage.FRAGMENT, sampler: { type: "filtering" } },
+  ],
+});
+const pipelineLayout = device.createPipelineLayout({ bindGroupLayouts: [sceneLayout] });
+const bindGroup = device.createBindGroup({
+  layout: sceneLayout,
+  entries: [
+    { binding: 0, resource: { buffer: uniformBuffer } },
+    { binding: 1, resource: sourceTexture.createView() },
+    { binding: 2, resource: sampler },
+  ],
+});
+```
+
+## VGPU helpers
+
+```ts
+import { bind, createBindGroup, createBindGroupLayout, createPipelineLayout, createSampler } from "@vgpu/core";
+
+const sampler = createSampler(device, { minFilter: "linear", magFilter: "linear" });
+const sceneLayout = createBindGroupLayout(device, {
+  label: "scene.bindings",
+  entries: [
+    bind.uniform(0, "vertex|fragment"),
+    bind.texture(1, "fragment", { sampleType: "float" }),
+    bind.sampler(2, "fragment", { type: "filtering" }),
+  ],
+});
+const pipelineLayout = createPipelineLayout(device, { bindGroups: [sceneLayout] });
+const bindGroup = createBindGroup(device, {
+  layout: sceneLayout,
+  entries: [
+    bind.resource(0, uniformBuffer),
+    bind.resource(1, sourceTexture),
+    bind.resource(2, sampler),
+  ],
+});
+```
+
+`createBindGroup` requires an explicit `layout`. This helper is intentionally not
+render-specific and imports only `@vgpu/core` primitives.
+
+`bind.resource(...)` unwraps VGPU `Buffer` to `{ buffer: buffer.gpu }`, VGPU
+`Texture` to `texture.createView()`, accepts raw `GPUBuffer`, `GPUTextureView`,
+`GPUSampler`, and passes through raw `GPUBindingResource` values.
+
+## `.gpu` escape hatch and lifecycle
+
+`.gpu` exposes the unmanaged raw WebGPU object for APIs VGPU does not wrap yet,
+feature probes, and advanced or niche calls. Prefer wrapper lifecycle methods:
+`texture.destroy()`, `buffer.destroy()`, and `device.destroy()`. Avoid calling
+`texture.gpu.destroy()` or `buffer.gpu.destroy()` directly because wrappers keep
+lifecycle state and test mocks in sync.

--- a/packages/core/src/bind.ts
+++ b/packages/core/src/bind.ts
@@ -1,0 +1,144 @@
+import { Buffer } from "./buffer.ts";
+import { Device } from "./device.ts";
+import { ValidationError } from "./errors.ts";
+import { Texture } from "./texture.ts";
+
+export type BindVisibility = GPUShaderStageFlags | string | readonly ("vertex" | "fragment" | "compute")[];
+export type DeviceLike = GPUDevice | Device | { readonly gpu: GPUDevice };
+
+export interface CreateBindGroupLayoutOptions {
+  readonly label?: string;
+  readonly entries: readonly GPUBindGroupLayoutEntry[];
+}
+
+export interface CreatePipelineLayoutOptions {
+  readonly label?: string;
+  readonly bindGroups: readonly GPUBindGroupLayout[];
+}
+
+export interface CreateBindGroupOptions {
+  readonly label?: string;
+  readonly layout: GPUBindGroupLayout;
+  readonly entries: readonly GPUBindGroupEntry[];
+}
+
+export function createBindGroupLayout(device: DeviceLike, opts: CreateBindGroupLayoutOptions): GPUBindGroupLayout {
+  return unwrapDevice(device).createBindGroupLayout({ label: opts.label, entries: [...opts.entries] });
+}
+
+export function createPipelineLayout(device: DeviceLike, opts: CreatePipelineLayoutOptions): GPUPipelineLayout {
+  return unwrapDevice(device).createPipelineLayout({ label: opts.label, bindGroupLayouts: [...opts.bindGroups] });
+}
+
+export function createBindGroup(device: DeviceLike, opts: CreateBindGroupOptions): GPUBindGroup {
+  if (!opts.layout) {
+    throw new ValidationError({
+      code: "VGPU-CORE-BIND-GROUP-LAYOUT-REQUIRED",
+      message: "createBindGroup requires an explicit layout. vgpu does not use layout: \"auto\" for bind groups.",
+      where: "createBindGroup",
+    });
+  }
+  return unwrapDevice(device).createBindGroup({ label: opts.label, layout: opts.layout, entries: [...opts.entries] });
+}
+
+export function createSampler(device: DeviceLike, descriptor: GPUSamplerDescriptor = {}): GPUSampler {
+  return unwrapDevice(device).createSampler(descriptor);
+}
+
+export const bind = {
+  uniform,
+  storage,
+  readonlyStorage,
+  texture,
+  storageTexture,
+  sampler,
+  resource,
+} as const;
+
+function uniform(binding: number, visibility: BindVisibility, opts: Omit<GPUBufferBindingLayout, "type"> = {}): GPUBindGroupLayoutEntry {
+  return { binding: explicitBinding(binding), visibility: visibilityFlags(visibility), buffer: { ...opts, type: "uniform" } };
+}
+
+function storage(binding: number, visibility: BindVisibility, opts: Omit<GPUBufferBindingLayout, "type"> = {}): GPUBindGroupLayoutEntry {
+  return { binding: explicitBinding(binding), visibility: visibilityFlags(visibility), buffer: { ...opts, type: "storage" } };
+}
+
+function readonlyStorage(binding: number, visibility: BindVisibility, opts: Omit<GPUBufferBindingLayout, "type"> = {}): GPUBindGroupLayoutEntry {
+  return { binding: explicitBinding(binding), visibility: visibilityFlags(visibility), buffer: { ...opts, type: "read-only-storage" } };
+}
+
+function texture(binding: number, visibility: BindVisibility, opts: GPUTextureBindingLayout = {}): GPUBindGroupLayoutEntry {
+  return { binding: explicitBinding(binding), visibility: visibilityFlags(visibility), texture: opts };
+}
+
+function storageTexture(binding: number, visibility: BindVisibility, opts: GPUStorageTextureBindingLayout): GPUBindGroupLayoutEntry {
+  return { binding: explicitBinding(binding), visibility: visibilityFlags(visibility), storageTexture: opts };
+}
+
+function sampler(binding: number, visibility: BindVisibility, opts: GPUSamplerBindingLayout = {}): GPUBindGroupLayoutEntry {
+  return { binding: explicitBinding(binding), visibility: visibilityFlags(visibility), sampler: opts };
+}
+
+function resource(binding: number, value: unknown): GPUBindGroupEntry {
+  return { binding: explicitBinding(binding), resource: unwrapBindingResource(value) };
+}
+
+function unwrapDevice(device: DeviceLike): GPUDevice {
+  return device instanceof Device ? device.gpu : "gpu" in device ? device.gpu : device;
+}
+
+function unwrapBindingResource(value: unknown): GPUBindingResource {
+  if (value instanceof Buffer) return { buffer: value.gpu };
+  if (value instanceof Texture) return value.createView();
+  if (isVGPUTextureLike(value)) return value.createView();
+  if (isGPUBufferBinding(value)) return value as GPUBufferBinding;
+  if (isVGPUBufferLike(value)) return { buffer: value.gpu };
+  if (isRawGPUBuffer(value)) return { buffer: value as GPUBuffer };
+  return value as GPUBindingResource;
+}
+
+function isGPUBufferBinding(value: unknown): value is GPUBufferBinding {
+  return isObject(value) && "buffer" in value;
+}
+
+function isRawGPUBuffer(value: unknown): value is GPUBuffer {
+  return isObject(value) && "size" in value && "usage" in value && typeof value.destroy === "function";
+}
+
+function isVGPUBufferLike(value: unknown): value is { readonly gpu: GPUBuffer } {
+  return isObject(value) && isRawGPUBuffer(value.gpu);
+}
+
+function isVGPUTextureLike(value: unknown): value is { createView(desc?: GPUTextureViewDescriptor): GPUTextureView } {
+  return isObject(value) && typeof value.createView === "function" && "gpu" in value;
+}
+
+function explicitBinding(binding: number): number {
+  if (!Number.isInteger(binding) || binding < 0) {
+    throw new ValidationError({
+      code: "VGPU-CORE-BINDING-INVALID",
+      message: "Binding entries require an explicit non-negative integer binding number.",
+      where: "bind",
+    });
+  }
+  return binding;
+}
+
+function visibilityFlags(visibility: BindVisibility): GPUShaderStageFlags {
+  if (typeof visibility === "number") return visibility;
+  const names = typeof visibility === "string" ? visibility.split(/[|,\s]+/) : visibility;
+  return names.reduce((flags, name) => flags | shaderStageFlag(name), 0) as GPUShaderStageFlags;
+}
+
+function shaderStageFlag(name: string): number {
+  const key = name.trim().toLowerCase();
+  const constants = globalThis.GPUShaderStage as unknown as Record<string, number> | undefined;
+  const flags: Record<string, number> = { vertex: constants?.VERTEX ?? 1, fragment: constants?.FRAGMENT ?? 2, compute: constants?.COMPUTE ?? 4 };
+  const flag = flags[key];
+  if (!flag) throw new ValidationError({ code: "VGPU-CORE-VISIBILITY-INVALID", message: `Unknown shader stage visibility '${name}'.`, where: "bind" });
+  return flag;
+}
+
+function isObject(value: unknown): value is Record<PropertyKey, unknown> {
+  return typeof value === "object" && value !== null;
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -5,6 +5,7 @@ export { Queue } from "./queue.ts";
 export { Shader } from "./shader.ts";
 export { Texture } from "./texture.ts";
 export { VGPUError, ValidationError } from "./errors.ts";
+export { bind, createBindGroup, createBindGroupLayout, createPipelineLayout, createSampler } from "./bind.ts";
 export { createMockGPUDevice } from "./mockGpu.ts";
 export type { AppCreateOptions, AppInstance, VGPUAdapter } from "./app-types.ts";
 export type {
@@ -15,4 +16,5 @@ export type {
   TextureUsageName,
   CreateDeviceOptions,
 } from "./types.ts";
+export type { BindVisibility, CreateBindGroupLayoutOptions, CreateBindGroupOptions, CreatePipelineLayoutOptions, DeviceLike } from "./bind.ts";
 export type { ShaderInput } from "./shader.ts";

--- a/packages/core/tests/bind.test.ts
+++ b/packages/core/tests/bind.test.ts
@@ -1,0 +1,130 @@
+import { expect, test } from "vitest";
+import { Buffer } from "../src/buffer.ts";
+import {
+  bind,
+  createBindGroup,
+  createBindGroupLayout,
+  createPipelineLayout,
+  createSampler,
+} from "../src/bind.ts";
+import { Device } from "../src/device.ts";
+import { ValidationError } from "../src/errors.ts";
+import { Texture } from "../src/texture.ts";
+
+function createCaptureDevice() {
+  const calls: Record<string, unknown> = {};
+  const gpu = {
+    createBindGroupLayout(desc: GPUBindGroupLayoutDescriptor) {
+      calls.bindGroupLayout = desc;
+      return { label: desc.label } as GPUBindGroupLayout;
+    },
+    createPipelineLayout(desc: GPUPipelineLayoutDescriptor) {
+      calls.pipelineLayout = desc;
+      return { label: desc.label } as GPUPipelineLayout;
+    },
+    createBindGroup(desc: GPUBindGroupDescriptor) {
+      calls.bindGroup = desc;
+      return { label: desc.label } as GPUBindGroup;
+    },
+    createSampler(desc: GPUSamplerDescriptor) {
+      calls.sampler = desc;
+      return { label: desc.label } as GPUSampler;
+    },
+  } as GPUDevice;
+  return { gpu, calls };
+}
+
+test("creates explicit bind group layout descriptors", () => {
+  const { gpu, calls } = createCaptureDevice();
+
+  const layout = createBindGroupLayout(gpu, {
+    label: "scene.bindings",
+    entries: [
+      bind.uniform(0, "vertex|fragment"),
+      bind.texture(1, "fragment", { sampleType: "float" }),
+      bind.sampler(2, "fragment", { type: "filtering" }),
+    ],
+  });
+
+  expect(layout).toEqual({ label: "scene.bindings" });
+  expect(calls.bindGroupLayout).toEqual({
+    label: "scene.bindings",
+    entries: [
+      { binding: 0, visibility: 3, buffer: { type: "uniform" } },
+      { binding: 1, visibility: 2, texture: { sampleType: "float" } },
+      { binding: 2, visibility: 2, sampler: { type: "filtering" } },
+    ],
+  });
+});
+
+test("creates explicit pipeline layout and sampler descriptors", () => {
+  const { gpu, calls } = createCaptureDevice();
+  const groupLayout = {} as GPUBindGroupLayout;
+
+  createPipelineLayout({ gpu }, { label: "pipeline", bindGroups: [groupLayout] });
+  createSampler(gpu, { label: "linear", magFilter: "linear", minFilter: "linear" });
+
+  expect(calls.pipelineLayout).toEqual({ label: "pipeline", bindGroupLayouts: [groupLayout] });
+  expect(calls.sampler).toEqual({ label: "linear", magFilter: "linear", minFilter: "linear" });
+});
+
+test("creates bind groups only when an explicit layout is provided", () => {
+  const { gpu, calls } = createCaptureDevice();
+  const layout = {} as GPUBindGroupLayout;
+  const rawResource = { textureViewBrand: true } as unknown as GPUTextureView;
+
+  createBindGroup(gpu, { label: "scene", layout, entries: [bind.resource(0, rawResource)] });
+
+  expect(calls.bindGroup).toEqual({ label: "scene", layout, entries: [{ binding: 0, resource: rawResource }] });
+  expect(() => createBindGroup(gpu, { label: "bad", layout: undefined as unknown as GPUBindGroupLayout, entries: [] })).toThrow(ValidationError);
+});
+
+test("unwraps vgpu and raw binding resources", () => {
+  const rawBuffer = { size: 16, usage: 64, destroy() {} } as unknown as GPUBuffer;
+  const vgpuBuffer = new Buffer({} as Device, rawBuffer, { size: 16, usage: ["uniform"] });
+  const view = { view: true } as unknown as GPUTextureView;
+  const rawTexture = { createView: () => view, destroy() {} } as unknown as GPUTexture;
+  const vgpuTexture = new Texture({} as Device, rawTexture, { size: [1, 1], format: "rgba8unorm", usage: ["texture_binding"] });
+  const rawBinding = { buffer: rawBuffer, offset: 4 } as GPUBufferBinding;
+  const sampler = { sampler: true } as unknown as GPUSampler;
+
+  expect(bind.resource(0, vgpuBuffer).resource).toEqual({ buffer: rawBuffer });
+  expect(bind.resource(1, rawBuffer).resource).toEqual({ buffer: rawBuffer });
+  expect(bind.resource(2, vgpuTexture).resource).toBe(view);
+  expect(bind.resource(3, view).resource).toBe(view);
+  expect(bind.resource(4, sampler).resource).toBe(sampler);
+  expect(bind.resource(5, rawBinding).resource).toBe(rawBinding);
+});
+
+test("parses shader stage visibility in headless runtimes", () => {
+  expect(bind.uniform(0, "vertex|fragment").visibility).toBe(3);
+  expect(bind.uniform(1, "compute").visibility).toBe(4);
+  expect(bind.uniform(2, ["vertex", "compute"]).visibility).toBe(5);
+  expect(bind.uniform(3, 1 | 2).visibility).toBe(3);
+});
+
+test("creates storage binding descriptors", () => {
+  expect(bind.storage(0, "compute")).toEqual({
+    binding: 0,
+    visibility: 4,
+    buffer: { type: "storage" },
+  });
+  expect(bind.readonlyStorage(1, "fragment")).toEqual({
+    binding: 1,
+    visibility: 2,
+    buffer: { type: "read-only-storage" },
+  });
+});
+
+test("creates storage texture binding descriptors", () => {
+  expect(bind.storageTexture(2, "compute", { access: "write-only", format: "rgba8unorm" })).toEqual({
+    binding: 2,
+    visibility: 4,
+    storageTexture: { access: "write-only", format: "rgba8unorm" },
+  });
+});
+
+test("requires explicit numeric bindings", () => {
+  expect(() => bind.uniform(-1, "vertex")).toThrow(ValidationError);
+  expect(() => bind.resource(1.5, {})).toThrow(ValidationError);
+});


### PR DESCRIPTION
## Summary

Closes #82. This is the core explicit binding/layout helper slice under parent #81.

Scope is intentionally #82-only: this does **not** implement #83 render frame/bundle/encoder batching helpers.

## Native WebGPU before

```ts
const sampler = device.createSampler({
  magFilter: "linear",
  minFilter: "linear",
  addressModeU: "clamp-to-edge",
  addressModeV: "clamp-to-edge",
});
const sceneLayout = device.createBindGroupLayout({
  label: "scene.bindings",
  entries: [
    { binding: 0, visibility: GPUShaderStage.VERTEX | GPUShaderStage.FRAGMENT, buffer: { type: "uniform" } },
    { binding: 1, visibility: GPUShaderStage.FRAGMENT, texture: { sampleType: "float" } },
    { binding: 2, visibility: GPUShaderStage.FRAGMENT, sampler: { type: "filtering" } },
  ],
});
const pipelineLayout = device.createPipelineLayout({
  label: "scene.pipelineLayout",
  bindGroupLayouts: [sceneLayout],
});
const bindGroup = device.createBindGroup({
  label: "scene.bindGroup",
  layout: sceneLayout,
  entries: [
    { binding: 0, resource: { buffer: uniform.gpu } },
    { binding: 1, resource: sourceTexture.createView() },
    { binding: 2, resource: sampler },
  ],
});
```

## VGPU helper after

```ts
import { bind, createBindGroup, createBindGroupLayout, createPipelineLayout, createSampler } from "@vgpu/core";

const sampler = createSampler(device, {
  magFilter: "linear",
  minFilter: "linear",
  addressModeU: "clamp-to-edge",
  addressModeV: "clamp-to-edge",
});
const sceneLayout = createBindGroupLayout(device, {
  label: "scene.bindings",
  entries: [
    bind.uniform(0, "vertex|fragment"),
    bind.texture(1, "fragment", { sampleType: "float" }),
    bind.sampler(2, "fragment", { type: "filtering" }),
  ],
});
const pipelineLayout = createPipelineLayout(device, {
  label: "scene.pipelineLayout",
  bindGroups: [sceneLayout],
});
const bindGroup = createBindGroup(device, {
  label: "scene.bindGroup",
  layout: sceneLayout,
  entries: [
    bind.resource(0, uniform),
    bind.resource(1, sourceTexture),
    bind.resource(2, sampler),
  ],
});
```

## Explicit layout and performance-control guarantees

- `createBindGroup` requires an explicit `layout` and throws a structured `ValidationError` when it is missing.
- Every helper keeps explicit numeric `binding` values; this preserves shader ABI control, pipeline layout compatibility, and performance-sensitive bind group reuse.
- There is no hidden layout auto-generation, WGSL reflection, or `layout: "auto"` inference/forcing.
- The helper API is positional/array-only in this slice; named binding maps are deferred and there is no `bind.named()` helper.
- Sampler creation remains descriptor-explicit; this slice does not add sampler presets such as `linear-clamp`.
- Raw `.gpu` access remains available as the escape hatch for unmanaged WebGPU APIs, feature probes, and advanced/niche calls.

## `.gpu` lifecycle docs summary

`.gpu` is still the raw WebGPU escape hatch, but wrapper lifecycle APIs should be preferred so wrapper state and mocks stay synchronized:

- Prefer `texture.destroy()`, `buffer.destroy()`, and `device.destroy()`.
- Avoid direct `texture.gpu.destroy()` / `buffer.gpu.destroy()` calls unless intentionally bypassing VGPU lifecycle management.

## Exact API implemented

- `createBindGroupLayout(device, { label?, entries })`
- `createPipelineLayout(device, { label?, bindGroups })`
- `createBindGroup(device, { label?, layout, entries })`
- `createSampler(device, descriptor?)`
- `bind.uniform(binding, visibility, opts?)`
- `bind.storage(binding, visibility, opts?)`
- `bind.readonlyStorage(binding, visibility, opts?)`
- `bind.texture(binding, visibility, opts?)`
- `bind.storageTexture(binding, visibility, opts)`
- `bind.sampler(binding, visibility, opts?)`
- `bind.resource(binding, value)`

## Docs/tests

Docs:
- Added `packages/core/src/bind.docs.md` with native WebGPU vs VGPU helper examples, explicit binding/layout notes, no `bind.named()` note, no sampler preset note, and `.gpu` lifecycle guidance.
- Updated `packages/core/README.md` exports and usage notes.
- Updated `docs/allowlist.txt` for new public symbols.

Tests:
- Added `packages/core/tests/bind.test.ts` covering descriptor equivalence, explicit layout requirement, resource unwrapping/raw pass-through, visibility parsing in headless/mock runtimes, numeric visibility values, storage buffers, read-only storage buffers, storage textures, and explicit numeric binding validation.

## Validation

Required validation record:

- `git diff --check` PASS
- `pnpm vitest run packages/core` PASS (2 files / 8 tests)
- `pnpm typecheck` PASS
- `pnpm test:fast` PASS (80 passed / 13 skipped test files; 384 passed / 55 skipped tests)

Post-review local rerun after the docs/tests additions also passed in this sandbox:

- `git diff --check` PASS
- `pnpm vitest run packages/core` PASS (2 files / 10 tests)
- `pnpm typecheck` PASS
- `pnpm test:fast` PASS (80 passed / 13 skipped test files; 386 passed / 55 skipped tests)

Note: pnpm emitted the sandbox engine warning because the runtime is Node `v20.20.0` while the repo requests `>=22 <23`; validation still passed.

## Review-cycle notes

- Reviewer found no code-level defects and no scope creep.
- Reviewer requested additional docs/tests coverage.
- Completed docs additions for positional/numeric-only helpers (`no bind.named()`) and no sampler presets.
- Completed tests for `storage`, `readonlyStorage`, `storageTexture`, and numeric visibility input.
