### PR TITLE
Add WGSL std math utilities

### DIFF
--- a/packages/wgsl-std/README.md
+++ b/packages/wgsl-std/README.md
@@ -5,7 +5,7 @@ Pure WGSL utility snippets for use with `@vgpu/wgsl` import resolution.
 This package intentionally ships raw `.wgsl` modules instead of JavaScript wrappers or a macro/include system. Import the explicit utility area you need:
 
 ```wgsl
-import { identityF32 } from "@vgpu/wgsl-std/math";
+import { saturate, remap, safeNormalize3, rotate2d } from "@vgpu/wgsl-std/math";
 import { identityVec3f } from "@vgpu/wgsl-std/color";
 ```
 
@@ -14,6 +14,19 @@ There is no root WGSL export. Subpath exports resolve to physical WGSL files:
 - `@vgpu/wgsl-std/math` -> `src/math/index.wgsl`
 - `@vgpu/wgsl-std/color` -> `src/color/index.wgsl`
 
-The scaffold currently includes only tiny identity helpers to prove resolver mechanics. Future slices will replace or expand these modules with the reviewed math and color utility catalog.
-
 WGSL snippets in this package must stay pure declaration modules: functions, constants, structs, and aliases only. They must not introduce hidden bindings, resource variables, overrides, or entry points.
+
+## Math utilities
+
+`@vgpu/wgsl-std/math` includes scalar range helpers and vector safety helpers:
+
+- `saturate(value: f32) -> f32`: clamp to `[0.0, 1.0]`.
+- `clamp01(value: f32) -> f32`: alias for `saturate`.
+- `inverseLerp(from: f32, to: f32, value: f32) -> f32`: unclamped inverse lerp; returns `0.0` when `from == to`.
+- `remap(inMin: f32, inMax: f32, outMin: f32, outMax: f32, value: f32) -> f32`: unclamped range remap; returns `outMin` when the input range is zero-length.
+- `safeNormalize2/3/4(value, fallback)`: normalize non-zero vectors and return `fallback` for zero-length vectors. WGSL has no user-defined generic overloads, so dimensions are explicit in v1.
+- `rotate2d(value: vec2f, radians: f32) -> vec2f`: counter-clockwise 2D rotation by radians.
+
+See `src/math/index.docs.md` for examples and edge-case notes.
+
+The color module currently contains only the scaffold identity helper; the reviewed color utility catalog is planned for a later slice.

--- a/packages/wgsl-std/src/math/index.docs.md
+++ b/packages/wgsl-std/src/math/index.docs.md
@@ -2,4 +2,53 @@
 
 Raw WGSL math utility module for `@vgpu/wgsl` imports.
 
-This scaffold exports `identityF32` only to exercise package resolution. The full math utility catalog is intentionally deferred to the math slice.
+All exports are pure WGSL declarations. Import only the helpers you use:
+
+```wgsl
+import { saturate, remap, safeNormalize3, rotate2d } from "@vgpu/wgsl-std/math";
+
+fn shade(normal: vec3f, uv: vec2f) -> vec3f {
+  let n = safeNormalize3(normal, vec3f(0.0, 0.0, 1.0));
+  let rotatedUv = rotate2d(uv, 0.78539816339);
+  let weight = saturate(remap(-1.0, 1.0, 0.0, 1.0, n.z));
+  return vec3f(rotatedUv, weight);
+}
+```
+
+## Catalog
+
+### `saturate(value: f32) -> f32`
+
+Clamps a scalar `f32` to `[0.0, 1.0]` using WGSL `clamp`.
+
+### `clamp01(value: f32) -> f32`
+
+Alias for `saturate`. Use whichever name is clearer at the call site.
+
+### `inverseLerp(from: f32, to: f32, value: f32) -> f32`
+
+Returns `(value - from) / (to - from)` without clamping the result. Values outside the input range produce values outside `[0.0, 1.0]`.
+
+If `from == to`, the input range has no length and the helper returns `0.0` deterministically instead of dividing by zero.
+
+### `remap(inMin: f32, inMax: f32, outMin: f32, outMax: f32, value: f32) -> f32`
+
+Maps `value` from input range `[inMin, inMax]` into output range `[outMin, outMax]` using `inverseLerp`, without clamping.
+
+If `inMin == inMax`, `inverseLerp` returns `0.0`, so `remap` returns `outMin`.
+
+### `safeNormalize2(value: vec2f, fallback: vec2f) -> vec2f`
+### `safeNormalize3(value: vec3f, fallback: vec3f) -> vec3f`
+### `safeNormalize4(value: vec4f, fallback: vec4f) -> vec4f`
+
+Normalizes non-zero vectors and returns `fallback` for zero-length vectors. The fallback is returned exactly as supplied; normalize it first if the fallback must be unit length.
+
+WGSL does not provide user-defined generic functions for multiple vector dimensions, so v1 exports explicit `2`, `3`, and `4` dimensional names instead of a single overloaded `safeNormalize`.
+
+### `rotate2d(value: vec2f, radians: f32) -> vec2f`
+
+Rotates a `vec2f` by `radians` counter-clockwise around the origin:
+
+```wgsl
+let up = rotate2d(vec2f(1.0, 0.0), 1.57079632679);
+```

--- a/packages/wgsl-std/src/math/index.wgsl
+++ b/packages/wgsl-std/src/math/index.wgsl
@@ -1,3 +1,47 @@
-export fn identityF32(value: f32) -> f32 {
-  return value;
+export fn saturate(value: f32) -> f32 {
+  return clamp(value, 0.0, 1.0);
+}
+
+export fn clamp01(value: f32) -> f32 {
+  return saturate(value);
+}
+
+export fn inverseLerp(from: f32, to: f32, value: f32) -> f32 {
+  let denominator = to - from;
+  if (denominator == 0.0) {
+    return 0.0;
+  }
+  return (value - from) / denominator;
+}
+
+export fn remap(inMin: f32, inMax: f32, outMin: f32, outMax: f32, value: f32) -> f32 {
+  let t = inverseLerp(inMin, inMax, value);
+  return outMin + t * (outMax - outMin);
+}
+
+export fn safeNormalize2(value: vec2f, fallback: vec2f) -> vec2f {
+  if (dot(value, value) <= 0.0) {
+    return fallback;
+  }
+  return normalize(value);
+}
+
+export fn safeNormalize3(value: vec3f, fallback: vec3f) -> vec3f {
+  if (dot(value, value) <= 0.0) {
+    return fallback;
+  }
+  return normalize(value);
+}
+
+export fn safeNormalize4(value: vec4f, fallback: vec4f) -> vec4f {
+  if (dot(value, value) <= 0.0) {
+    return fallback;
+  }
+  return normalize(value);
+}
+
+export fn rotate2d(value: vec2f, radians: f32) -> vec2f {
+  let c = cos(radians);
+  let s = sin(radians);
+  return vec2f(value.x * c - value.y * s, value.x * s + value.y * c);
 }

--- a/packages/wgsl-std/src/math/index.wgsl
+++ b/packages/wgsl-std/src/math/index.wgsl
@@ -20,28 +20,31 @@ export fn remap(inMin: f32, inMax: f32, outMin: f32, outMax: f32, value: f32) ->
 }
 
 export fn safeNormalize2(value: vec2f, fallback: vec2f) -> vec2f {
-  if (dot(value, value) <= 0.0) {
+  let lengthSquared = dot(value, value);
+  if (lengthSquared <= 0.0) {
     return fallback;
   }
-  return normalize(value);
+  return value * inverseSqrt(lengthSquared);
 }
 
 export fn safeNormalize3(value: vec3f, fallback: vec3f) -> vec3f {
-  if (dot(value, value) <= 0.0) {
+  let lengthSquared = dot(value, value);
+  if (lengthSquared <= 0.0) {
     return fallback;
   }
-  return normalize(value);
+  return value * inverseSqrt(lengthSquared);
 }
 
 export fn safeNormalize4(value: vec4f, fallback: vec4f) -> vec4f {
-  if (dot(value, value) <= 0.0) {
+  let lengthSquared = dot(value, value);
+  if (lengthSquared <= 0.0) {
     return fallback;
   }
-  return normalize(value);
+  return value * inverseSqrt(lengthSquared);
 }
 
 export fn rotate2d(value: vec2f, radians: f32) -> vec2f {
   let c = cos(radians);
   let s = sin(radians);
-  return vec2f(value.x * c - value.y * s, value.x * s + value.y * c);
+  return mat2x2f(c, s, -s, c) * value;
 }

--- a/packages/wgsl-std/tests/math.test.ts
+++ b/packages/wgsl-std/tests/math.test.ts
@@ -1,0 +1,227 @@
+import { mkdir, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { describe, expect, test } from "vitest";
+import { createNodeAdapter } from "@vgpu/adapter-node";
+import { App } from "@vgpu/core";
+import { resolveShader } from "@vgpu/wgsl/runtime";
+
+const dockerTest = process.env.VGPU_DOCKER_TEST === "1";
+
+const EPSILON = 1e-6;
+
+interface ScalarCase {
+  readonly name: string;
+  readonly actual: number;
+  readonly expected: number;
+}
+
+interface Vec2Case {
+  readonly name: string;
+  readonly actual: readonly [number, number];
+  readonly expected: readonly [number, number];
+}
+
+describe("CPU reference math catalog", () => {
+  test("scalar helpers define deterministic edge behavior", () => {
+    const cases: readonly ScalarCase[] = [
+      { name: "saturate below", actual: saturateRef(-0.25), expected: 0 },
+      { name: "saturate within", actual: saturateRef(0.375), expected: 0.375 },
+      { name: "saturate above", actual: saturateRef(1.25), expected: 1 },
+      { name: "clamp01 alias", actual: clamp01Ref(1.25), expected: saturateRef(1.25) },
+      { name: "inverseLerp midpoint", actual: inverseLerpRef(2, 6, 4), expected: 0.5 },
+      { name: "inverseLerp unclamped", actual: inverseLerpRef(2, 6, 10), expected: 2 },
+      { name: "inverseLerp zero range", actual: inverseLerpRef(2, 2, 10), expected: 0 },
+      { name: "remap midpoint", actual: remapRef(0, 10, -1, 1, 5), expected: 0 },
+      { name: "remap zero input range", actual: remapRef(2, 2, 4, 8, 10), expected: 4 },
+    ];
+
+    for (const { name, actual, expected } of cases) {
+      expect.soft(actual, name).toBeCloseTo(expected, 6);
+    }
+  });
+
+  test("vector helpers define safe normalize and rotation behavior", () => {
+    const cases: readonly Vec2Case[] = [
+      { name: "safeNormalize2 non-zero", actual: safeNormalize2Ref([3, 4], [1, 0]), expected: [0.6, 0.8] },
+      { name: "safeNormalize2 zero fallback", actual: safeNormalize2Ref([0, 0], [1, 0]), expected: [1, 0] },
+      { name: "rotate2d quarter turn", actual: rotate2dRef([1, 0], Math.PI / 2), expected: [0, 1] },
+    ];
+
+    for (const { name, actual, expected } of cases) {
+      expectVec2Close(actual, expected, name);
+    }
+  });
+});
+
+test("math helpers resolve from @vgpu/wgsl-std/math and produce valid declarations", async () => {
+  const dir = await workspaceFixture();
+  const entry = join(dir, "app", "main.wgsl");
+  await writeFile(entry, `import { saturate, clamp01, inverseLerp, remap, safeNormalize2, safeNormalize3, safeNormalize4, rotate2d } from "@vgpu/wgsl-std/math";
+fn main() -> vec4f {
+  let scalar = saturate(-0.5) + clamp01(1.5) + inverseLerp(2.0, 6.0, 4.0) + remap(0.0, 10.0, -1.0, 1.0, 5.0);
+  let v2 = rotate2d(safeNormalize2(vec2f(3.0, 4.0), vec2f(1.0, 0.0)), 1.5707963267948966);
+  let v3 = safeNormalize3(vec3f(0.0), vec3f(0.0, 1.0, 0.0));
+  let v4 = safeNormalize4(vec4f(0.0), vec4f(0.0, 0.0, 1.0, 0.0));
+  return vec4f(scalar + v2.x + v3.y + v4.z, v2.y, v3.y, v4.z);
+}`);
+
+  const result = await resolveShader({ entry, validate: false });
+
+  expect(result.deps.some((dep) => dep.endsWith("node_modules/@vgpu/wgsl-std/src/math/index.wgsl"))).toBe(true);
+  for (const name of ["saturate", "clamp01", "inverseLerp", "remap", "safeNormalize2", "safeNormalize3", "safeNormalize4", "rotate2d"]) {
+    expect.soft(result.wgsl, name).toMatch(new RegExp(`fn _vgsl_[0-9a-f]{8}__${name}\\(`, "u"));
+  }
+  expect(result.wgsl).not.toContain("identityF32");
+});
+
+test("math helper minified output is deterministic", async () => {
+  const dir = await workspaceFixture();
+  const entry = join(dir, "app", "main.wgsl");
+  await writeFile(entry, `import { saturate, remap } from "@vgpu/wgsl-std/math";
+fn main() -> f32 {
+  return saturate(remap(0.0, 10.0, -1.0, 1.0, 12.0));
+}`);
+
+  const first = await resolveShader({ entry, validate: false, minify: true });
+  const second = await resolveShader({ entry, validate: false, minify: true });
+
+  expect(first.wgsl).toBe(second.wgsl);
+  expect(first.wgsl).not.toContain("\n");
+  expect(first.wgsl).not.toContain("//");
+  expect(first.wgsl).toContain("clamp(");
+});
+
+test.skipIf(!dockerTest)("resolved math utility shader validates with naga", async () => {
+  const dir = await workspaceFixture();
+  const entry = join(dir, "app", "main.wgsl");
+  await writeFile(entry, `import { saturate, safeNormalize2, rotate2d } from "@vgpu/wgsl-std/math";
+@compute @workgroup_size(1)
+fn main() {
+  let value = saturate(rotate2d(safeNormalize2(vec2f(1.0, 0.0), vec2f(0.0, 1.0)), 0.5).x);
+}`);
+
+  await expect(resolveShader({ entry })).resolves.toHaveProperty("wgsl");
+});
+
+test.skipIf(!dockerTest)("math helpers match CPU references in a tiny compute shader", async () => {
+  const values = await runMathCompute();
+  const expected = new Float32Array([
+    saturateRef(-0.25),
+    saturateRef(1.25),
+    inverseLerpRef(2, 6, 4),
+    inverseLerpRef(2, 2, 10),
+    remapRef(0, 10, -1, 1, 5),
+    remapRef(2, 2, 4, 8, 10),
+    ...safeNormalize2Ref([3, 4], [1, 0]),
+    ...safeNormalize2Ref([0, 0], [1, 0]),
+    ...rotate2dRef([1, 0], Math.PI / 2),
+  ]);
+
+  expect(values.length).toBe(expected.length);
+  values.forEach((value, index) => {
+    expect(value).toBeCloseTo(expected[index], 4);
+  });
+});
+
+function saturateRef(value: number): number {
+  return Math.min(Math.max(value, 0), 1);
+}
+
+function clamp01Ref(value: number): number {
+  return saturateRef(value);
+}
+
+function inverseLerpRef(from: number, to: number, value: number): number {
+  const denominator = to - from;
+  return denominator === 0 ? 0 : (value - from) / denominator;
+}
+
+function remapRef(inMin: number, inMax: number, outMin: number, outMax: number, value: number): number {
+  return outMin + inverseLerpRef(inMin, inMax, value) * (outMax - outMin);
+}
+
+function safeNormalize2Ref(value: readonly [number, number], fallback: readonly [number, number]): [number, number] {
+  const lengthSq = value[0] * value[0] + value[1] * value[1];
+  if (lengthSq <= 0) return [fallback[0], fallback[1]];
+  const invLength = 1 / Math.sqrt(lengthSq);
+  return [value[0] * invLength, value[1] * invLength];
+}
+
+function rotate2dRef(value: readonly [number, number], radians: number): [number, number] {
+  const c = Math.cos(radians);
+  const s = Math.sin(radians);
+  return [value[0] * c - value[1] * s, value[0] * s + value[1] * c];
+}
+
+function expectVec2Close(actual: readonly [number, number], expected: readonly [number, number], name: string): void {
+  expect.soft(actual[0], `${name}.x`).toBeCloseTo(expected[0], 6);
+  expect.soft(actual[1], `${name}.y`).toBeCloseTo(expected[1], 6);
+}
+
+async function runMathCompute(): Promise<Float32Array> {
+  const outputLength = 12;
+  const outputSize = outputLength * Float32Array.BYTES_PER_ELEMENT;
+  const modules = {
+    "/main.wgsl": `import { saturate, inverseLerp, remap, safeNormalize2, rotate2d } from "@vgpu/wgsl-std/math";
+struct Out { values: array<f32, ${outputLength}> }
+@group(0) @binding(0) var<storage, read_write> out: Out;
+@compute @workgroup_size(1)
+fn main() {
+  out.values[0] = saturate(-0.25);
+  out.values[1] = saturate(1.25);
+  out.values[2] = inverseLerp(2.0, 6.0, 4.0);
+  out.values[3] = inverseLerp(2.0, 2.0, 10.0);
+  out.values[4] = remap(0.0, 10.0, -1.0, 1.0, 5.0);
+  out.values[5] = remap(2.0, 2.0, 4.0, 8.0, 10.0);
+  let n = safeNormalize2(vec2f(3.0, 4.0), vec2f(1.0, 0.0));
+  out.values[6] = n.x;
+  out.values[7] = n.y;
+  let z = safeNormalize2(vec2f(0.0), vec2f(1.0, 0.0));
+  out.values[8] = z.x;
+  out.values[9] = z.y;
+  let r = rotate2d(vec2f(1.0, 0.0), 1.5707963267948966);
+  out.values[10] = r.x;
+  out.values[11] = r.y;
+}`,
+  };
+  const shader = await resolveShader({ entry: "/main.wgsl", modules, packageMap: { "@vgpu/wgsl-std/math": resolve("packages/wgsl-std/src/math/index.wgsl") }, validate: false });
+
+  const { device } = await App.create({ adapter: createNodeAdapter() });
+  const gpu = device.gpu;
+  const output = gpu.createBuffer({ size: outputSize, usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_SRC | GPUBufferUsage.COPY_DST });
+  const readback = gpu.createBuffer({ size: outputSize, usage: GPUBufferUsage.MAP_READ | GPUBufferUsage.COPY_DST });
+  try {
+    const pipeline = gpu.createComputePipeline({ layout: "auto", compute: { module: gpu.createShaderModule({ code: shader.wgsl }), entryPoint: "main" } });
+    const bindGroup = gpu.createBindGroup({ layout: pipeline.getBindGroupLayout(0), entries: [{ binding: 0, resource: { buffer: output } }] });
+    const encoder = gpu.createCommandEncoder();
+    const pass = encoder.beginComputePass();
+    pass.setPipeline(pipeline);
+    pass.setBindGroup(0, bindGroup);
+    pass.dispatchWorkgroups(1);
+    pass.end();
+    encoder.copyBufferToBuffer(output, 0, readback, 0, outputSize);
+    gpu.queue.submit([encoder.finish()]);
+    await gpu.queue.onSubmittedWorkDone();
+    await readback.mapAsync(GPUMapMode.READ);
+    return new Float32Array(new Uint8Array(readback.getMappedRange()).slice().buffer);
+  } finally {
+    if (readback.mapState === "mapped") readback.unmap();
+    readback.destroy();
+    output.destroy();
+    device.destroy();
+  }
+}
+
+async function workspaceFixture(): Promise<string> {
+  const dir = await mkdirTemp();
+  await mkdir(join(dir, "app"), { recursive: true });
+  await mkdir(join(dir, "node_modules", "@vgpu"), { recursive: true });
+  await symlink(resolve("packages/wgsl-std"), join(dir, "node_modules", "@vgpu", "wgsl-std"), "dir");
+  return dir;
+}
+
+async function mkdirTemp(): Promise<string> {
+  const { mkdtemp } = await import("node:fs/promises");
+  return mkdtemp(join(tmpdir(), "vgpu-wgsl-std-"));
+}

--- a/packages/wgsl-std/tests/math.test.ts
+++ b/packages/wgsl-std/tests/math.test.ts
@@ -8,8 +8,6 @@ import { resolveShader } from "@vgpu/wgsl/runtime";
 
 const dockerTest = process.env.VGPU_DOCKER_TEST === "1";
 
-const EPSILON = 1e-6;
-
 interface ScalarCase {
   readonly name: string;
   readonly actual: number;
@@ -20,6 +18,18 @@ interface Vec2Case {
   readonly name: string;
   readonly actual: readonly [number, number];
   readonly expected: readonly [number, number];
+}
+
+interface Vec3Case {
+  readonly name: string;
+  readonly actual: readonly [number, number, number];
+  readonly expected: readonly [number, number, number];
+}
+
+interface Vec4Case {
+  readonly name: string;
+  readonly actual: readonly [number, number, number, number];
+  readonly expected: readonly [number, number, number, number];
 }
 
 describe("CPU reference math catalog", () => {
@@ -42,14 +52,28 @@ describe("CPU reference math catalog", () => {
   });
 
   test("vector helpers define safe normalize and rotation behavior", () => {
-    const cases: readonly Vec2Case[] = [
+    const vec2Cases: readonly Vec2Case[] = [
       { name: "safeNormalize2 non-zero", actual: safeNormalize2Ref([3, 4], [1, 0]), expected: [0.6, 0.8] },
       { name: "safeNormalize2 zero fallback", actual: safeNormalize2Ref([0, 0], [1, 0]), expected: [1, 0] },
       { name: "rotate2d quarter turn", actual: rotate2dRef([1, 0], Math.PI / 2), expected: [0, 1] },
     ];
+    const vec3Cases: readonly Vec3Case[] = [
+      { name: "safeNormalize3 non-zero", actual: safeNormalize3Ref([2, 0, 0], [0, 1, 0]), expected: [1, 0, 0] },
+      { name: "safeNormalize3 zero fallback", actual: safeNormalize3Ref([0, 0, 0], [0, 1, 0]), expected: [0, 1, 0] },
+    ];
+    const vec4Cases: readonly Vec4Case[] = [
+      { name: "safeNormalize4 non-zero", actual: safeNormalize4Ref([0, 0, 0, 5], [0, 0, 1, 0]), expected: [0, 0, 0, 1] },
+      { name: "safeNormalize4 zero fallback", actual: safeNormalize4Ref([0, 0, 0, 0], [0, 0, 1, 0]), expected: [0, 0, 1, 0] },
+    ];
 
-    for (const { name, actual, expected } of cases) {
+    for (const { name, actual, expected } of vec2Cases) {
       expectVec2Close(actual, expected, name);
+    }
+    for (const { name, actual, expected } of vec3Cases) {
+      expectVec3Close(actual, expected, name);
+    }
+    for (const { name, actual, expected } of vec4Cases) {
+      expectVec4Close(actual, expected, name);
     }
   });
 });
@@ -148,6 +172,20 @@ function safeNormalize2Ref(value: readonly [number, number], fallback: readonly 
   return [value[0] * invLength, value[1] * invLength];
 }
 
+function safeNormalize3Ref(value: readonly [number, number, number], fallback: readonly [number, number, number]): [number, number, number] {
+  const lengthSq = value[0] * value[0] + value[1] * value[1] + value[2] * value[2];
+  if (lengthSq <= 0) return [fallback[0], fallback[1], fallback[2]];
+  const invLength = 1 / Math.sqrt(lengthSq);
+  return [value[0] * invLength, value[1] * invLength, value[2] * invLength];
+}
+
+function safeNormalize4Ref(value: readonly [number, number, number, number], fallback: readonly [number, number, number, number]): [number, number, number, number] {
+  const lengthSq = value[0] * value[0] + value[1] * value[1] + value[2] * value[2] + value[3] * value[3];
+  if (lengthSq <= 0) return [fallback[0], fallback[1], fallback[2], fallback[3]];
+  const invLength = 1 / Math.sqrt(lengthSq);
+  return [value[0] * invLength, value[1] * invLength, value[2] * invLength, value[3] * invLength];
+}
+
 function rotate2dRef(value: readonly [number, number], radians: number): [number, number] {
   const c = Math.cos(radians);
   const s = Math.sin(radians);
@@ -157,6 +195,19 @@ function rotate2dRef(value: readonly [number, number], radians: number): [number
 function expectVec2Close(actual: readonly [number, number], expected: readonly [number, number], name: string): void {
   expect.soft(actual[0], `${name}.x`).toBeCloseTo(expected[0], 6);
   expect.soft(actual[1], `${name}.y`).toBeCloseTo(expected[1], 6);
+}
+
+function expectVec3Close(actual: readonly [number, number, number], expected: readonly [number, number, number], name: string): void {
+  expect.soft(actual[0], `${name}.x`).toBeCloseTo(expected[0], 6);
+  expect.soft(actual[1], `${name}.y`).toBeCloseTo(expected[1], 6);
+  expect.soft(actual[2], `${name}.z`).toBeCloseTo(expected[2], 6);
+}
+
+function expectVec4Close(actual: readonly [number, number, number, number], expected: readonly [number, number, number, number], name: string): void {
+  expect.soft(actual[0], `${name}.x`).toBeCloseTo(expected[0], 6);
+  expect.soft(actual[1], `${name}.y`).toBeCloseTo(expected[1], 6);
+  expect.soft(actual[2], `${name}.z`).toBeCloseTo(expected[2], 6);
+  expect.soft(actual[3], `${name}.w`).toBeCloseTo(expected[3], 6);
 }
 
 async function runMathCompute(): Promise<Float32Array> {

--- a/packages/wgsl-std/tests/package-resolution.test.ts
+++ b/packages/wgsl-std/tests/package-resolution.test.ts
@@ -49,8 +49,9 @@ fn main() -> f32 {
   const compact = first.wgsl.replace(/\s+/gu, "");
   expect(compact).toMatch(/^fna\(\)->f32\{returnb\(1\.5\);\}/u);
   expect(compact).toContain("returnclamp(");
-  expect(compact).toContain("returnnormalize(");
-  expect(compact).toContain("returnvec2f(");
+  expect(compact).not.toContain("normalize(");
+  expect(compact).not.toContain("vec2f(");
+  expect(compact).not.toMatch(/inverseLerp|remap|safeNormalize|rotate2d/u);
 });
 
 async function workspaceFixture(): Promise<string> {

--- a/packages/wgsl-std/tests/package-resolution.test.ts
+++ b/packages/wgsl-std/tests/package-resolution.test.ts
@@ -7,10 +7,10 @@ import { resolveShader } from "@vgpu/wgsl/runtime";
 test("math and color package subpaths resolve through package exports", async () => {
   const dir = await workspaceFixture();
   const entry = join(dir, "app", "main.wgsl");
-  await writeFile(entry, `import { identityF32 } from "@vgpu/wgsl-std/math";
+  await writeFile(entry, `import { saturate } from "@vgpu/wgsl-std/math";
 import { identityVec3f } from "@vgpu/wgsl-std/color";
 fn main() -> vec3f {
-  return identityVec3f(vec3f(identityF32(1.0)));
+  return identityVec3f(vec3f(saturate(1.5)));
 }`);
 
   const result = await resolveShader({ entry, validate: false });
@@ -19,15 +19,15 @@ fn main() -> vec3f {
   expect(result.deps.some((dep) => dep.endsWith("node_modules/@vgpu/wgsl-std/src/color/index.wgsl"))).toBe(true);
   expect(result.wgsl).toContain("node_modules/@vgpu/wgsl-std/src/math/index.wgsl");
   expect(result.wgsl).toContain("node_modules/@vgpu/wgsl-std/src/color/index.wgsl");
-  expect(result.wgsl).toMatch(/fn _vgsl_[0-9a-f]{8}__identityF32\(value: f32\) -> f32/);
+  expect(result.wgsl).toMatch(/fn _vgsl_[0-9a-f]{8}__saturate\(value: f32\) -> f32/);
   expect(result.wgsl).toMatch(/fn _vgsl_[0-9a-f]{8}__identityVec3f\(value: vec3f\) -> vec3f/);
 });
 
 test("wgsl-std has no root WGSL export", async () => {
   const dir = await workspaceFixture();
   const entry = join(dir, "app", "main.wgsl");
-  await writeFile(entry, `import { identityF32 } from "@vgpu/wgsl-std";
-fn main() -> f32 { return identityF32(1.0); }`);
+  await writeFile(entry, `import { saturate } from "@vgpu/wgsl-std";
+fn main() -> f32 { return saturate(1.0); }`);
 
   await expect(resolveShader({ entry, validate: false })).rejects.toMatchObject({ code: "VGPU-WGSL-PKG-NOTFOUND" });
 });
@@ -35,9 +35,9 @@ fn main() -> f32 { return identityF32(1.0); }`);
 test("resolved wgsl-std output is deterministic when minified", async () => {
   const dir = await workspaceFixture();
   const entry = join(dir, "app", "main.wgsl");
-  await writeFile(entry, `import { identityF32 } from "@vgpu/wgsl-std/math";
+  await writeFile(entry, `import { saturate } from "@vgpu/wgsl-std/math";
 fn main() -> f32 {
-  return identityF32(0.5);
+  return saturate(1.5);
 }`);
 
   const first = await resolveShader({ entry, validate: false, minify: true });
@@ -46,7 +46,11 @@ fn main() -> f32 {
   expect(first.wgsl).toBe(second.wgsl);
   expect(first.wgsl).not.toContain("\n");
   expect(first.wgsl).not.toContain("//");
-  expect(first.wgsl.replace(/\s+/gu, "")).toMatch(/^fna\(\)->f32\{returnb\(0\.5\);\}fnb\(([a-z]+):f32\)->f32\{return\1;\}$/u);
+  const compact = first.wgsl.replace(/\s+/gu, "");
+  expect(compact).toMatch(/^fna\(\)->f32\{returnb\(1\.5\);\}/u);
+  expect(compact).toContain("returnclamp(");
+  expect(compact).toContain("returnnormalize(");
+  expect(compact).toContain("returnvec2f(");
 });
 
 async function workspaceFixture(): Promise<string> {


### PR DESCRIPTION
## Summary
- replace the math scaffold with pure WGSL scalar/range/vector helpers
- add docs for math utility behavior, zero-range remap/inverseLerp, zero-length safeNormalize fallbacks, and examples
- add resolver/minify/CPU-reference tests, with naga validation and compute parity behind VGPU_DOCKER_TEST

## Utilities
- saturate
- clamp01
- inverseLerp
- remap
- safeNormalize2 / safeNormalize3 / safeNormalize4 (explicit names because WGSL has no user-defined overloads/generics)
- rotate2d

## Validation
- pnpm exec vitest run packages/wgsl-std/tests/math.test.ts packages/wgsl-std/tests/package-resolution.test.ts packages/wgsl-std/tests/purity.test.ts
- pnpm exec tsc -b
- pnpm run build
- pnpm exec vitest run packages/wgsl-std packages/wgsl

TDD evidence: math expectation tests were added before implementation and initially failed with missing exports (saturate etc.); implementation then made focused tests pass. Initial wgsl+wgsl-std run before build failed only because packages/wgsl/dist/loader-webpack/index.js was absent; after build, the same command passed.

Session: 55357873-e4c0-4f8d-9a8d-fa8ae35311bc