### PR TITLE
docs: document headless snapshot workflow

### DIFF
--- a/packages/adapter-node/README.md
+++ b/packages/adapter-node/README.md
@@ -52,8 +52,80 @@ const texture = device.createTexture({
 });
 
 const bytes = await texture.read();
+texture.destroy();
 device.destroy();
 ```
+
+## Agentic headless snapshot testing
+
+For snapshot agents, render a deterministic, named scene into an explicit
+offscreen texture and hand the readback bytes to your project's PNG or pixel-diff
+tooling. VGPU does not ship an image-diff framework and does not automate browser
+screenshots.
+
+```ts
+import { createNodeDevice } from "@vgpu/adapter-node";
+
+const width = 256;
+const height = 256;
+const format: GPUTextureFormat = "rgba8unorm";
+const snapshotName = "hero-triangle";
+
+const device = await createNodeDevice({ label: `snapshot.${snapshotName}.device` });
+
+try {
+  const target = device.createTexture({
+    label: `snapshot.${snapshotName}.target`,
+    size: [width, height],
+    format,
+    usage: ["render_attachment", "copy_src"],
+  });
+
+  // Render a deterministic frame into `target` using fixed scene inputs:
+  // camera, time, seed, viewport, and fixture data.
+  const encoder = device.gpu.createCommandEncoder({ label: `snapshot.${snapshotName}.frame` });
+  const pass = encoder.beginRenderPass({
+    colorAttachments: [{
+      view: target.createView(),
+      clearValue: { r: 0, g: 0, b: 0, a: 1 },
+      loadOp: "clear",
+      storeOp: "store",
+    }],
+  });
+  // pass.setPipeline(pipeline);
+  // pass.draw(...);
+  pass.end();
+
+  device.queue.gpu.submit([encoder.finish()]);
+  await device.queue.flush();
+
+  const rgba = await target.read();
+  // Encode/compare `rgba` with external tools such as pngjs/pixelmatch
+  // or your repository's existing snapshot harness.
+
+  target.destroy();
+} finally {
+  device.destroy();
+}
+```
+
+Native WebGPU readback requires creating a `COPY_SRC` texture, copying to a
+`MAP_READ` buffer with 256-byte row alignment, waiting for submitted work, and
+removing row padding. `Texture.read()` wraps that boilerplate for VGPU textures.
+For resource teardown, prefer wrapper methods such as `texture.destroy()`,
+`buffer.destroy()`, and `device.destroy()`; use `texture.gpu.destroy()` or
+`buffer.gpu.destroy()` only as a deliberate raw WebGPU escape hatch.
+
+Troubleshooting checklist for snapshot tests:
+
+- Use a `Texture.read()`-supported format; prefer `rgba8unorm` for snapshots.
+- Include `"copy_src"` on the target usage alongside `"render_attachment"`.
+- Submit commands and `await device.queue.flush()` before `await target.read()`.
+- Freeze scene inputs and include names in labels/snapshot filenames.
+- Run GLIBC or headless rendering failures in the pinned Docker environment.
+
+See `createNodeDevice` docs for the full native-before/VGPU-after workflow,
+including a PNG/pixel-diff harness sketch and the relation to #81, #82, and #83.
 
 ## Troubleshooting native Dawn binary loading
 

--- a/packages/adapter-node/src/createNodeAdapter.docs.md
+++ b/packages/adapter-node/src/createNodeAdapter.docs.md
@@ -17,6 +17,16 @@ another Node 22 host based on Debian trixie, Ubuntu 24.04+, or equivalent GLIBC
 
 For headless/software rendering, match the Docker environment variables
 `LIBGL_ALWAYS_SOFTWARE=1`, `DISPLAY=:99`, and
-`XDG_RUNTIME_DIR=/tmp/xdg-runtime`. `VGPU_DAWN_FLAGS` may be set to
-space-separated Dawn flags, such as `VGPU_DAWN_FLAGS=backend=opengl`, and
-replaces the adapter's default backend flag selection.
+`XDG_RUNTIME_DIR=/tmp/xdg-runtime`. The pinned Docker image uses Node 22 on
+Debian trixie with Mesa/EGL/GL and Xvfb for the OpenGL software stack, which is
+the recommended baseline for CI and visual snapshot agents. `VGPU_DAWN_FLAGS`
+may be set to space-separated Dawn flags, such as
+`VGPU_DAWN_FLAGS=backend=opengl`, and replaces the adapter's default backend flag
+selection.
+
+For agentic headless snapshot tests, pair this adapter with an explicit
+offscreen `rgba8unorm` render target that includes `"copy_src"`, submit the
+render commands, `await device.queue.flush()`, then read pixels through
+`Texture.read()`. Keep PNG encoding and pixel comparison in project test tooling
+(such as `pngjs`, `pixelmatch`, or existing snapshots), not in the VGPU API. See
+`createNodeDevice` for a full native-before/VGPU-after guide.

--- a/packages/adapter-node/src/createNodeDevice.docs.md
+++ b/packages/adapter-node/src/createNodeDevice.docs.md
@@ -2,4 +2,252 @@
 
 `createNodeDevice(opts?)` is a mechanical convenience that requests a `Device` from
 the Node adapter directly. Prefer `App.create({ adapter: createNodeAdapter() })`
-when bootstrapping application code.
+when bootstrapping application code; use `createNodeDevice()` for focused scripts,
+server-side renders, and agentic headless snapshot tests that need one explicit
+WebGPU device.
+
+## Agentic headless snapshot workflow
+
+A snapshot agent should render a deterministic, named scene into an offscreen
+texture, wait for GPU work to finish, read the texture bytes, and hand those
+bytes to project-owned PNG or pixel-diff tooling. VGPU does not provide an
+image-diff framework and does not drive browser screenshots; it keeps the
+WebGPU render target and readback steps small and explicit.
+
+Name the inputs that control the frame (camera, time, seed, viewport, material
+fixtures) and keep them stable between runs. Name the render target as well so
+native WebGPU validation output points back to the snapshot under test.
+
+### Native WebGPU readback boilerplate
+
+In raw WebGPU, reading an offscreen render target is a separate copy-to-buffer
+operation. You must create the target with `COPY_SRC`, align rows to 256 bytes,
+copy the texture into a mappable buffer, submit the copy, wait for submitted work,
+map the buffer, then strip row padding before comparing pixels:
+
+```ts
+const width = 256;
+const height = 256;
+const bytesPerPixel = 4;
+const unpaddedBytesPerRow = width * bytesPerPixel;
+const bytesPerRow = Math.ceil(unpaddedBytesPerRow / 256) * 256;
+
+const target = gpuDevice.createTexture({
+  label: "snapshot.hero.native.target",
+  size: { width, height },
+  format: "rgba8unorm",
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.COPY_SRC,
+});
+
+// Render the deterministic frame into `target` here.
+
+const readback = gpuDevice.createBuffer({
+  label: "snapshot.hero.native.readback",
+  size: bytesPerRow * height,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+});
+
+const encoder = gpuDevice.createCommandEncoder({ label: "snapshot.hero.native.copy" });
+encoder.copyTextureToBuffer(
+  { texture: target },
+  { buffer: readback, bytesPerRow, rowsPerImage: height },
+  { width, height, depthOrArrayLayers: 1 },
+);
+gpuDevice.queue.submit([encoder.finish()]);
+await gpuDevice.queue.onSubmittedWorkDone();
+
+await readback.mapAsync(GPUMapMode.READ);
+const mapped = new Uint8Array(readback.getMappedRange());
+const rgba = new Uint8Array(unpaddedBytesPerRow * height);
+for (let y = 0; y < height; y += 1) {
+  rgba.set(
+    mapped.subarray(y * bytesPerRow, y * bytesPerRow + unpaddedBytesPerRow),
+    y * unpaddedBytesPerRow,
+  );
+}
+readback.unmap();
+```
+
+`Texture.read()` wraps that readback path for VGPU textures, including the
+padding removal, while preserving normal WebGPU rendering and command submission.
+
+### With VGPU in Node
+
+Use the Node adapter, create an explicit offscreen render target, submit your
+render commands, flush the queue, then read RGBA bytes. The example uses raw
+WebGPU pipeline creation through `.gpu` because VGPU intentionally keeps that
+escape hatch available for native interop; wrapper lifecycle methods should still
+own teardown.
+
+```ts
+import { createNodeDevice } from "@vgpu/adapter-node";
+
+const width = 256;
+const height = 256;
+const format: GPUTextureFormat = "rgba8unorm";
+
+const scene = {
+  name: "hero-triangle",
+  seed: 7,
+  timeSeconds: 0,
+  camera: "orthographic-front",
+};
+
+const device = await createNodeDevice({ label: `snapshot.${scene.name}.device` });
+
+try {
+  const target = device.createTexture({
+    label: `snapshot.${scene.name}.target`,
+    size: [width, height],
+    format,
+    usage: ["render_attachment", "copy_src"],
+  });
+
+  const shader = device.gpu.createShaderModule({
+    label: `snapshot.${scene.name}.shader`,
+    code: /* wgsl */ `
+      @vertex
+      fn vs(@builtin(vertex_index) vertexIndex: u32) -> @builtin(position) vec4f {
+        let positions = array<vec2f, 3>(
+          vec2f(-0.75, -0.75),
+          vec2f( 0.75, -0.75),
+          vec2f( 0.00,  0.75),
+        );
+        return vec4f(positions[vertexIndex], 0.0, 1.0);
+      }
+
+      @fragment
+      fn fs(@builtin(position) position: vec4f) -> @location(0) vec4f {
+        let uv = position.xy / vec2f(${width}.0, ${height}.0);
+        return vec4f(uv.x, uv.y, 0.25, 1.0);
+      }
+    `,
+  });
+
+  const pipeline = device.gpu.createRenderPipeline({
+    label: `snapshot.${scene.name}.pipeline`,
+    layout: "auto",
+    vertex: { module: shader, entryPoint: "vs" },
+    fragment: { module: shader, entryPoint: "fs", targets: [{ format }] },
+    primitive: { topology: "triangle-list" },
+  });
+
+  const encoder = device.gpu.createCommandEncoder({ label: `snapshot.${scene.name}.frame` });
+  const pass = encoder.beginRenderPass({
+    label: `snapshot.${scene.name}.pass`,
+    colorAttachments: [{
+      view: target.createView(),
+      clearValue: { r: 0, g: 0, b: 0, a: 1 },
+      loadOp: "clear",
+      storeOp: "store",
+    }],
+  });
+  pass.setPipeline(pipeline);
+  pass.draw(3);
+  pass.end();
+
+  device.queue.gpu.submit([encoder.finish()]);
+  await device.queue.flush();
+
+  const rgba = await target.read();
+  // Pass `rgba` to project-owned PNG or pixel-diff tooling.
+
+  target.destroy();
+} finally {
+  device.destroy();
+}
+```
+
+### Test harness sketch
+
+Keep PNG encoding and image comparison outside the VGPU API. A Vitest/Jest-style
+harness can use packages such as `pngjs` and `pixelmatch`, or your repository's
+existing snapshot writer:
+
+```ts
+import { readFileSync, writeFileSync } from "node:fs";
+import pixelmatch from "pixelmatch";
+import { PNG } from "pngjs";
+
+const actualPng = new PNG({ width, height });
+actualPng.data.set(rgba);
+
+if (process.env.VGPU_WRITE_SNAPSHOTS === "1") {
+  writeFileSync("snapshots/hero-triangle.png", PNG.sync.write(actualPng));
+} else {
+  const expected = PNG.sync.read(readFileSync("snapshots/hero-triangle.png"));
+  const diff = new PNG({ width, height });
+  const mismatched = pixelmatch(
+    expected.data,
+    actualPng.data,
+    diff.data,
+    width,
+    height,
+    { threshold: 0.02 },
+  );
+  if (mismatched > 0) {
+    writeFileSync("snapshots/hero-triangle.diff.png", PNG.sync.write(diff));
+    throw new Error(`Snapshot mismatch: ${mismatched} pixels differ`);
+  }
+}
+```
+
+## CI, Docker, and GLIBC caveats
+
+On Linux, the Dawn native binary loaded through `webgpu@0.4.0` may require GLIBC
+2.38 or newer. Debian 12/bookworm and similar hosts can fail while loading the
+binary with a message such as `/lib/aarch64-linux-gnu/libc.so.6: version
+'GLIBC_2.38' not found`. That is an environment compatibility issue, not a
+shader or snapshot failure.
+
+For reproducible agent and CI runs, prefer the pinned Docker path:
+
+```bash
+pnpm test:docker
+```
+
+The Docker image uses Node 22 on Debian trixie with Mesa/EGL/GL and Xvfb for the
+OpenGL software stack. It also sets the headless defaults used by the adapter:
+`LIBGL_ALWAYS_SOFTWARE=1`, `DISPLAY=:99`, and
+`XDG_RUNTIME_DIR=/tmp/xdg-runtime`. To update project snapshots in that
+environment, use a project convention such as:
+
+```bash
+VGPU_WRITE_SNAPSHOTS=1 pnpm test:docker
+```
+
+## `.gpu` lifecycle guidance
+
+`.gpu` is a raw WebGPU escape hatch. Use it for operations VGPU does not wrap,
+such as custom pipelines, render passes, query sets, or native interop. Prefer
+VGPU wrapper lifecycle methods for resources VGPU owns: call `texture.destroy()`,
+`buffer.destroy()`, and `device.destroy()` rather than `texture.gpu.destroy()` or
+`buffer.gpu.destroy()`. Direct raw destruction is reserved for deliberate
+escape-hatch/native interop cases where you also own the consequences.
+
+## Troubleshooting snapshot tests
+
+- **Unsupported format**: `Texture.read()` supports the formats documented by
+  `Texture` readback, including `rgba8unorm` and `rgba8unorm-srgb`. Prefer
+  `rgba8unorm` for deterministic snapshots unless the test intentionally covers
+  another documented readback format. Unsupported formats throw
+  `VGPU-CORE-UNSUPPORTED-FORMAT`.
+- **Missing `copy_src` usage**: the render target must include `"copy_src"` in
+  addition to `"render_attachment"`; otherwise readback copy validation fails.
+- **Unflushed queue**: submit the render commands and `await device.queue.flush()`
+  before `await target.read()` so the readback observes the completed frame.
+- **Non-deterministic inputs**: freeze clock, random seeds, camera, viewport,
+  device options, and fixture data. Include those names in labels and snapshot
+  filenames.
+- **Native environment failures**: GLIBC/Dawn load errors, Xvfb issues, or Mesa
+  setup problems are host/container issues. Re-run in `pnpm test:docker` or on a
+  Node 22 host with Debian trixie, Ubuntu 24.04+, or another GLIBC >= 2.38
+  runtime.
+
+## Related work
+
+This workflow builds on the core readback and Node adapter/Docker work tracked in
+#81 and #82, and it relates to the explicit frame-helper work referenced by #83
+when a test wants a higher-level frame abstraction instead of raw command
+encoders. It is documentation only and leaves future API changes to separate
+issues.

--- a/packages/core/src/Texture.docs.md
+++ b/packages/core/src/Texture.docs.md
@@ -2,7 +2,9 @@
 
 `Texture` is the core opaque GPU texture object created by
 `device.createTexture(...)`. It wraps a `GPUTexture`, tracks the creation
-options, and provides deterministic `rgba8unorm` readback for snapshot tests.
+options, and provides deterministic readback for snapshot tests. `rgba8unorm`
+and `rgba8unorm-srgb` are supported for readback; prefer `rgba8unorm` for
+deterministic snapshots unless a test specifically covers sRGB behavior.
 
 `TextureOptions` contains:
 
@@ -11,10 +13,12 @@ options, and provides deterministic `rgba8unorm` readback for snapshot tests.
 - `usage`: texture usage names such as `"render_attachment"` and `"copy_src"`.
 - `label`: optional WebGPU label.
 
-Invariants: `read()` only supports `rgba8unorm` and throws structured
-`VGPU-CORE-UNSUPPORTED-FORMAT` for unsupported formats. `createView(...)`
-forwards to the raw texture. `destroy()` is idempotent; after destroy, `read()`
-throws because the texture is no longer alive.
+Invariants: `read()` only supports the documented readback formats above and
+throws structured `VGPU-CORE-UNSUPPORTED-FORMAT` for unsupported formats.
+`createView(...)` forwards to the raw texture. `destroy()` is idempotent; after
+destroy, `read()` throws because the texture is no longer alive. Prefer
+`texture.destroy()` over `texture.gpu.destroy()` for VGPU-owned textures; `.gpu`
+remains available as the raw WebGPU escape hatch for native interop.
 
 Example:
 


### PR DESCRIPTION
## Summary

Closes #88.

Documents an agentic headless snapshot testing workflow for VGPU:

- native WebGPU readback boilerplate first, showing the copy-to-buffer/readback padding work that VGPU avoids
- VGPU Node flow using `createNodeDevice`, an explicit offscreen render target, `device.queue.flush()`, and `Texture.read()`
- deterministic, named scene inputs and named render targets for stable agent/CI runs
- external PNG/pixel-diff harness sketch with `pngjs`/`pixelmatch` as project tooling, not VGPU API surface
- CI/Docker/GLIBC caveats aligned with the pinned Node 22 + Debian trixie + Mesa/EGL/GL/Xvfb environment
- `.gpu` lifecycle guidance: prefer wrapper destroy methods while preserving raw WebGPU escape-hatch flexibility
- troubleshooting for unsupported formats, missing `copy_src`, queue flush ordering, nondeterministic inputs, and native environment issues

References #81 for the readback/snapshot context and also mentions the related Node adapter/Docker and frame-helper work (#82/#83). #86 and #87 are separate and intentionally not implemented here.

## Native WebGPU vs VGPU comparison

The guide starts with raw WebGPU readback: create a `COPY_SRC` render target, copy to a `MAP_READ` buffer with 256-byte row alignment, wait for submitted work, map the buffer, and strip row padding.

The VGPU version keeps rendering explicit but reduces readback to an offscreen `rgba8unorm` texture with `render_attachment` + `copy_src`, followed by:

```ts
device.queue.gpu.submit([encoder.finish()]);
await device.queue.flush();
const rgba = await target.read();
```

It also notes that `rgba8unorm-srgb` readback is supported, but `rgba8unorm` is preferred for deterministic snapshots.

## Docs-only

This is a docs-only PR. Changed docs:

- `packages/adapter-node/src/createNodeDevice.docs.md`
- `packages/adapter-node/src/createNodeAdapter.docs.md`
- `packages/adapter-node/README.md`
- `packages/core/src/Texture.docs.md`

No production code changed. No `docs/allowlist.txt` change was needed because no new docs file or symbol was added.

## Validation

Ran in this sandbox under Node `v20.20.0`; pnpm emitted the expected repo engine warning because the workspace requires Node `>=22 <23`.

- `git diff --check` — passed
- `pnpm typecheck` — passed after `pnpm install --frozen-lockfile`
- `pnpm test:fast` — passed before the final minor wording fixes: 84 test files passed, 14 skipped; 445 tests passed, 63 skipped

Final minor wording fixes were docs-only, so I reran `git diff --check` and `pnpm typecheck`.

## Review cycle notes

A debug reviewer inspected the original docs commit and returned PASS, confirming:

- docs-only changes
- native-before/VGPU-after workflow present
- explicit `rgba8unorm` offscreen target with `render_attachment` + `copy_src`
- deterministic named scene inputs
- `flush()` + `Texture.read()` flow
- external PNG/pixelmatch tooling only
- Docker/GLIBC/trixie caveats
- `.gpu` lifecycle guidance
- troubleshooting coverage
- no #86/#87 implementation or references

After reviewer/orchestrator follow-up, I applied two minor fixes:

1. softened the #83 relation wording so it does not over-attribute `beginFrame(...)` to that issue
2. explicitly noted `rgba8unorm-srgb` readback support while keeping `rgba8unorm` as the preferred deterministic snapshot format
