### PR TITLE
feat(wgsl-std): add scaffold and resolver contract

### DIFF
--- a/packages/wgsl-std/LICENSE
+++ b/packages/wgsl-std/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Vercel, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/wgsl-std/README.md
+++ b/packages/wgsl-std/README.md
@@ -1,0 +1,19 @@
+# @vgpu/wgsl-std
+
+Pure WGSL utility snippets for use with `@vgpu/wgsl` import resolution.
+
+This package intentionally ships raw `.wgsl` modules instead of JavaScript wrappers or a macro/include system. Import the explicit utility area you need:
+
+```wgsl
+import { identityF32 } from "@vgpu/wgsl-std/math";
+import { identityVec3f } from "@vgpu/wgsl-std/color";
+```
+
+There is no root WGSL export. Subpath exports resolve to physical WGSL files:
+
+- `@vgpu/wgsl-std/math` -> `src/math/index.wgsl`
+- `@vgpu/wgsl-std/color` -> `src/color/index.wgsl`
+
+The scaffold currently includes only tiny identity helpers to prove resolver mechanics. Future slices will replace or expand these modules with the reviewed math and color utility catalog.
+
+WGSL snippets in this package must stay pure declaration modules: functions, constants, structs, and aliases only. They must not introduce hidden bindings, resource variables, overrides, or entry points.

--- a/packages/wgsl-std/package.json
+++ b/packages/wgsl-std/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "@vgpu/wgsl-std",
+  "version": "0.0.5",
+  "description": "Pure WGSL utility snippets for vgpu shaders.",
+  "keywords": [
+    "webgpu",
+    "graphics",
+    "rendering",
+    "wgsl",
+    "shader",
+    "utilities"
+  ],
+  "homepage": "https://github.com/vercel-labs/vgpu#readme",
+  "bugs": {
+    "url": "https://github.com/vercel-labs/vgpu/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/vercel-labs/vgpu.git",
+    "directory": "packages/wgsl-std"
+  },
+  "license": "MIT",
+  "author": "Matias Gonzalez <matiasngf@hotmail.com>",
+  "private": false,
+  "publishConfig": {
+    "access": "public"
+  },
+  "sideEffects": false,
+  "type": "module",
+  "exports": {
+    "./math": "./src/math/index.wgsl",
+    "./color": "./src/color/index.wgsl"
+  },
+  "files": [
+    "src/**/*.wgsl",
+    "src/**/*.docs.md",
+    "README.md",
+    "LICENSE"
+  ]
+}

--- a/packages/wgsl-std/src/color/index.docs.md
+++ b/packages/wgsl-std/src/color/index.docs.md
@@ -1,0 +1,5 @@
+# @vgpu/wgsl-std/color
+
+Raw WGSL color utility module for `@vgpu/wgsl` imports.
+
+This scaffold exports `identityVec3f` only to exercise package resolution. The full color utility catalog is intentionally deferred to the color slice.

--- a/packages/wgsl-std/src/color/index.wgsl
+++ b/packages/wgsl-std/src/color/index.wgsl
@@ -1,0 +1,3 @@
+export fn identityVec3f(value: vec3f) -> vec3f {
+  return value;
+}

--- a/packages/wgsl-std/src/math/index.docs.md
+++ b/packages/wgsl-std/src/math/index.docs.md
@@ -1,0 +1,5 @@
+# @vgpu/wgsl-std/math
+
+Raw WGSL math utility module for `@vgpu/wgsl` imports.
+
+This scaffold exports `identityF32` only to exercise package resolution. The full math utility catalog is intentionally deferred to the math slice.

--- a/packages/wgsl-std/src/math/index.wgsl
+++ b/packages/wgsl-std/src/math/index.wgsl
@@ -1,0 +1,3 @@
+export fn identityF32(value: f32) -> f32 {
+  return value;
+}

--- a/packages/wgsl-std/tests/package-resolution.test.ts
+++ b/packages/wgsl-std/tests/package-resolution.test.ts
@@ -1,0 +1,61 @@
+import { mkdir, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { expect, test } from "vitest";
+import { resolveShader } from "@vgpu/wgsl/runtime";
+
+test("math and color package subpaths resolve through package exports", async () => {
+  const dir = await workspaceFixture();
+  const entry = join(dir, "app", "main.wgsl");
+  await writeFile(entry, `import { identityF32 } from "@vgpu/wgsl-std/math";
+import { identityVec3f } from "@vgpu/wgsl-std/color";
+fn main() -> vec3f {
+  return identityVec3f(vec3f(identityF32(1.0)));
+}`);
+
+  const result = await resolveShader({ entry, validate: false });
+
+  expect(result.deps.some((dep) => dep.endsWith("node_modules/@vgpu/wgsl-std/src/math/index.wgsl"))).toBe(true);
+  expect(result.deps.some((dep) => dep.endsWith("node_modules/@vgpu/wgsl-std/src/color/index.wgsl"))).toBe(true);
+  expect(result.wgsl).toContain("node_modules/@vgpu/wgsl-std/src/math/index.wgsl");
+  expect(result.wgsl).toContain("node_modules/@vgpu/wgsl-std/src/color/index.wgsl");
+  expect(result.wgsl).toMatch(/fn _vgsl_[0-9a-f]{8}__identityF32\(value: f32\) -> f32/);
+  expect(result.wgsl).toMatch(/fn _vgsl_[0-9a-f]{8}__identityVec3f\(value: vec3f\) -> vec3f/);
+});
+
+test("wgsl-std has no root WGSL export", async () => {
+  const dir = await workspaceFixture();
+  const entry = join(dir, "app", "main.wgsl");
+  await writeFile(entry, `import { identityF32 } from "@vgpu/wgsl-std";
+fn main() -> f32 { return identityF32(1.0); }`);
+
+  await expect(resolveShader({ entry, validate: false })).rejects.toMatchObject({ code: "VGPU-WGSL-PKG-NOTFOUND" });
+});
+
+test("resolved wgsl-std output is deterministic when minified", async () => {
+  const dir = await workspaceFixture();
+  const entry = join(dir, "app", "main.wgsl");
+  await writeFile(entry, `import { identityF32 } from "@vgpu/wgsl-std/math";
+fn main() -> f32 {
+  return identityF32(0.5);
+}`);
+
+  const first = await resolveShader({ entry, validate: false, minify: true });
+  const second = await resolveShader({ entry, validate: false, minify: true });
+
+  expect(first.wgsl).toBe(second.wgsl);
+  expect(first.wgsl).toBe("fn a()-> f32{return b(0.5);}fn b(c:f32)-> f32{return c;}");
+});
+
+async function workspaceFixture(): Promise<string> {
+  const dir = await mkdirTemp();
+  await mkdir(join(dir, "app"), { recursive: true });
+  await mkdir(join(dir, "node_modules", "@vgpu"), { recursive: true });
+  await symlink(resolve("packages/wgsl-std"), join(dir, "node_modules", "@vgpu", "wgsl-std"), "dir");
+  return dir;
+}
+
+async function mkdirTemp(): Promise<string> {
+  const { mkdtemp } = await import("node:fs/promises");
+  return mkdtemp(join(tmpdir(), "vgpu-wgsl-std-"));
+}

--- a/packages/wgsl-std/tests/package-resolution.test.ts
+++ b/packages/wgsl-std/tests/package-resolution.test.ts
@@ -44,7 +44,9 @@ fn main() -> f32 {
   const second = await resolveShader({ entry, validate: false, minify: true });
 
   expect(first.wgsl).toBe(second.wgsl);
-  expect(first.wgsl).toBe("fn a()-> f32{return b(0.5);}fn b(c:f32)-> f32{return c;}");
+  expect(first.wgsl).not.toContain("\n");
+  expect(first.wgsl).not.toContain("//");
+  expect(first.wgsl.replace(/\s+/gu, "")).toMatch(/^fna\(\)->f32\{returnb\(0\.5\);\}fnb\(([a-z]+):f32\)->f32\{return\1;\}$/u);
 });
 
 async function workspaceFixture(): Promise<string> {

--- a/packages/wgsl-std/tests/purity.test.ts
+++ b/packages/wgsl-std/tests/purity.test.ts
@@ -1,15 +1,16 @@
 import { readdir, readFile } from "node:fs/promises";
 import { join, relative, resolve } from "node:path";
-import { expect, test } from "vitest";
+import { describe, expect, test } from "vitest";
 
 const packageRoot = resolve("packages/wgsl-std");
 const sourceRoot = join(packageRoot, "src");
-const forbiddenPatterns: readonly RegExp[] = [
-  /@\s*binding\b/u,
-  /@\s*group\b/u,
-  /@\s*(vertex|fragment|compute)\b/u,
-  /\boverride\b/u,
-  /\bvar\s*<\s*(uniform|storage|workgroup)\b/u,
+const allowedTopLevelDeclaration = /^(export\s+)?(fn|const|struct|alias)\b/u;
+const forbiddenModulePatterns: readonly { readonly pattern: RegExp; readonly label: string }[] = [
+  { pattern: /@\s*binding\b/u, label: "resource binding attributes" },
+  { pattern: /@\s*group\b/u, label: "resource group attributes" },
+  { pattern: /@\s*(vertex|fragment|compute)\b/u, label: "entry point attributes" },
+  { pattern: /\boverride\b/u, label: "pipeline overrides" },
+  { pattern: /\bvar\s*<\s*(uniform|storage|workgroup)\b/u, label: "resource variables" },
 ];
 
 test("exported wgsl-std snippets stay pure declaration modules", async () => {
@@ -22,16 +23,30 @@ test("exported wgsl-std snippets stay pure declaration modules", async () => {
 
   for (const file of files) {
     const source = await readFile(file, "utf8");
-    const withoutComments = stripComments(source);
+    const errors = purityErrors(source).map((error) => `${relative(packageRoot, file)}: ${error}`);
 
-    for (const pattern of forbiddenPatterns) {
-      expect.soft(withoutComments, `${relative(packageRoot, file)} must not match ${pattern}`).not.toMatch(pattern);
-    }
-
-    for (const declaration of topLevelDeclarations(withoutComments)) {
-      expect.soft(declaration, `${relative(packageRoot, file)} has only fn/const/struct/alias top-level declarations`).toMatch(/^(export\s+)?(fn|const|struct|alias)\b/u);
-    }
+    expect.soft(errors).toEqual([]);
   }
+});
+
+describe("purity lint regressions", () => {
+  test.each([
+    ["top-level private var", "var hiddenCounter: u32;"],
+    ["top-level explicit private var", "var<private> hiddenCounter: u32;"],
+    ["exported top-level private var", "export var hiddenCounter: u32;"],
+    ["resource var", "var<uniform> hiddenUniform: u32;"],
+  ])("rejects %s", (_name, source) => {
+    expect(purityErrors(source)).toEqual(expect.arrayContaining([
+      expect.stringContaining("top-level declaration must be fn/const/struct/alias"),
+    ]));
+  });
+
+  test("allows function-local vars", () => {
+    expect(purityErrors(`export fn localOnly(value: u32) -> u32 {
+  var hiddenCounter = value;
+  return hiddenCounter;
+}`)).toEqual([]);
+  });
 });
 
 async function findWgslFiles(dir: string): Promise<string[]> {
@@ -42,6 +57,23 @@ async function findWgslFiles(dir: string): Promise<string[]> {
     return entry.isFile() && entry.name.endsWith(".wgsl") ? [fullPath] : [];
   }));
   return nested.flat();
+}
+
+function purityErrors(source: string): string[] {
+  const withoutComments = stripComments(source);
+  const errors: string[] = [];
+
+  for (const { pattern, label } of forbiddenModulePatterns) {
+    if (pattern.test(withoutComments)) errors.push(`forbidden ${label}: ${pattern}`);
+  }
+
+  for (const declaration of topLevelDeclarations(withoutComments)) {
+    if (!allowedTopLevelDeclaration.test(declaration)) {
+      errors.push(`top-level declaration must be fn/const/struct/alias only: ${declaration}`);
+    }
+  }
+
+  return errors;
 }
 
 function stripComments(source: string): string {

--- a/packages/wgsl-std/tests/purity.test.ts
+++ b/packages/wgsl-std/tests/purity.test.ts
@@ -1,0 +1,70 @@
+import { readdir, readFile } from "node:fs/promises";
+import { join, relative, resolve } from "node:path";
+import { expect, test } from "vitest";
+
+const packageRoot = resolve("packages/wgsl-std");
+const sourceRoot = join(packageRoot, "src");
+const forbiddenPatterns: readonly RegExp[] = [
+  /@\s*binding\b/u,
+  /@\s*group\b/u,
+  /@\s*(vertex|fragment|compute)\b/u,
+  /\boverride\b/u,
+  /\bvar\s*<\s*(uniform|storage|workgroup)\b/u,
+];
+
+test("exported wgsl-std snippets stay pure declaration modules", async () => {
+  const files = await findWgslFiles(sourceRoot);
+
+  expect(files.map((file) => relative(packageRoot, file).replace(/\\/gu, "/")).sort()).toEqual([
+    "src/color/index.wgsl",
+    "src/math/index.wgsl",
+  ]);
+
+  for (const file of files) {
+    const source = await readFile(file, "utf8");
+    const withoutComments = stripComments(source);
+
+    for (const pattern of forbiddenPatterns) {
+      expect.soft(withoutComments, `${relative(packageRoot, file)} must not match ${pattern}`).not.toMatch(pattern);
+    }
+
+    for (const declaration of topLevelDeclarations(withoutComments)) {
+      expect.soft(declaration, `${relative(packageRoot, file)} has only fn/const/struct/alias top-level declarations`).toMatch(/^(export\s+)?(fn|const|struct|alias)\b/u);
+    }
+  }
+});
+
+async function findWgslFiles(dir: string): Promise<string[]> {
+  const entries = await readdir(dir, { withFileTypes: true });
+  const nested = await Promise.all(entries.map(async (entry) => {
+    const fullPath = join(dir, entry.name);
+    if (entry.isDirectory()) return findWgslFiles(fullPath);
+    return entry.isFile() && entry.name.endsWith(".wgsl") ? [fullPath] : [];
+  }));
+  return nested.flat();
+}
+
+function stripComments(source: string): string {
+  return source
+    .replace(/\/\*[\s\S]*?\*\//gu, "")
+    .replace(/\/\/.*$/gmu, "");
+}
+
+function topLevelDeclarations(source: string): string[] {
+  const declarations: string[] = [];
+  let depth = 0;
+  let start = 0;
+  for (let index = 0; index < source.length; index += 1) {
+    const char = source[index];
+    if (char === "{") depth += 1;
+    if (char === "}") depth -= 1;
+    if (depth === 0 && (char === ";" || char === "}")) {
+      const declaration = source.slice(start, index + 1).trim();
+      if (declaration) declarations.push(declaration);
+      start = index + 1;
+    }
+  }
+  const tail = source.slice(start).trim();
+  if (tail) declarations.push(tail);
+  return declarations;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -96,6 +96,8 @@ importers:
         specifier: ^5.97.1
         version: 5.106.2(esbuild@0.21.5)
 
+  packages/wgsl-std: {}
+
 packages:
 
   '@emnapi/runtime@1.10.0':


### PR DESCRIPTION
## Summary
- add @vgpu/wgsl-std package with raw WGSL math/color subpath exports
- add minimal pure identity helpers to prove @vgpu/wgsl package export resolution
- add purity self-lint and resolver/minify tests

## TDD evidence
- Red: package-resolution and purity tests failed before scaffold with VGPU-WGSL-PKG-NOTFOUND and missing src directory.
- Green: new wgsl-std tests pass after package scaffold.

## Validation
- pnpm exec vitest run packages/wgsl-std/tests/package-resolution.test.ts packages/wgsl-std/tests/purity.test.ts
- pnpm exec tsc -b --pretty false
- pnpm exec vitest run packages/wgsl packages/wgsl-std
- pnpm build

Base: feature/issue-92-wgsl-utils