### PR TITLE
Add wgsl-std color utilities

### DIFF
--- a/packages/wgsl-std/README.md
+++ b/packages/wgsl-std/README.md
@@ -6,7 +6,7 @@ This package intentionally ships raw `.wgsl` modules instead of JavaScript wrapp
 
 ```wgsl
 import { saturate, remap, safeNormalize3, rotate2d } from "@vgpu/wgsl-std/math";
-import { identityVec3f } from "@vgpu/wgsl-std/color";
+import { srgbToLinear3, linearToSrgb3, luminance, applyExposure } from "@vgpu/wgsl-std/color";
 ```
 
 There is no root WGSL export. Subpath exports resolve to physical WGSL files:
@@ -29,4 +29,19 @@ WGSL snippets in this package must stay pure declaration modules: functions, con
 
 See `src/math/index.docs.md` for examples and edge-case notes.
 
-The color module currently contains only the scaffold identity helper; the reviewed color utility catalog is planned for a later slice.
+## Color utilities
+
+`@vgpu/wgsl-std/color` includes non-PBR color helpers:
+
+- `srgbToLinear(value: f32) -> f32`: standard IEC/sRGB decode transfer for one channel.
+- `srgbToLinear3(color: vec3f) -> vec3f`: decode RGB channels from sRGB to linear light.
+- `srgbToLinear4(color: vec4f) -> vec4f`: decode RGB channels and preserve alpha.
+- `linearToSrgb(value: f32) -> f32`: standard IEC/sRGB encode transfer for one channel.
+- `linearToSrgb3(color: vec3f) -> vec3f`: encode RGB channels from linear light to sRGB.
+- `linearToSrgb4(color: vec4f) -> vec4f`: encode RGB channels and preserve alpha.
+- `luminance(color: vec3f) -> f32`: relative luminance using Rec.709/sRGB coefficients `(0.2126, 0.7152, 0.0722)`. Pass linear-light color.
+- `applyExposure(color: vec3f, exposure: f32) -> vec3f`: multiply by `exp2(exposure)`, where exposure is measured in stops/EV.
+
+WGSL has no user-defined generics, so vector transfer helpers use `3`/`4` suffixes while scalar transfer helpers keep the base names. Color transfer helpers expect normal `[0.0, 1.0]` color-channel inputs but do not clamp; clamp explicitly with `@vgpu/wgsl-std/math` when desired. The color module intentionally defers PBR helpers and tonemappers (ACES/Hable/Filament/Reinhard) so applications choose their own display transform.
+
+See `src/color/index.docs.md` for formulas, examples, and performance notes.

--- a/packages/wgsl-std/src/color/index.docs.md
+++ b/packages/wgsl-std/src/color/index.docs.md
@@ -1,5 +1,72 @@
 # @vgpu/wgsl-std/color
 
-Raw WGSL color utility module for `@vgpu/wgsl` imports.
+Raw WGSL color utility module for `@vgpu/wgsl` imports. The module contains pure declarations only: no bindings, overrides, hidden state, or entry points.
 
-This scaffold exports `identityVec3f` only to exercise package resolution. The full color utility catalog is intentionally deferred to the color slice.
+```wgsl
+import { srgbToLinear3, linearToSrgb3, luminance, applyExposure } from "@vgpu/wgsl-std/color";
+
+fn shade(baseColorSrgb: vec3f, exposureStops: f32) -> vec3f {
+  let linear = srgbToLinear3(baseColorSrgb);
+  let exposed = applyExposure(linear, exposureStops);
+  return linearToSrgb3(exposed);
+}
+```
+
+## API
+
+WGSL has no user-defined generics, so v1 uses an explicit dimensional suffix for vector transfer helpers and unsuffixed scalar helpers:
+
+- `srgbToLinear(value: f32) -> f32`
+- `srgbToLinear3(color: vec3f) -> vec3f`
+- `srgbToLinear4(color: vec4f) -> vec4f`
+- `linearToSrgb(value: f32) -> f32`
+- `linearToSrgb3(color: vec3f) -> vec3f`
+- `linearToSrgb4(color: vec4f) -> vec4f`
+- `luminance(color: vec3f) -> f32`
+- `applyExposure(color: vec3f, exposure: f32) -> vec3f`
+
+The `vec4f` transfer helpers convert RGB channels and preserve alpha unchanged.
+
+## sRGB transfer functions
+
+`srgbToLinear*` and `linearToSrgb*` implement the standard IEC/sRGB piecewise transfer formulas:
+
+```text
+srgbToLinear(c) = c / 12.92                         when c <= 0.04045
+                = ((c + 0.055) / 1.055) ^ 2.4       otherwise
+
+linearToSrgb(c) = 12.92 * c                         when c <= 0.0031308
+                = 1.055 * c ^ (1 / 2.4) - 0.055     otherwise
+```
+
+The expected input and output range is `[0.0, 1.0]` for color channels. These helpers do **not** clamp inputs or outputs; callers that need display-range saturation should import `saturate` or `clamp01` from `@vgpu/wgsl-std/math` explicitly.
+
+## Luminance
+
+`luminance(color)` returns relative luminance for a linear RGB color using Rec.709/sRGB coefficients:
+
+```text
+dot(color, vec3f(0.2126, 0.7152, 0.0722))
+```
+
+Pass linear-light color values. If your source is sRGB encoded, decode with `srgbToLinear3` before computing luminance.
+
+## Exposure
+
+`applyExposure(color, exposure)` treats `exposure` as photographic stops/EV and returns:
+
+```text
+color * exp2(exposure)
+```
+
+Examples: `0.0` leaves the color unchanged, `1.0` doubles it, and `-2.0` multiplies it by `0.25`. The function is intentionally unclamped so HDR pipelines can keep values above `1.0` until an explicit later display transform.
+
+## Performance notes
+
+- Scalar transfer helpers branch once and use `pow` only above the sRGB breakpoint.
+- Vector transfer helpers call the scalar helper per RGB channel. This keeps behavior identical for scalar and vector paths and avoids hidden approximation tables.
+- `luminance` is a single dot product; `applyExposure` is a scalar `exp2` and vector multiply.
+
+## Deferred helpers
+
+This v1 color module intentionally does not include PBR helpers, BRDF/Fresnel/IBL routines, ACES/Hable/Filament tonemappers, or a default tonemap. Tonemapping and PBR-specific utilities are deferred so applications choose their own display transform and resource model explicitly.

--- a/packages/wgsl-std/src/color/index.wgsl
+++ b/packages/wgsl-std/src/color/index.wgsl
@@ -1,3 +1,37 @@
-export fn identityVec3f(value: vec3f) -> vec3f {
-  return value;
+export fn luminance(value: vec3f) -> f32 {
+  return dot(value, vec3f(0.2126, 0.7152, 0.0722));
+}
+
+export fn applyExposure(value: vec3f, exposure: f32) -> vec3f {
+  return value * exp2(exposure);
+}
+
+export fn srgbToLinear(value: f32) -> f32 {
+  if (value <= 0.04045) {
+    return value / 12.92;
+  }
+  return pow((value + 0.055) / 1.055, 2.4);
+}
+
+export fn srgbToLinear3(value: vec3f) -> vec3f {
+  return vec3f(srgbToLinear(value.r), srgbToLinear(value.g), srgbToLinear(value.b));
+}
+
+export fn srgbToLinear4(value: vec4f) -> vec4f {
+  return vec4f(srgbToLinear3(value.rgb), value.a);
+}
+
+export fn linearToSrgb(value: f32) -> f32 {
+  if (value <= 0.0031308) {
+    return value * 12.92;
+  }
+  return 1.055 * pow(value, 1.0 / 2.4) - 0.055;
+}
+
+export fn linearToSrgb3(value: vec3f) -> vec3f {
+  return vec3f(linearToSrgb(value.r), linearToSrgb(value.g), linearToSrgb(value.b));
+}
+
+export fn linearToSrgb4(value: vec4f) -> vec4f {
+  return vec4f(linearToSrgb3(value.rgb), value.a);
 }

--- a/packages/wgsl-std/tests/color.test.ts
+++ b/packages/wgsl-std/tests/color.test.ts
@@ -1,0 +1,219 @@
+import { mkdir, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { describe, expect, test } from "vitest";
+import { resolveShader } from "@vgpu/wgsl/runtime";
+
+const dockerTest = process.env.VGPU_DOCKER_TEST === "1";
+
+interface ScalarCase {
+  readonly name: string;
+  readonly actual: number;
+  readonly expected: number;
+}
+
+interface Vec3Case {
+  readonly name: string;
+  readonly actual: readonly [number, number, number];
+  readonly expected: readonly [number, number, number];
+}
+
+interface Vec4Case {
+  readonly name: string;
+  readonly actual: readonly [number, number, number, number];
+  readonly expected: readonly [number, number, number, number];
+}
+
+describe("CPU reference color catalog", () => {
+  test("sRGB transfer helpers match standard known values and round trips", () => {
+    const scalarCases: readonly ScalarCase[] = [
+      { name: "srgbToLinear black", actual: srgbToLinearRef(0), expected: 0 },
+      { name: "srgbToLinear breakpoint", actual: srgbToLinearRef(0.04045), expected: 0.0031308049535603713 },
+      { name: "srgbToLinear half", actual: srgbToLinearRef(0.5), expected: 0.21404114048223255 },
+      { name: "srgbToLinear white", actual: srgbToLinearRef(1), expected: 1 },
+      { name: "linearToSrgb black", actual: linearToSrgbRef(0), expected: 0 },
+      { name: "linearToSrgb breakpoint", actual: linearToSrgbRef(0.0031308), expected: 0.040449936 },
+      { name: "linearToSrgb half", actual: linearToSrgbRef(0.5), expected: 0.7353569830524495 },
+      { name: "linearToSrgb white", actual: linearToSrgbRef(1), expected: 0.9999999999999999 },
+      { name: "srgbToLinear is unclamped below range", actual: srgbToLinearRef(-0.5), expected: -0.5 / 12.92 },
+      { name: "linearToSrgb is unclamped below range", actual: linearToSrgbRef(-0.01), expected: -0.1292 },
+    ];
+
+    for (const { name, actual, expected } of scalarCases) {
+      expect.soft(actual, name).toBeCloseTo(expected, 8);
+    }
+
+    for (const value of [0, 0.0031308, 0.18, 0.5, 1]) {
+      expect.soft(srgbToLinearRef(linearToSrgbRef(value)), `linear roundtrip ${value}`).toBeCloseTo(value, 6);
+    }
+    for (const value of [0, 0.04045, 0.25, 0.5, 1]) {
+      expect.soft(linearToSrgbRef(srgbToLinearRef(value)), `srgb roundtrip ${value}`).toBeCloseTo(value, 6);
+    }
+  });
+
+  test("vector sRGB helpers apply transfer functions per channel", () => {
+    const vec3Cases: readonly Vec3Case[] = [
+      { name: "srgbToLinear3", actual: srgbToLinear3Ref([0, 0.5, 1]), expected: [0, 0.21404114048223255, 1] },
+      { name: "linearToSrgb3", actual: linearToSrgb3Ref([0, 0.18, 1]), expected: [0, 0.46135612950044164, 0.9999999999999999] },
+    ];
+    const vec4Cases: readonly Vec4Case[] = [
+      { name: "srgbToLinear4 preserves alpha", actual: srgbToLinear4Ref([0, 0.5, 1, 0.25]), expected: [0, 0.21404114048223255, 1, 0.25] },
+      { name: "linearToSrgb4 preserves alpha", actual: linearToSrgb4Ref([0, 0.18, 1, 0.25]), expected: [0, 0.46135612950044164, 0.9999999999999999, 0.25] },
+    ];
+
+    for (const { name, actual, expected } of vec3Cases) {
+      expectVec3Close(actual, expected, name);
+    }
+    for (const { name, actual, expected } of vec4Cases) {
+      expectVec4Close(actual, expected, name);
+    }
+  });
+
+  test("luminance and exposure helpers use documented color-space conventions", () => {
+    const cases: readonly ScalarCase[] = [
+      { name: "luminance red", actual: luminanceRef([1, 0, 0]), expected: 0.2126 },
+      { name: "luminance green", actual: luminanceRef([0, 1, 0]), expected: 0.7152 },
+      { name: "luminance blue", actual: luminanceRef([0, 0, 1]), expected: 0.0722 },
+      { name: "luminance white", actual: luminanceRef([1, 1, 1]), expected: 1 },
+    ];
+    for (const { name, actual, expected } of cases) {
+      expect.soft(actual, name).toBeCloseTo(expected, 6);
+    }
+
+    expectVec3Close(applyExposureRef([0.18, 0.5, 1], 0), [0.18, 0.5, 1], "exposure zero");
+    expectVec3Close(applyExposureRef([0.18, 0.5, 1], 1), [0.36, 1, 2], "exposure +1 stop");
+    expectVec3Close(applyExposureRef([0.18, 0.5, 1], -2), [0.045, 0.125, 0.25], "exposure -2 stops");
+  });
+});
+
+test("color helpers resolve from @vgpu/wgsl-std/color and produce valid declarations", async () => {
+  const dir = await workspaceFixture();
+  const entry = join(dir, "app", "main.wgsl");
+  await writeFile(entry, `import { srgbToLinear, srgbToLinear3, srgbToLinear4, linearToSrgb, linearToSrgb3, linearToSrgb4, luminance, applyExposure } from "@vgpu/wgsl-std/color";
+fn main() -> vec4f {
+  let c = srgbToLinear3(vec3f(0.5, 0.25, 1.0));
+  let a = srgbToLinear4(vec4f(0.5, 0.25, 1.0, 0.75)).a;
+  let encoded = linearToSrgb3(applyExposure(c, 1.0));
+  let scalar = srgbToLinear(0.5) + linearToSrgb(0.18) + luminance(c) + linearToSrgb4(vec4f(c, a)).a;
+  return vec4f(encoded, scalar);
+}`);
+
+  const result = await resolveShader({ entry, validate: false });
+
+  expect(result.deps.some((dep) => dep.endsWith("node_modules/@vgpu/wgsl-std/src/color/index.wgsl"))).toBe(true);
+  for (const name of ["srgbToLinear", "srgbToLinear3", "srgbToLinear4", "linearToSrgb", "linearToSrgb3", "linearToSrgb4", "luminance", "applyExposure"]) {
+    expect.soft(result.wgsl, name).toMatch(new RegExp(`fn _vgsl_[0-9a-f]{8}__${name}\\(`, "u"));
+  }
+  expect(result.wgsl).not.toContain("identityVec3f");
+});
+
+test("single color helper import resolves deterministically", async () => {
+  const dir = await workspaceFixture();
+  const entry = join(dir, "app", "main.wgsl");
+  await writeFile(entry, `import { luminance } from "@vgpu/wgsl-std/color";
+fn main() -> f32 {
+  return luminance(vec3f(1.0, 1.0, 1.0));
+}`);
+
+  const first = await resolveShader({ entry, validate: false, minify: true });
+  const second = await resolveShader({ entry, validate: false, minify: true });
+
+  expect(first.wgsl).toBe(second.wgsl);
+  expect(first.wgsl).toContain("dot(");
+  expect(first.wgsl).not.toContain("\n");
+  expect(first.wgsl).not.toContain("//");
+});
+
+test("color helper minified output is deterministic", async () => {
+  const dir = await workspaceFixture();
+  const entry = join(dir, "app", "main.wgsl");
+  await writeFile(entry, `import { srgbToLinear3, luminance } from "@vgpu/wgsl-std/color";
+fn main() -> f32 {
+  return luminance(srgbToLinear3(vec3f(0.5, 0.25, 1.0)));
+}`);
+
+  const first = await resolveShader({ entry, validate: false, minify: true });
+  const second = await resolveShader({ entry, validate: false, minify: true });
+
+  expect(first.wgsl).toBe(second.wgsl);
+  expect(first.wgsl).not.toContain("\n");
+  expect(first.wgsl).not.toContain("//");
+  expect(first.wgsl).toContain("pow(");
+  expect(first.wgsl).toContain("dot(");
+});
+
+test.skipIf(!dockerTest)("resolved color utility shader validates with naga", async () => {
+  const dir = await workspaceFixture();
+  const entry = join(dir, "app", "main.wgsl");
+  await writeFile(entry, `import { srgbToLinear3, linearToSrgb3, luminance, applyExposure } from "@vgpu/wgsl-std/color";
+@compute @workgroup_size(1)
+fn main() {
+  let linear = srgbToLinear3(vec3f(0.5, 0.25, 1.0));
+  let exposed = applyExposure(linear, 1.0);
+  let encoded = linearToSrgb3(exposed);
+  let value = luminance(encoded);
+}`);
+
+  await expect(resolveShader({ entry })).resolves.toHaveProperty("wgsl");
+});
+
+function srgbToLinearRef(value: number): number {
+  if (value <= 0.04045) return value / 12.92;
+  return Math.pow((value + 0.055) / 1.055, 2.4);
+}
+
+function linearToSrgbRef(value: number): number {
+  if (value <= 0.0031308) return value * 12.92;
+  return 1.055 * Math.pow(value, 1 / 2.4) - 0.055;
+}
+
+function srgbToLinear3Ref(value: readonly [number, number, number]): [number, number, number] {
+  return [srgbToLinearRef(value[0]), srgbToLinearRef(value[1]), srgbToLinearRef(value[2])];
+}
+
+function srgbToLinear4Ref(value: readonly [number, number, number, number]): [number, number, number, number] {
+  return [srgbToLinearRef(value[0]), srgbToLinearRef(value[1]), srgbToLinearRef(value[2]), value[3]];
+}
+
+function linearToSrgb3Ref(value: readonly [number, number, number]): [number, number, number] {
+  return [linearToSrgbRef(value[0]), linearToSrgbRef(value[1]), linearToSrgbRef(value[2])];
+}
+
+function linearToSrgb4Ref(value: readonly [number, number, number, number]): [number, number, number, number] {
+  return [linearToSrgbRef(value[0]), linearToSrgbRef(value[1]), linearToSrgbRef(value[2]), value[3]];
+}
+
+function luminanceRef(value: readonly [number, number, number]): number {
+  return value[0] * 0.2126 + value[1] * 0.7152 + value[2] * 0.0722;
+}
+
+function applyExposureRef(value: readonly [number, number, number], exposure: number): [number, number, number] {
+  const scale = Math.pow(2, exposure);
+  return [value[0] * scale, value[1] * scale, value[2] * scale];
+}
+
+function expectVec3Close(actual: readonly [number, number, number], expected: readonly [number, number, number], name: string): void {
+  expect.soft(actual[0], `${name}.x`).toBeCloseTo(expected[0], 6);
+  expect.soft(actual[1], `${name}.y`).toBeCloseTo(expected[1], 6);
+  expect.soft(actual[2], `${name}.z`).toBeCloseTo(expected[2], 6);
+}
+
+function expectVec4Close(actual: readonly [number, number, number, number], expected: readonly [number, number, number, number], name: string): void {
+  expect.soft(actual[0], `${name}.x`).toBeCloseTo(expected[0], 6);
+  expect.soft(actual[1], `${name}.y`).toBeCloseTo(expected[1], 6);
+  expect.soft(actual[2], `${name}.z`).toBeCloseTo(expected[2], 6);
+  expect.soft(actual[3], `${name}.w`).toBeCloseTo(expected[3], 6);
+}
+
+async function workspaceFixture(): Promise<string> {
+  const dir = await mkdirTemp();
+  await mkdir(join(dir, "app"), { recursive: true });
+  await mkdir(join(dir, "node_modules", "@vgpu"), { recursive: true });
+  await symlink(resolve("packages/wgsl-std"), join(dir, "node_modules", "@vgpu", "wgsl-std"), "dir");
+  return dir;
+}
+
+async function mkdirTemp(): Promise<string> {
+  const { mkdtemp } = await import("node:fs/promises");
+  return mkdtemp(join(tmpdir(), "vgpu-wgsl-std-"));
+}

--- a/packages/wgsl-std/tests/package-resolution.test.ts
+++ b/packages/wgsl-std/tests/package-resolution.test.ts
@@ -8,9 +8,9 @@ test("math and color package subpaths resolve through package exports", async ()
   const dir = await workspaceFixture();
   const entry = join(dir, "app", "main.wgsl");
   await writeFile(entry, `import { saturate } from "@vgpu/wgsl-std/math";
-import { identityVec3f } from "@vgpu/wgsl-std/color";
-fn main() -> vec3f {
-  return identityVec3f(vec3f(saturate(1.5)));
+import { luminance } from "@vgpu/wgsl-std/color";
+fn main() -> f32 {
+  return luminance(vec3f(saturate(1.5)));
 }`);
 
   const result = await resolveShader({ entry, validate: false });
@@ -20,7 +20,7 @@ fn main() -> vec3f {
   expect(result.wgsl).toContain("node_modules/@vgpu/wgsl-std/src/math/index.wgsl");
   expect(result.wgsl).toContain("node_modules/@vgpu/wgsl-std/src/color/index.wgsl");
   expect(result.wgsl).toMatch(/fn _vgsl_[0-9a-f]{8}__saturate\(value: f32\) -> f32/);
-  expect(result.wgsl).toMatch(/fn _vgsl_[0-9a-f]{8}__identityVec3f\(value: vec3f\) -> vec3f/);
+  expect(result.wgsl).toMatch(/fn _vgsl_[0-9a-f]{8}__luminance\(value: vec3f\) -> f32/);
 });
 
 test("wgsl-std has no root WGSL export", async () => {


### PR DESCRIPTION
## Summary
- replace the scaffold color identity helper with pure WGSL non-PBR color utilities
- add sRGB transfer, luminance, and exposure CPU/reference resolver tests
- document formulas, unclamped behavior, exposure convention, and deferred tonemaps/PBR helpers

## API
- `srgbToLinear(value: f32) -> f32`
- `srgbToLinear3(value: vec3f) -> vec3f`
- `srgbToLinear4(value: vec4f) -> vec4f`
- `linearToSrgb(value: f32) -> f32`
- `linearToSrgb3(value: vec3f) -> vec3f`
- `linearToSrgb4(value: vec4f) -> vec4f`
- `luminance(value: vec3f) -> f32`
- `applyExposure(value: vec3f, exposure: f32) -> vec3f`

## Testing
- `pnpm vitest run packages/wgsl-std/tests`
- `pnpm build`
- `pnpm typecheck`
- `pnpm vitest run packages/wgsl packages/wgsl-std`

Notes: Docker/native validation tests remain gated by `VGPU_DOCKER_TEST=1`. Initial `pnpm vitest run packages/wgsl packages/wgsl-std` failed before build because `packages/wgsl/dist/loader-webpack/index.js` was absent; after `pnpm build`, the same command passed.