### PR TITLE
Add homepage-safe render pipeline APIs

### DIFF
--- a/.changeset/homepage-safe-render-apis.md
+++ b/.changeset/homepage-safe-render-apis.md
@@ -1,0 +1,6 @@
+---
+"@vgpu/core": minor
+"@vgpu/render": minor
+---
+
+Add descriptor-like render pipeline options, async render pipeline creation with explicit fallback policy, and mock GPU instrumentation for homepage-safe render hot-path tests. Document raw `.gpu` escape hatches, Frame's one-encoder/one-submit contract, render bundle resize lifecycle caveats, and render hot-path caveats.

--- a/.changeset/homepage-safe-render-apis.md
+++ b/.changeset/homepage-safe-render-apis.md
@@ -3,4 +3,4 @@
 "@vgpu/render": minor
 ---
 
-Add descriptor-like render pipeline options, async render pipeline creation with explicit fallback policy, and mock GPU instrumentation for homepage-safe render hot-path tests. Document raw `.gpu` escape hatches, Frame's one-encoder/one-submit contract, render bundle resize lifecycle caveats, and render hot-path caveats.
+Add descriptor-like render pipeline options and async render pipeline creation with explicit fallback policy. The `@vgpu/core` minor covers formal mock GPU test utilities: async render-pipeline mock support plus mock device instrumentation for validating homepage-safe render hot paths. Documentation now calls out raw `.gpu` escape hatches, Frame's one-encoder/one-submit contract, render bundle rebuild lifecycle caveats, and render hot-path caveats.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Agentic-first WebGPU library. Run the same code on Node (Dawn), the web (browser
 | Package | What it is |
 | --- | --- |
 | [`@vgpu/core`](./packages/core/README.md) | Core runtime primitives for devices, buffers, textures, shaders, queues, and app bootstrapping. |
-| [`@vgpu/render`](./packages/render/README.md) | Minimal render-pipeline and render-pass helpers built on top of `@vgpu/core`. |
+| [`@vgpu/render`](./packages/render/README.md) | Minimal render-pipeline, `Frame`, render-bundle, and `RapidRenderer` helpers; `RapidRenderer` is for simple draws/examples, not production multipass or bundle-heavy hot paths. |
 | [`@vgpu/wgsl`](./packages/wgsl/README.md) | WGSL compile helpers plus runtime resolution and webpack/vite integration points. |
 | [`@vgpu/wgsl-std`](./packages/wgsl-std/README.md) | Standard WGSL utility modules for math, color, and sampling helpers. |
 | [`@vgpu/adapter-mock`](./packages/adapter-mock/README.md) | Mock adapter for tests and local validation without real GPU hardware. |

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -6,7 +6,8 @@ export { Shader } from "./shader.ts";
 export { Texture } from "./texture.ts";
 export { VGPUError, ValidationError } from "./errors.ts";
 export { bind, createBindGroup, createBindGroupLayout, createPipelineLayout, createSampler } from "./bind.ts";
-export { createMockGPUDevice } from "./mockGpu.ts";
+export { createMockGPUDevice, getMockGPUDeviceInstrumentation } from "./mockGpu.ts";
+export type { MockGPUDeviceInstrumentation } from "./mockGpu.ts";
 export type { AppCreateOptions, AppInstance, VGPUAdapter } from "./app-types.ts";
 export type {
   BufferOptions,

--- a/packages/core/src/mockGpu.ts
+++ b/packages/core/src/mockGpu.ts
@@ -1,11 +1,38 @@
 import { bufferUsageFlags } from "./gpuConstants.ts";
 import { isMockGPUBuffer, type MockGPUBuffer, type MockGPUTexture } from "./mock-gpu-storage.ts";
 
+export interface MockGPUDeviceInstrumentation {
+  readonly calls: {
+    createBuffer: number;
+    createBindGroup: number;
+    createCommandEncoder: number;
+    createRenderBundleEncoder: number;
+    createRenderPipeline: number;
+    createRenderPipelineAsync: number;
+  };
+  readonly createBufferDescriptors: GPUBufferDescriptor[];
+  readonly createBindGroupDescriptors: GPUBindGroupDescriptor[];
+  readonly createCommandEncoderDescriptors: GPUCommandEncoderDescriptor[];
+  readonly createRenderBundleEncoderDescriptors: GPURenderBundleEncoderDescriptor[];
+  readonly createRenderPipelineDescriptors: GPURenderPipelineDescriptor[];
+  readonly createRenderPipelineAsyncDescriptors: GPURenderPipelineDescriptor[];
+}
+
+const mockInstrumentationKey = "__vgpuMockInstrumentation";
+
+type InstrumentedGPUDevice = GPUDevice & { [mockInstrumentationKey]?: MockGPUDeviceInstrumentation };
+
 export function createMockGPUDevice(): GPUDevice {
-  return {
+  const instrumentation = createMockGPUDeviceInstrumentation();
+  const device: InstrumentedGPUDevice = {
+    [mockInstrumentationKey]: instrumentation,
     limits: createMockSupportedLimits(),
     features: createMockSupportedFeatures(),
-    createBuffer: createMockBuffer,
+    createBuffer(desc: GPUBufferDescriptor): MockGPUBuffer {
+      instrumentation.calls.createBuffer += 1;
+      instrumentation.createBufferDescriptors.push(desc);
+      return createMockBuffer(desc);
+    },
     createTexture(desc: GPUTextureDescriptor): MockGPUTexture {
       const size = textureSize(desc.size);
       const bytes = new Uint8Array(size.width * size.height * 4);
@@ -28,17 +55,46 @@ export function createMockGPUDevice(): GPUDevice {
     createShaderModule: () => ({}) as GPUShaderModule,
     createBindGroupLayout: () => ({}) as GPUBindGroupLayout,
     createPipelineLayout: () => ({}) as GPUPipelineLayout,
-    createBindGroup: () => ({}) as GPUBindGroup,
+    createBindGroup(desc: GPUBindGroupDescriptor): GPUBindGroup {
+      instrumentation.calls.createBindGroup += 1;
+      instrumentation.createBindGroupDescriptors.push(desc);
+      return {} as GPUBindGroup;
+    },
     createSampler: () => ({}) as GPUSampler,
-    createRenderPipeline: () => ({}) as GPURenderPipeline,
-    createCommandEncoder() {
+    createRenderPipeline(desc: GPURenderPipelineDescriptor): GPURenderPipeline {
+      instrumentation.calls.createRenderPipeline += 1;
+      instrumentation.createRenderPipelineDescriptors.push(desc);
+      return {} as GPURenderPipeline;
+    },
+    async createRenderPipelineAsync(desc: GPURenderPipelineDescriptor): Promise<GPURenderPipeline> {
+      instrumentation.calls.createRenderPipelineAsync += 1;
+      instrumentation.createRenderPipelineAsyncDescriptors.push(desc);
+      return {} as GPURenderPipeline;
+    },
+    createRenderBundleEncoder(desc: GPURenderBundleEncoderDescriptor): GPURenderBundleEncoder {
+      instrumentation.calls.createRenderBundleEncoder += 1;
+      instrumentation.createRenderBundleEncoderDescriptors.push(desc);
+      return {
+        setPipeline() {},
+        setBindGroup() {},
+        setVertexBuffer() {},
+        setIndexBuffer() {},
+        draw() {},
+        drawIndexed() {},
+        finish: () => ({} as GPURenderBundle),
+      // Mock render bundle encoder: only state/draw/finish methods used by render tests are implemented.
+      } as unknown as GPURenderBundleEncoder;
+    },
+    createCommandEncoder(desc: GPUCommandEncoderDescriptor = {}): GPUCommandEncoder {
+      instrumentation.calls.createCommandEncoder += 1;
+      instrumentation.createCommandEncoderDescriptors.push(desc);
       return {
         copyBufferToBuffer() {},
         copyTextureToBuffer() {},
-        // Mock render pass encoder: only binding/pipeline/draw/end methods used by tests are implemented.
-        beginRenderPass: () => ({ setBindGroup() {}, setVertexBuffer() {}, setPipeline() {}, draw() {}, end() {} }) as unknown as GPURenderPassEncoder,
+        // Mock render pass encoder: only binding/pipeline/draw/bundle/end methods used by tests are implemented.
+        beginRenderPass: () => ({ setBindGroup() {}, setVertexBuffer() {}, setPipeline() {}, executeBundles() {}, draw() {}, end() {} }) as unknown as GPURenderPassEncoder,
         finish: () => ({}),
-      // Mock command encoder: only copy/render/finish methods used by core are implemented.
+      // Mock command encoder: only copy/render/finish methods used by core/render are implemented.
       } as unknown as GPUCommandEncoder;
     },
     destroy() {},
@@ -50,11 +106,39 @@ export function createMockGPUDevice(): GPUDevice {
       onSubmittedWorkDone: async () => undefined,
     },
   // Mock device: shape is intentionally partial but covers every member used by adapters/tests.
-  } as unknown as GPUDevice;
+  } as unknown as InstrumentedGPUDevice;
+  return device;
+}
+
+export function getMockGPUDeviceInstrumentation(device: GPUDevice): MockGPUDeviceInstrumentation {
+  const instrumentation = (device as InstrumentedGPUDevice)[mockInstrumentationKey];
+  if (!instrumentation) {
+    throw new Error("GPUDevice was not created by createMockGPUDevice()");
+  }
+  return instrumentation;
 }
 
 export function mockBufferDescriptor(size: number): GPUBufferDescriptor {
   return { size, usage: bufferUsageFlags(["copy_src", "copy_dst"]) };
+}
+
+function createMockGPUDeviceInstrumentation(): MockGPUDeviceInstrumentation {
+  return {
+    calls: {
+      createBuffer: 0,
+      createBindGroup: 0,
+      createCommandEncoder: 0,
+      createRenderBundleEncoder: 0,
+      createRenderPipeline: 0,
+      createRenderPipelineAsync: 0,
+    },
+    createBufferDescriptors: [],
+    createBindGroupDescriptors: [],
+    createCommandEncoderDescriptors: [],
+    createRenderBundleEncoderDescriptors: [],
+    createRenderPipelineDescriptors: [],
+    createRenderPipelineAsyncDescriptors: [],
+  };
 }
 
 function createMockSupportedLimits(): GPUSupportedLimits {

--- a/packages/render/README.md
+++ b/packages/render/README.md
@@ -17,6 +17,7 @@ pnpm add @vgpu/render
 - `RenderPass`
 - `beginFrame` / `Frame`
 - `createRenderBundle` / `RenderBundleRecorder`
+- `RapidRenderer`
 
 ### Types
 - `RenderPipelineOptions`
@@ -56,6 +57,23 @@ pass.setPipeline(pipeline);
 pass.draw(3);
 pass.end(); // finishes and submits this one-shot pass
 ```
+
+## Rapid renderer
+
+`RapidRenderer` is available for examples and simple one-draw submissions:
+
+```ts
+import { RapidRenderer } from "@vgpu/render";
+
+const renderer = new RapidRenderer(device);
+material.writeUniforms({ viewProjection, model, cameraPosition, light });
+await renderer.draw({ material, mesh, target, depthTarget });
+```
+
+For homepage-grade hot paths, do not resolve shaders or rebuild pipelines inside
+the animation-frame path. If shader source truly changes dynamically, resolve and
+create the replacement pipeline outside the frame loop, then stage or
+double-buffer the swap so a completed pipeline is installed at a frame boundary.
 
 ## Explicit multipass frame
 
@@ -117,7 +135,7 @@ frame.submit(); // finishes once and submits once
 
 `Frame` preserves authored ordering and exposes its raw `GPUCommandEncoder` as `frame.gpu` for advanced commands. Direct raw encoder calls follow WebGPU behavior; VGPU helper methods guard use after `submit()` with `VGPU-FRAME-SUBMITTED`.
 
-For homepage-grade hot paths, create pipelines (sync or async), buffers, bind groups, and render bundles during setup/warmup or resize, then keep per-frame code to command encoding and one queue submit. `createRenderPipelineAsync()` defaults to `fallback: "sync"` with a once-only diagnostic when native async creation is unavailable; use `fallback: "throw"` if warmup must fail rather than block.
+For homepage-grade hot paths, create pipelines (sync or async), buffers, bind groups, and render bundles during setup/warmup or resize, then keep per-frame code to command encoding and one queue submit. `createRenderPipelineAsync()` defaults to `fallback: "sync"` with a once-only diagnostic when native async creation is unavailable; use `fallback: "throw"` if warmup must fail rather than block. Avoid runtime `resolveShader()`/shader creation in frame loops; dynamically changing shader source should be resolved and pipelined off the frame path, with staged or double-buffered swaps at frame boundaries.
 
 Raw `.gpu` properties such as `device.gpu`, `queue.gpu`, `buffer.gpu`, `texture.gpu`, `shader.gpu`, `frame.gpu`, and `RenderBundleRecorder.gpu` are intentional advanced escape hatches to native WebGPU objects and are treated as semver-protected public API. Native WebGPU validation and lifecycle rules still apply when using them directly.
 

--- a/packages/render/README.md
+++ b/packages/render/README.md
@@ -13,7 +13,7 @@ pnpm add @vgpu/render
 ## Exports
 
 ### Runtime
-- `createRenderPipeline`
+- `createRenderPipeline` / `createRenderPipelineAsync`
 - `RenderPass`
 - `beginFrame` / `Frame`
 - `createRenderBundle` / `RenderBundleRecorder`
@@ -116,6 +116,10 @@ frame.submit(); // finishes once and submits once
 ```
 
 `Frame` preserves authored ordering and exposes its raw `GPUCommandEncoder` as `frame.gpu` for advanced commands. Direct raw encoder calls follow WebGPU behavior; VGPU helper methods guard use after `submit()` with `VGPU-FRAME-SUBMITTED`.
+
+For homepage-grade hot paths, create pipelines (sync or async), buffers, bind groups, and render bundles during setup/warmup or resize, then keep per-frame code to command encoding and one queue submit. `createRenderPipelineAsync()` defaults to `fallback: "sync"` with a once-only diagnostic when native async creation is unavailable; use `fallback: "throw"` if warmup must fail rather than block.
+
+Raw `.gpu` properties such as `device.gpu`, `queue.gpu`, `buffer.gpu`, `texture.gpu`, `shader.gpu`, `frame.gpu`, and `RenderBundleRecorder.gpu` are intentional advanced escape hatches to native WebGPU objects and are treated as semver-protected public API. Native WebGPU validation and lifecycle rules still apply when using them directly.
 
 ## License
 

--- a/packages/render/src/Frame.docs.md
+++ b/packages/render/src/Frame.docs.md
@@ -35,7 +35,10 @@ device.queue.gpu.submit([encoder.finish()]);
 ## With VGPU Frame
 
 `Frame` keeps that same lifecycle: one encoder, explicit pass order, finish once,
-submit once.
+submit once. This one-encoder/one-submit contract is intentional for homepage-style
+multipass renderers: setup and warmup should create pipelines, buffers, bind
+groups, and bundles up front; the per-frame path should only encode commands and
+submit the finished command buffer.
 
 ```ts
 const frame = beginFrame(device, { label: "hero.frame" });
@@ -64,8 +67,9 @@ the only submission point.
 
 The raw command encoder is available as `frame.gpu` for WebGPU operations that
 are intentionally not wrapped, such as `writeTimestamp()` or `resolveQuerySet()`.
-Direct raw encoder calls follow native WebGPU behavior; VGPU only guards its own
-helper methods after `submit()`.
+This is an advanced, semver-protected public escape hatch. Direct raw encoder
+calls follow native WebGPU behavior; VGPU only guards its own helper methods
+after `submit()`.
 
 `copyBufferToBuffer(source, destination, size, sourceOffset?, destinationOffset?)`
 is a small typed helper that accepts either core `Buffer` instances or raw

--- a/packages/render/src/createRenderPipeline.docs.md
+++ b/packages/render/src/createRenderPipeline.docs.md
@@ -1,34 +1,94 @@
-# createRenderPipeline
+# createRenderPipeline / createRenderPipelineAsync
 
-Creates a GPU render pipeline from a vgpu `Shader` plus vertex and fragment
-entry points. Returns a raw `GPURenderPipeline` with no wrapper.
+Creates a GPU render pipeline from descriptor-like VGPU options. Both helpers
+return a raw `GPURenderPipeline` with no wrapper so the result can be passed
+directly to native WebGPU, `RenderPass.setPipeline()`, or render-bundle recording.
 
-## Signature
+## Signatures
 
-`createRenderPipeline(device: Device, opts: RenderPipelineOptions): GPURenderPipeline`
+```ts
+createRenderPipeline(device: Device, opts: RenderPipelineOptions): GPURenderPipeline
+createRenderPipelineAsync(device: Device, opts: RenderPipelineOptions): Promise<GPURenderPipeline>
+```
+
+`createRenderPipelineAsync` calls `GPUDevice.createRenderPipelineAsync()` when it
+exists. If the implementation does not expose the async API, the default
+compatibility policy is `fallback: "sync"`, which emits a once-only diagnostic and
+calls `createRenderPipeline()` instead. Performance-critical warmup can pass
+`fallback: "throw"` to receive a structured `VGPUError` with code
+`VGPU-RENDER-PIPELINE-ASYNC-UNAVAILABLE` instead of accidentally blocking.
+
+VGPU does not cache pipelines: one helper call equals one WebGPU device call.
+Keep pipeline caches explicit and owned by the caller.
 
 ## Options
 
-- `shader`: the `Shader` whose compiled GPU module will back both stages.
-- `vertex.entry`: the vertex shader entry-point name.
-- `fragment.entry`: the fragment shader entry-point name.
-- `fragment.targets`: the color target formats and blend/write settings.
-- `primitive`: optional WebGPU primitive state such as topology or culling.
-- `layout`: optional pipeline layout, or `"auto"` to let WebGPU derive one.
+- `shader`: optional shared `Shader` or raw `GPUShaderModule` used by stages that
+  do not provide their own module.
+- `vertex`: vertex stage options.
+  - `shader` / `module`: optional per-stage `Shader` or raw `GPUShaderModule`.
+  - `entry` / `entryPoint`: vertex entry-point name.
+  - `buffers`: optional vertex buffer layouts and attributes.
+  - `constants`: optional pipeline constants.
+- `fragment`: optional fragment stage options.
+  - `shader` / `module`: optional per-stage `Shader` or raw `GPUShaderModule`.
+  - `entry` / `entryPoint`: fragment entry-point name.
+  - `targets`: color target formats plus blend and write-mask state.
+  - `constants`: optional pipeline constants.
+- `primitive`: optional WebGPU primitive state.
+- `depthStencil`: optional depth/stencil state.
+- `multisample`: optional multisample state.
+- `layout`: explicit `GPUPipelineLayout`, or `"auto"`. Defaults to `"auto"`.
 - `label`: optional debug label forwarded to WebGPU.
+- `fallback`: async-only fallback policy, `"sync"` or `"throw"`.
 
-## Example
+## Examples
+
+Shared VGPU `Shader` module:
 
 ```ts
-const pipeline = createRenderPipeline(device, {
+const pipeline = await createRenderPipelineAsync(device, {
+  label: "hero.pipeline",
+  fallback: "throw",
   shader,
-  vertex: { entry: "vs_main" },
-  fragment: { entry: "fs_main", targets: [{ format: "rgba8unorm" }] },
-  primitive: { topology: "triangle-list" },
+  layout: explicitPipelineLayout,
+  vertex: {
+    entry: "vs_main",
+    buffers: [{
+      arrayStride: 16,
+      attributes: [{ shaderLocation: 0, offset: 0, format: "float32x4" }],
+    }],
+  },
+  fragment: {
+    entry: "fs_main",
+    targets: [{
+      format,
+      blend: {
+        color: { operation: "add", srcFactor: "one", dstFactor: "one-minus-src-alpha" },
+        alpha: { operation: "add", srcFactor: "one", dstFactor: "one-minus-src-alpha" },
+      },
+      writeMask: 0xf,
+    }],
+  },
+  primitive: { topology: "triangle-list", cullMode: "back" },
+  depthStencil: { format: "depth24plus", depthWriteEnabled: true, depthCompare: "less" },
+  multisample: { count: 4 },
 });
 ```
 
-## Notes
+Raw shader modules and per-stage constants:
 
-The returned `GPURenderPipeline` can be used directly with WebGPU APIs or
-passed to `RenderPass.setPipeline`.
+```ts
+const pipeline = createRenderPipeline(device, {
+  layout: "auto",
+  vertex: { module: vertexModule, entryPoint: "vs", constants: { scale: 2 } },
+  fragment: { module: fragmentModule, entryPoint: "fs", targets: [{ format }] },
+});
+```
+
+## Raw escape hatch
+
+`Shader.gpu` is an intentional advanced escape hatch to the underlying
+`GPUShaderModule`. It is part of VGPU's public API surface and should be treated
+as semver-protected, but direct native WebGPU usage remains responsible for
+native WebGPU validation and lifecycle rules.

--- a/packages/render/src/index.ts
+++ b/packages/render/src/index.ts
@@ -1,6 +1,6 @@
 export { beginFrame, Frame } from "./frame.ts";
 export { createRenderBundle, RenderBundleRecorder } from "./render-bundle.ts";
-export { createRenderPipeline } from "./pipeline.ts";
+export { createRenderPipeline, createRenderPipelineAsync } from "./pipeline.ts";
 export { RenderPass } from "./render-pass.ts";
 export { RapidRenderer } from "./rapid-renderer.ts";
 export { UniformPool } from "./uniform-pool.ts";

--- a/packages/render/src/index.ts
+++ b/packages/render/src/index.ts
@@ -6,7 +6,14 @@ export { RapidRenderer } from "./rapid-renderer.ts";
 export { UniformPool } from "./uniform-pool.ts";
 export type { FrameOptions, FrameRenderPassCallback } from "./frame.ts";
 export type { RenderBundleOptions } from "./render-bundle.ts";
-export type { RenderPipelineOptions } from "./pipeline.ts";
+export type {
+  RenderPipelineAsyncFallback,
+  RenderPipelineFragmentOptions,
+  RenderPipelineOptions,
+  RenderPipelineShaderInput,
+  RenderPipelineStageOptions,
+  RenderPipelineVertexOptions,
+} from "./pipeline.ts";
 export type { DrawSpec } from "./rapid-renderer.ts";
 export type { UniformLayout, UniformPoolOptions, UniformSlot } from "./uniform-pool-types.ts";
 export type {

--- a/packages/render/src/pipeline.ts
+++ b/packages/render/src/pipeline.ts
@@ -1,4 +1,4 @@
-import { VGPUError, type Device, type Shader } from "@vgpu/core";
+import { Shader, VGPUError, type Device } from "@vgpu/core";
 
 export type RenderPipelineShaderInput = Shader | GPUShaderModule;
 export type RenderPipelineAsyncFallback = "sync" | "throw";
@@ -37,6 +37,9 @@ export interface RenderPipelineOptions {
   readonly fallback?: RenderPipelineAsyncFallback;
 }
 
+// Warn once per JS process. This keeps compatibility fallback visible without spamming
+// apps that intentionally warm up multiple pipelines on implementations without
+// GPUDevice.createRenderPipelineAsync().
 let didWarnAboutAsyncFallback = false;
 
 export function createRenderPipeline(device: Device, opts: RenderPipelineOptions): GPURenderPipeline {
@@ -69,7 +72,7 @@ function toRenderPipelineDescriptor(opts: RenderPipelineOptions): GPURenderPipel
     layout: opts.layout ?? "auto",
     vertex: {
       module: stageModule(opts.vertex, opts.shader, "vertex"),
-      entryPoint: stageEntryPoint(opts.vertex, "vertex"),
+      entryPoint: stageEntryPoint(opts.vertex),
       constants: opts.vertex.constants,
       buffers: opts.vertex.buffers ? [...opts.vertex.buffers] : undefined,
     },
@@ -81,7 +84,7 @@ function toRenderPipelineDescriptor(opts: RenderPipelineOptions): GPURenderPipel
   if (opts.fragment) {
     descriptor.fragment = {
       module: stageModule(opts.fragment, opts.shader, "fragment"),
-      entryPoint: stageEntryPoint(opts.fragment, "fragment"),
+      entryPoint: stageEntryPoint(opts.fragment),
       constants: opts.fragment.constants,
       targets: [...opts.fragment.targets],
     };
@@ -103,21 +106,16 @@ function stageModule(stage: RenderPipelineStageOptions, fallback: RenderPipeline
   return isShader(module) ? module.gpu : module;
 }
 
-function stageEntryPoint(stage: RenderPipelineStageOptions, stageName: "vertex" | "fragment"): string {
-  const entryPoint = stage.entryPoint ?? stage.entry;
-  if (!entryPoint) {
-    throw new VGPUError({
-      code: "VGPU-RENDER-PIPELINE-MISSING-ENTRY-POINT",
-      message: `Missing entry point for ${stageName} stage.`,
-      fix: "Pass entry or entryPoint on the render pipeline stage options.",
-      where: `createRenderPipeline.${stageName}`,
-    });
-  }
-  return entryPoint;
+function stageEntryPoint(stage: RenderPipelineStageOptions): string | undefined {
+  return stage.entryPoint ?? stage.entry;
 }
 
 function isShader(input: RenderPipelineShaderInput): input is Shader {
-  return typeof input === "object" && input !== null && "gpu" in input;
+  return input instanceof Shader;
+}
+
+export function __resetCreateRenderPipelineAsyncFallbackWarningForTests(): void {
+  didWarnAboutAsyncFallback = false;
 }
 
 function warnAsyncFallbackOnce(): void {

--- a/packages/render/src/pipeline.ts
+++ b/packages/render/src/pipeline.ts
@@ -1,20 +1,129 @@
-import type { Device, Shader } from "@vgpu/core";
+import { VGPUError, type Device, type Shader } from "@vgpu/core";
 
-export interface RenderPipelineOptions {
-  readonly shader: Shader;
-  readonly vertex: { readonly entry: string };
-  readonly fragment: { readonly entry: string; readonly targets: readonly GPUColorTargetState[] };
-  readonly primitive?: GPUPrimitiveState;
-  readonly layout?: GPUPipelineLayout | "auto";
-  readonly label?: string;
+export type RenderPipelineShaderInput = Shader | GPUShaderModule;
+export type RenderPipelineAsyncFallback = "sync" | "throw";
+
+export interface RenderPipelineStageOptions {
+  /** VGPU Shader or raw GPUShaderModule for this stage. Defaults to RenderPipelineOptions.shader. */
+  readonly shader?: RenderPipelineShaderInput;
+  /** Descriptor-like alias for shader. */
+  readonly module?: RenderPipelineShaderInput;
+  /** Entry-point name. Kept for backwards compatibility with the first render helper API. */
+  readonly entry?: string;
+  /** Descriptor-like entry-point name. */
+  readonly entryPoint?: string;
+  readonly constants?: Record<string, GPUPipelineConstantValue>;
 }
 
+export interface RenderPipelineVertexOptions extends RenderPipelineStageOptions {
+  readonly buffers?: readonly (GPUVertexBufferLayout | null)[];
+}
+
+export interface RenderPipelineFragmentOptions extends RenderPipelineStageOptions {
+  readonly targets: readonly (GPUColorTargetState | null)[];
+}
+
+export interface RenderPipelineOptions {
+  /** Optional shared shader module used by vertex/fragment stages that do not provide their own module. */
+  readonly shader?: RenderPipelineShaderInput;
+  readonly vertex: RenderPipelineVertexOptions;
+  readonly fragment?: RenderPipelineFragmentOptions;
+  readonly primitive?: GPUPrimitiveState;
+  readonly depthStencil?: GPUDepthStencilState;
+  readonly multisample?: GPUMultisampleState;
+  readonly layout?: GPUPipelineLayout | "auto";
+  readonly label?: string;
+  /** createRenderPipelineAsync fallback when GPUDevice.createRenderPipelineAsync is unavailable. Defaults to "sync". */
+  readonly fallback?: RenderPipelineAsyncFallback;
+}
+
+let didWarnAboutAsyncFallback = false;
+
 export function createRenderPipeline(device: Device, opts: RenderPipelineOptions): GPURenderPipeline {
-  return device.gpu.createRenderPipeline({
+  return device.gpu.createRenderPipeline(toRenderPipelineDescriptor(opts));
+}
+
+export async function createRenderPipelineAsync(device: Device, opts: RenderPipelineOptions): Promise<GPURenderPipeline> {
+  const descriptor = toRenderPipelineDescriptor(opts);
+  const createAsync = device.gpu.createRenderPipelineAsync;
+  if (typeof createAsync === "function") {
+    return createAsync.call(device.gpu, descriptor);
+  }
+
+  if ((opts.fallback ?? "sync") === "throw") {
+    throw new VGPUError({
+      code: "VGPU-RENDER-PIPELINE-ASYNC-UNAVAILABLE",
+      message: "GPUDevice.createRenderPipelineAsync is unavailable on this WebGPU implementation.",
+      fix: "Use fallback: 'sync' for compatibility or call createRenderPipeline() explicitly during setup/warmup.",
+      where: "createRenderPipelineAsync",
+    });
+  }
+
+  warnAsyncFallbackOnce();
+  return device.gpu.createRenderPipeline(descriptor);
+}
+
+function toRenderPipelineDescriptor(opts: RenderPipelineOptions): GPURenderPipelineDescriptor {
+  const descriptor: GPURenderPipelineDescriptor = {
     label: opts.label,
     layout: opts.layout ?? "auto",
-    vertex: { module: opts.shader.gpu, entryPoint: opts.vertex.entry },
-    fragment: { module: opts.shader.gpu, entryPoint: opts.fragment.entry, targets: [...opts.fragment.targets] },
+    vertex: {
+      module: stageModule(opts.vertex, opts.shader, "vertex"),
+      entryPoint: stageEntryPoint(opts.vertex, "vertex"),
+      constants: opts.vertex.constants,
+      buffers: opts.vertex.buffers ? [...opts.vertex.buffers] : undefined,
+    },
     primitive: opts.primitive,
-  });
+    depthStencil: opts.depthStencil,
+    multisample: opts.multisample,
+  };
+
+  if (opts.fragment) {
+    descriptor.fragment = {
+      module: stageModule(opts.fragment, opts.shader, "fragment"),
+      entryPoint: stageEntryPoint(opts.fragment, "fragment"),
+      constants: opts.fragment.constants,
+      targets: [...opts.fragment.targets],
+    };
+  }
+
+  return descriptor;
+}
+
+function stageModule(stage: RenderPipelineStageOptions, fallback: RenderPipelineShaderInput | undefined, stageName: "vertex" | "fragment"): GPUShaderModule {
+  const module = stage.module ?? stage.shader ?? fallback;
+  if (!module) {
+    throw new VGPUError({
+      code: "VGPU-RENDER-PIPELINE-MISSING-SHADER",
+      message: `Missing shader module for ${stageName} stage.`,
+      fix: "Pass options.shader for a shared module or pass vertex/fragment module or shader.",
+      where: `createRenderPipeline.${stageName}`,
+    });
+  }
+  return isShader(module) ? module.gpu : module;
+}
+
+function stageEntryPoint(stage: RenderPipelineStageOptions, stageName: "vertex" | "fragment"): string {
+  const entryPoint = stage.entryPoint ?? stage.entry;
+  if (!entryPoint) {
+    throw new VGPUError({
+      code: "VGPU-RENDER-PIPELINE-MISSING-ENTRY-POINT",
+      message: `Missing entry point for ${stageName} stage.`,
+      fix: "Pass entry or entryPoint on the render pipeline stage options.",
+      where: `createRenderPipeline.${stageName}`,
+    });
+  }
+  return entryPoint;
+}
+
+function isShader(input: RenderPipelineShaderInput): input is Shader {
+  return typeof input === "object" && input !== null && "gpu" in input;
+}
+
+function warnAsyncFallbackOnce(): void {
+  if (didWarnAboutAsyncFallback) return;
+  didWarnAboutAsyncFallback = true;
+  globalThis.console?.warn?.(
+    "[vgpu/render] createRenderPipelineAsync is unavailable; falling back to synchronous createRenderPipeline(). Pass fallback: 'throw' to make this a structured VGPUError.",
+  );
 }

--- a/packages/render/src/rapid-renderer.docs.md
+++ b/packages/render/src/rapid-renderer.docs.md
@@ -24,5 +24,9 @@ semver-protected public escape hatch. `draw()` resolves after command submission
 homepage hot-path work. For performance-critical renderers, keep pipeline,
 buffer, bind-group, and render-bundle creation in setup/warmup code. Similarly,
 `material().writeUniforms()` writes CPU-side uniform data for later upload and
-should be scheduled deliberately, and runtime `resolveShader()`/shader creation
-belongs outside animation-frame loops unless the shader source really changed.
+should be scheduled deliberately.
+
+Do not resolve shaders, compile shaders, or rebuild pipelines inside the animation
+frame path. If shader source truly changes dynamically, resolve the shader and
+create the replacement pipeline outside the frame loop, then stage or
+double-buffer the swap so a completed pipeline is installed at a frame boundary.

--- a/packages/render/src/rapid-renderer.docs.md
+++ b/packages/render/src/rapid-renderer.docs.md
@@ -15,4 +15,14 @@ material has uniforms. The renderer does not write camera, transform, light, or
 material parameters.
 
 `clearValue` defaults to opaque black. `depthTarget` is optional. `renderer.gpu`
-returns the raw `GPUDevice`. `draw()` resolves after command submission.
+returns the raw `GPUDevice`. Like other `.gpu` fields, this is an advanced,
+semver-protected public escape hatch. `draw()` resolves after command submission.
+
+## Hot-path caveats
+
+`RapidRenderer` is optimized for examples and simple draws, not for hiding all
+homepage hot-path work. For performance-critical renderers, keep pipeline,
+buffer, bind-group, and render-bundle creation in setup/warmup code. Similarly,
+`material().writeUniforms()` writes CPU-side uniform data for later upload and
+should be scheduled deliberately, and runtime `resolveShader()`/shader creation
+belongs outside animation-frame loops unless the shader source really changed.

--- a/packages/render/src/render-bundle.docs.md
+++ b/packages/render/src/render-bundle.docs.md
@@ -37,10 +37,10 @@ methods for `setPipeline`, `setBindGroup`, `setVertexBuffer`, and `draw`. The ra
 underlying `GPURenderBundleEncoder`.
 
 Create bundles during setup or resize, not in the per-frame hot path. A bundle is
-compatible with the attachment formats, depth/stencil format, sample count, and
-read-only flags it was recorded with. If a resize changes target format/sample
-state or other bundle-compatible state, rebuild the affected bundles before the
-next frame.
+compatible with the `colorFormats`, `depthStencilFormat`, `sampleCount`,
+`depthReadOnly`, and `stencilReadOnly` values it was recorded with. If resize or
+render-target reconfiguration changes any of those bundle-compatible fields,
+re-record the affected bundles before the next frame.
 
 VGPU preserves explicit pipeline, layout, and bind-group control. Bundle helpers
 never infer layouts and do not switch to `layout: "auto"` for performance.

--- a/packages/render/src/render-bundle.docs.md
+++ b/packages/render/src/render-bundle.docs.md
@@ -32,7 +32,15 @@ Options mirror the required parts of `GPURenderBundleEncoderDescriptor`:
 `colorFormats`, optional `depthStencilFormat`, optional `sampleCount`, and the
 optional depth/stencil read-only flags. The `record` callback receives a
 `RenderBundleRecorder` wrapper with `gpu` escape-hatch access plus convenience
-methods for `setPipeline`, `setBindGroup`, `setVertexBuffer`, and `draw`.
+methods for `setPipeline`, `setBindGroup`, `setVertexBuffer`, and `draw`. The raw
+`bundle.gpu` recorder is an advanced, semver-protected public escape hatch to the
+underlying `GPURenderBundleEncoder`.
+
+Create bundles during setup or resize, not in the per-frame hot path. A bundle is
+compatible with the attachment formats, depth/stencil format, sample count, and
+read-only flags it was recorded with. If a resize changes target format/sample
+state or other bundle-compatible state, rebuild the affected bundles before the
+next frame.
 
 VGPU preserves explicit pipeline, layout, and bind-group control. Bundle helpers
 never infer layouts and do not switch to `layout: "auto"` for performance.

--- a/packages/render/tests/frame.test.ts
+++ b/packages/render/tests/frame.test.ts
@@ -1,6 +1,6 @@
 import { expect, test, vi } from "vitest";
 import { createMockAdapter } from "@vgpu/adapter-mock";
-import { App, getMockGPUDeviceInstrumentation, type Device, type Shader } from "@vgpu/core";
+import { App, getMockGPUDeviceInstrumentation, type Device } from "@vgpu/core";
 import { beginFrame, createRenderBundle, createRenderPipeline } from "@vgpu/render";
 
 interface RecordedRenderPass {
@@ -80,7 +80,10 @@ test("copyBufferToBuffer unwraps buffers and writes to the frame encoder", async
 
 test("homepage-grade frame keeps setup resources out of the per-frame hot path", async () => {
   const { device } = await App.create({ adapter: createMockAdapter() });
-  const shader = { gpu: device.gpu.createShaderModule({ label: "hero.shader", code: "" }) } as Shader;
+  const shader = device.createShader(`
+@vertex fn vs_main() -> @builtin(position) vec4f { return vec4f(); }
+@fragment fn fs_main() -> @location(0) vec4f { return vec4f(); }
+`);
   const pipeline = createRenderPipeline(device, {
     label: "hero.pipeline",
     shader,
@@ -136,6 +139,7 @@ test("homepage-grade frame keeps setup resources out of the per-frame hot path",
     return count + ((executedBundles as GPURenderBundle[] | undefined)?.length ?? 0);
   }, 0);
   expect(executedBundleCount).toBe(5);
+  expect(commandEncoder.copyBufferToBuffer).toHaveBeenCalledTimes(1);
   expect(commandEncoder.copyBufferToBuffer).toHaveBeenCalledWith(buffers[0]!.gpu, 0, buffers[1]!.gpu, 0, 16);
   expect(submit).toHaveBeenCalledTimes(1);
   expect(frameCounts.createRenderPipeline).toBe(setupCounts.createRenderPipeline);

--- a/packages/render/tests/frame.test.ts
+++ b/packages/render/tests/frame.test.ts
@@ -1,7 +1,7 @@
 import { expect, test, vi } from "vitest";
 import { createMockAdapter } from "@vgpu/adapter-mock";
-import { App, type Device } from "@vgpu/core";
-import { beginFrame } from "@vgpu/render";
+import { App, getMockGPUDeviceInstrumentation, type Device, type Shader } from "@vgpu/core";
+import { beginFrame, createRenderBundle, createRenderPipeline } from "@vgpu/render";
 
 interface RecordedRenderPass {
   readonly setPipeline: ReturnType<typeof vi.fn>;
@@ -75,6 +75,73 @@ test("copyBufferToBuffer unwraps buffers and writes to the frame encoder", async
   frame.copyBufferToBuffer(src, dst, 8, 4, 2);
 
   expect(commandEncoder.copyBufferToBuffer).toHaveBeenCalledWith(src.gpu, 4, dst.gpu, 2, 8);
+  device.destroy();
+});
+
+test("homepage-grade frame keeps setup resources out of the per-frame hot path", async () => {
+  const { device } = await App.create({ adapter: createMockAdapter() });
+  const shader = { gpu: device.gpu.createShaderModule({ label: "hero.shader", code: "" }) } as Shader;
+  const pipeline = createRenderPipeline(device, {
+    label: "hero.pipeline",
+    shader,
+    vertex: { entry: "vs_main" },
+    fragment: { entry: "fs_main", targets: [{ format: "rgba8unorm" }] },
+  });
+  const buffers = Array.from({ length: 2 }, (_, index) => device.createBuffer({ label: `hero.buffer.${index}`, size: 16, usage: ["vertex"] }));
+  const bindGroups = Array.from({ length: 2 }, (_, index) => device.gpu.createBindGroup({ label: `hero.bindGroup.${index}`, layout: {} as GPUBindGroupLayout, entries: [] }));
+  const bundles = Array.from({ length: 5 }, (_, index) => createRenderBundle(device, {
+    label: `hero.bundle.${index}`,
+    colorFormats: ["rgba8unorm"],
+    record(bundle) {
+      bundle.setPipeline(pipeline);
+      bundle.setBindGroup(0, bindGroups[index % bindGroups.length] ?? null);
+      bundle.setVertexBuffer(0, buffers[index % buffers.length]?.gpu ?? null);
+      bundle.draw(3);
+    },
+  }));
+  const setupCounts = { ...getMockGPUDeviceInstrumentation(device.gpu).calls };
+  const passEncoders: RecordedRenderPass[] = [];
+  const commandEncoder = {
+    beginRenderPass: vi.fn(() => {
+      const passEncoder: RecordedRenderPass = {
+        setPipeline: vi.fn(),
+        setBindGroup: vi.fn(),
+        setVertexBuffer: vi.fn(),
+        executeBundles: vi.fn(),
+        draw: vi.fn(),
+        end: vi.fn(),
+      };
+      passEncoders.push(passEncoder);
+      return passEncoder as unknown as GPURenderPassEncoder;
+    }),
+    copyBufferToBuffer: vi.fn(),
+    finish: vi.fn(() => "hero-command-buffer" as unknown as GPUCommandBuffer),
+  } as unknown as GPUCommandEncoder & { readonly beginRenderPass: ReturnType<typeof vi.fn>; readonly copyBufferToBuffer: ReturnType<typeof vi.fn>; readonly finish: ReturnType<typeof vi.fn> };
+  device.gpu.createCommandEncoder = vi.fn(() => commandEncoder);
+  const submit = vi.fn();
+  device.queue.gpu.submit = submit;
+
+  const frame = beginFrame(device, { label: "hero.frame" });
+  frame.renderPass({ label: "light", colorAttachments: [colorAttachment()] }, (pass) => pass.executeBundles([bundles[0]!, bundles[1]!]));
+  frame.gpu.copyBufferToBuffer(buffers[0]!.gpu, 0, buffers[1]!.gpu, 0, 16);
+  frame.renderPass({ label: "scene", colorAttachments: [colorAttachment()] }, (pass) => pass.executeBundles([bundles[2]!, bundles[3]!]));
+  frame.renderPass({ label: "composite", colorAttachments: [colorAttachment()] }, (pass) => pass.executeBundles([bundles[4]!]));
+  frame.submit();
+
+  const frameCounts = getMockGPUDeviceInstrumentation(device.gpu).calls;
+  expect(device.gpu.createCommandEncoder).toHaveBeenCalledTimes(1);
+  expect(commandEncoder.beginRenderPass).toHaveBeenCalledTimes(3);
+  const executedBundleCount = passEncoders.reduce((count, pass) => {
+    const [executedBundles] = pass.executeBundles.mock.calls[0] ?? [];
+    return count + ((executedBundles as GPURenderBundle[] | undefined)?.length ?? 0);
+  }, 0);
+  expect(executedBundleCount).toBe(5);
+  expect(commandEncoder.copyBufferToBuffer).toHaveBeenCalledWith(buffers[0]!.gpu, 0, buffers[1]!.gpu, 0, 16);
+  expect(submit).toHaveBeenCalledTimes(1);
+  expect(frameCounts.createRenderPipeline).toBe(setupCounts.createRenderPipeline);
+  expect(frameCounts.createBuffer).toBe(setupCounts.createBuffer);
+  expect(frameCounts.createBindGroup).toBe(setupCounts.createBindGroup);
+  expect(frameCounts.createRenderBundleEncoder).toBe(setupCounts.createRenderBundleEncoder);
   device.destroy();
 });
 

--- a/packages/render/tests/pipeline.test.ts
+++ b/packages/render/tests/pipeline.test.ts
@@ -1,14 +1,17 @@
 import { expect, test, vi } from "vitest";
 import { Device, VGPUError, createMockGPUDevice, getMockGPUDeviceInstrumentation, type Shader } from "@vgpu/core";
 import { createRenderPipeline, createRenderPipelineAsync } from "@vgpu/render";
+import { __resetCreateRenderPipelineAsyncFallbackWarningForTests } from "../src/pipeline.ts";
 
 function makeDevice(): Device {
   return new Device(createMockGPUDevice(), null);
 }
 
-function makeShader(device: Device, label = "shader"): Shader {
-  const module = device.gpu.createShaderModule({ label, code: "" });
-  return { gpu: module } as Shader;
+function makeShader(device: Device, _label = "shader"): Shader {
+  return device.createShader(`
+@vertex fn vs_main() -> @builtin(position) vec4f { return vec4f(); }
+@fragment fn fs_main() -> @location(0) vec4f { return vec4f(); }
+`);
 }
 
 test("createRenderPipeline and createRenderPipelineAsync build parity descriptors", async () => {
@@ -69,6 +72,22 @@ test("accepts raw GPUShaderModule and per-stage Shader modules with constants", 
   device.destroy();
 });
 
+test("forwards omitted entry points as undefined for WebGPU inference", async () => {
+  const device = makeDevice();
+  const shader = makeShader(device);
+
+  createRenderPipeline(device, {
+    shader,
+    vertex: {},
+    fragment: { targets: [{ format: "rgba8unorm" }] },
+  });
+
+  const [descriptor] = getMockGPUDeviceInstrumentation(device.gpu).createRenderPipelineDescriptors;
+  expect(descriptor.vertex.entryPoint).toBeUndefined();
+  expect(descriptor.fragment?.entryPoint).toBeUndefined();
+  device.destroy();
+});
+
 test("does not cache hidden render pipelines", async () => {
   const device = makeDevice();
   const shader = makeShader(device);
@@ -86,6 +105,7 @@ test("does not cache hidden render pipelines", async () => {
 });
 
 test("createRenderPipelineAsync falls back to sync once with a diagnostic by default", async () => {
+  __resetCreateRenderPipelineAsyncFallbackWarningForTests();
   const gpu = createMockGPUDevice();
   (gpu as { createRenderPipelineAsync?: GPUDevice["createRenderPipelineAsync"] }).createRenderPipelineAsync = undefined;
   const device = new Device(gpu, null);

--- a/packages/render/tests/pipeline.test.ts
+++ b/packages/render/tests/pipeline.test.ts
@@ -88,6 +88,25 @@ test("forwards omitted entry points as undefined for WebGPU inference", async ()
   device.destroy();
 });
 
+test("throws VGPUError when shader module is missing", () => {
+  const device = makeDevice();
+
+  try {
+    createRenderPipeline(device, {
+      vertex: { entry: "vs" },
+      fragment: { entry: "fs", targets: [{ format: "rgba8unorm" }] },
+    });
+    expect.fail("expected missing shader to throw");
+  } catch (error) {
+    expect(error).toBeInstanceOf(VGPUError);
+    expect(error).toMatchObject({
+      code: "VGPU-RENDER-PIPELINE-MISSING-SHADER",
+      where: "createRenderPipeline.vertex",
+    });
+  }
+  device.destroy();
+});
+
 test("does not cache hidden render pipelines", async () => {
   const device = makeDevice();
   const shader = makeShader(device);

--- a/packages/render/tests/pipeline.test.ts
+++ b/packages/render/tests/pipeline.test.ts
@@ -1,0 +1,131 @@
+import { expect, test, vi } from "vitest";
+import { Device, VGPUError, createMockGPUDevice, getMockGPUDeviceInstrumentation, type Shader } from "@vgpu/core";
+import { createRenderPipeline, createRenderPipelineAsync } from "@vgpu/render";
+
+function makeDevice(): Device {
+  return new Device(createMockGPUDevice(), null);
+}
+
+function makeShader(device: Device, label = "shader"): Shader {
+  const module = device.gpu.createShaderModule({ label, code: "" });
+  return { gpu: module } as Shader;
+}
+
+test("createRenderPipeline and createRenderPipelineAsync build parity descriptors", async () => {
+  const device = makeDevice();
+  const shader = makeShader(device);
+  const opts = {
+    label: "hero.pipeline",
+    shader,
+    layout: "auto" as const,
+    vertex: {
+      entry: "vs_main",
+      buffers: [{ arrayStride: 16, attributes: [{ shaderLocation: 0, offset: 0, format: "float32x4" as const }] }],
+    },
+    fragment: {
+      entry: "fs_main",
+      targets: [{ format: "rgba8unorm" as const, blend: { color: { operation: "add" as const, srcFactor: "one" as const, dstFactor: "one-minus-src-alpha" as const }, alpha: { operation: "add" as const, srcFactor: "one" as const, dstFactor: "one-minus-src-alpha" as const } }, writeMask: 0x1 | 0x2 }],
+    },
+    primitive: { topology: "triangle-list" as const, cullMode: "back" as const },
+    depthStencil: { format: "depth24plus" as const, depthWriteEnabled: true, depthCompare: "less" as const },
+    multisample: { count: 4, mask: 0xffffffff, alphaToCoverageEnabled: true },
+  };
+
+  createRenderPipeline(device, opts);
+  await createRenderPipelineAsync(device, opts);
+
+  const mock = getMockGPUDeviceInstrumentation(device.gpu);
+  expect(mock.calls.createRenderPipeline).toBe(1);
+  expect(mock.calls.createRenderPipelineAsync).toBe(1);
+  expect(mock.createRenderPipelineDescriptors[0]).toEqual(mock.createRenderPipelineAsyncDescriptors[0]);
+  expect(mock.createRenderPipelineDescriptors[0]).toMatchObject({
+    label: "hero.pipeline",
+    layout: "auto",
+    vertex: { module: shader.gpu, entryPoint: "vs_main", buffers: opts.vertex.buffers },
+    fragment: { module: shader.gpu, entryPoint: "fs_main", targets: opts.fragment.targets },
+    primitive: opts.primitive,
+    depthStencil: opts.depthStencil,
+    multisample: opts.multisample,
+  });
+  device.destroy();
+});
+
+test("accepts raw GPUShaderModule and per-stage Shader modules with constants", async () => {
+  const device = makeDevice();
+  const vertexModule = device.gpu.createShaderModule({ label: "vertex", code: "" });
+  const fragmentShader = makeShader(device, "fragment");
+
+  await createRenderPipelineAsync(device, {
+    label: "mixed-modules",
+    layout: device.gpu.createPipelineLayout({ bindGroupLayouts: [] }),
+    vertex: { module: vertexModule, entryPoint: "vs", constants: { scale: 2 } },
+    fragment: { shader: fragmentShader, entryPoint: "fs", constants: { enabled: true }, targets: [{ format: "bgra8unorm", writeMask: 0xf }] },
+  });
+
+  const [descriptor] = getMockGPUDeviceInstrumentation(device.gpu).createRenderPipelineAsyncDescriptors;
+  expect(descriptor.vertex).toMatchObject({ module: vertexModule, entryPoint: "vs", constants: { scale: 2 } });
+  expect(descriptor.fragment).toMatchObject({ module: fragmentShader.gpu, entryPoint: "fs", constants: { enabled: true }, targets: [{ format: "bgra8unorm", writeMask: 0xf }] });
+  expect(descriptor.layout).not.toBe("auto");
+  device.destroy();
+});
+
+test("does not cache hidden render pipelines", async () => {
+  const device = makeDevice();
+  const shader = makeShader(device);
+  const opts = { shader, vertex: { entry: "vs" }, fragment: { entry: "fs", targets: [{ format: "rgba8unorm" as const }] } };
+
+  createRenderPipeline(device, opts);
+  createRenderPipeline(device, opts);
+  await createRenderPipelineAsync(device, opts);
+  await createRenderPipelineAsync(device, opts);
+
+  const mock = getMockGPUDeviceInstrumentation(device.gpu);
+  expect(mock.calls.createRenderPipeline).toBe(2);
+  expect(mock.calls.createRenderPipelineAsync).toBe(2);
+  device.destroy();
+});
+
+test("createRenderPipelineAsync falls back to sync once with a diagnostic by default", async () => {
+  const gpu = createMockGPUDevice();
+  (gpu as { createRenderPipelineAsync?: GPUDevice["createRenderPipelineAsync"] }).createRenderPipelineAsync = undefined;
+  const device = new Device(gpu, null);
+  const shader = makeShader(device);
+  const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+  await createRenderPipelineAsync(device, { shader, vertex: { entry: "vs" }, fragment: { entry: "fs", targets: [{ format: "rgba8unorm" }] } });
+  await createRenderPipelineAsync(device, { shader, vertex: { entry: "vs" }, fragment: { entry: "fs", targets: [{ format: "rgba8unorm" }] } });
+
+  const mock = getMockGPUDeviceInstrumentation(device.gpu);
+  expect(mock.calls.createRenderPipeline).toBe(2);
+  expect(mock.calls.createRenderPipelineAsync).toBe(0);
+  expect(warn).toHaveBeenCalledTimes(1);
+  expect(warn.mock.calls[0]?.[0]).toContain("createRenderPipelineAsync");
+  warn.mockRestore();
+  device.destroy();
+});
+
+test("createRenderPipelineAsync throws VGPUError when async is unavailable and fallback is throw", async () => {
+  const gpu = createMockGPUDevice();
+  (gpu as { createRenderPipelineAsync?: GPUDevice["createRenderPipelineAsync"] }).createRenderPipelineAsync = undefined;
+  const device = new Device(gpu, null);
+  const shader = makeShader(device);
+
+  await expect(createRenderPipelineAsync(device, {
+    fallback: "throw",
+    shader,
+    vertex: { entry: "vs" },
+    fragment: { entry: "fs", targets: [{ format: "rgba8unorm" }] },
+  })).rejects.toMatchObject({
+    name: "VGPUError",
+    code: "VGPU-RENDER-PIPELINE-ASYNC-UNAVAILABLE",
+    where: "createRenderPipelineAsync",
+  });
+  await expect(createRenderPipelineAsync(device, {
+    fallback: "throw",
+    shader,
+    vertex: { entry: "vs" },
+    fragment: { entry: "fs", targets: [{ format: "rgba8unorm" }] },
+  })).rejects.toBeInstanceOf(VGPUError);
+  expect(getMockGPUDeviceInstrumentation(device.gpu).calls.createRenderPipeline).toBe(0);
+  device.destroy();
+});

--- a/packages/wgsl-std/src/math/index.wgsl
+++ b/packages/wgsl-std/src/math/index.wgsl
@@ -6,12 +6,12 @@ export fn clamp01(value: f32) -> f32 {
   return saturate(value);
 }
 
-export fn inverseLerp(from: f32, to: f32, value: f32) -> f32 {
-  let denominator = to - from;
+export fn inverseLerp(start: f32, end: f32, value: f32) -> f32 {
+  let denominator = end - start;
   if (denominator == 0.0) {
     return 0.0;
   }
-  return (value - from) / denominator;
+  return (value - start) / denominator;
 }
 
 export fn remap(inMin: f32, inMax: f32, outMin: f32, outMax: f32, value: f32) -> f32 {

--- a/packages/wgsl-std/tests/math.test.ts
+++ b/packages/wgsl-std/tests/math.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, symlink, writeFile } from "node:fs/promises";
+import { mkdir, readFile, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { describe, expect, test } from "vitest";
@@ -213,6 +213,7 @@ function expectVec4Close(actual: readonly [number, number, number, number], expe
 async function runMathCompute(): Promise<Float32Array> {
   const outputLength = 12;
   const outputSize = outputLength * Float32Array.BYTES_PER_ELEMENT;
+  const mathPath = resolve("packages/wgsl-std/src/math/index.wgsl");
   const modules = {
     "/main.wgsl": `import { saturate, inverseLerp, remap, safeNormalize2, rotate2d } from "@vgpu/wgsl-std/math";
 struct Out { values: array<f32, ${outputLength}> }
@@ -235,8 +236,9 @@ fn main() {
   out.values[10] = r.x;
   out.values[11] = r.y;
 }`,
+    [mathPath]: await readFile(mathPath, "utf8"),
   };
-  const shader = await resolveShader({ entry: "/main.wgsl", modules, packageMap: { "@vgpu/wgsl-std/math": resolve("packages/wgsl-std/src/math/index.wgsl") }, validate: false });
+  const shader = await resolveShader({ entry: "/main.wgsl", modules, packageMap: { "@vgpu/wgsl-std/math": mathPath }, validate: false });
 
   const { device } = await App.create({ adapter: createNodeAdapter() });
   const gpu = device.gpu;


### PR DESCRIPTION
## Summary

Closes #100

This PR adds homepage-safe render helpers around WebGPU’s raw pipeline/frame primitives while preserving explicit control:

- Adds descriptor-like `createRenderPipeline()` options and sibling `createRenderPipelineAsync()`.
- Supports VGPU `Shader` objects and raw `GPUShaderModule` values, shared or per-stage.
- Forwards WebGPU-like pipeline fields: layouts, vertex buffers/attributes, fragment targets/blend/write masks, primitive, depth/stencil, multisample, constants, and labels.
- Keeps return values raw (`GPURenderPipeline`, `GPURenderBundle`) and documents `.gpu` escape hatches as advanced semver-protected public API.
- Adds mock GPU instrumentation and tests for the homepage hot-path invariant: setup creates resources/pipelines/bundles, frames only encode work and submit once.

## Pipeline helper flow

```mermaid
flowchart TD
  A[User RenderPipelineOptions] --> B[toRenderPipelineDescriptor shared builder]
  B --> C{createRenderPipeline or createRenderPipelineAsync?}
  C -- sync --> D[device.gpu.createRenderPipeline(descriptor)]
  C -- async --> E{GPUDevice.createRenderPipelineAsync exists?}
  E -- yes --> F[device.gpu.createRenderPipelineAsync(descriptor)]
  E -- no + fallback omitted/default sync --> G[warn once per JS process]
  G --> D
  E -- no + fallback throw --> H[throw VGPUError<br/>VGPU-RENDER-PIPELINE-ASYNC-UNAVAILABLE]
  D --> I[raw GPURenderPipeline]
  F --> I
```

Fallback policy:

- Default is compatibility-first: omitted `fallback` behaves like `fallback: "sync"`.
- Sync fallback emits a once-only diagnostic so async unavailability is visible without spamming warmup loops.
- Use `fallback: "throw"` during perf-critical initialization when blocking sync pipeline creation should fail fast.

## Interface snippets

Async pipeline creation with descriptor-like options:

```ts
const pipeline = await createRenderPipelineAsync(device, {
  label: "hero.pipeline",
  shader,
  layout: "auto",
  vertex: {
    entryPoint: "vs_main",
    buffers: [
      {
        arrayStride: 16,
        attributes: [{ shaderLocation: 0, offset: 0, format: "float32x4" }],
      },
    ],
  },
  fragment: {
    entryPoint: "fs_main",
    targets: [{ format: "rgba8unorm" }],
  },
  depthStencil: {
    format: "depth24plus",
    depthWriteEnabled: true,
    depthCompare: "less",
  },
  multisample: { count: 4 },
  fallback: "throw",
});
```

Raw `GPUShaderModule` and per-stage module usage:

```ts
const vertexModule = device.gpu.createShaderModule({ code: vertexWGSL });
const fragmentShader = device.createShader(fragmentWGSL);

const pipeline = createRenderPipeline(device, {
  layout: pipelineLayout,
  vertex: {
    module: vertexModule,
    entryPoint: "vs_main",
    constants: { scale: 2 },
  },
  fragment: {
    shader: fragmentShader,
    entryPoint: "fs_main",
    constants: { enabled: true },
    targets: [{ format: "bgra8unorm", writeMask: 0xf }],
  },
});
```

## Homepage frame hot path

```mermaid
sequenceDiagram
  participant Setup
  participant FrameLoop
  participant GPUDevice
  participant Queue

  Setup->>GPUDevice: create shaders / buffers / bind groups
  Setup->>GPUDevice: createRenderPipelineAsync/createRenderPipeline
  Setup->>GPUDevice: create 5 render bundles

  loop each animation frame
    FrameLoop->>GPUDevice: beginFrame() creates one command encoder
    FrameLoop->>FrameLoop: pass 1 executes bundles 1-2
    FrameLoop->>FrameLoop: pass 2 executes bundles 3-4
    FrameLoop->>FrameLoop: pass 3 executes bundle 5
    FrameLoop->>Queue: submit once
  end

  Note over FrameLoop,GPUDevice: No shader/resource/pipeline/bundle creation in the per-frame hot path
```

Frame-style hot-path sketch:

```ts
// Setup / resize path:
const bundles = [heroBundle, gridBundle, particlesBundle, uiBundle, debugBundle];
const pipeline = await createRenderPipelineAsync(device, pipelineOptions);

// Per-frame path:
const frame = beginFrame(device, { label: "homepage.frame" });

frame.renderPass(gbufferPass, (pass) => {
  pass.setPipeline(pipeline);
  pass.executeBundles([bundles[0], bundles[1]]);
});

frame.renderPass(lightingPass, (pass) => {
  pass.executeBundles([bundles[2], bundles[3]]);
});

frame.renderPass(uiPass, (pass) => {
  pass.executeBundles([bundles[4]]);
});

frame.submit(); // one encoder.finish() + one queue.submit()
```

The tests assert a homepage-like frame executes 3 passes, 5 bundles, and one queue submit without hidden per-frame resource or pipeline creation.

## Raw WebGPU vs VGPU

| Concern | Raw WebGPU | VGPU helper |
| --- | --- | --- |
| Pipeline descriptor | Full `GPURenderPipelineDescriptor` ceremony at call sites | Descriptor-like focused options converted by a shared builder |
| Shader input | `GPUShaderModule` only | VGPU `Shader` or raw `GPUShaderModule`, shared or per-stage |
| Async creation | Caller handles support/fallback checks | `createRenderPipelineAsync()` with explicit `fallback` policy |
| Return value | `GPURenderPipeline` | Raw `GPURenderPipeline` |
| Hot path | Caller discipline | Frame/render-bundle docs and instrumentation-backed tests codify one-encoder/one-submit guidance |

VGPU does **not** cache render pipelines: one helper call equals one WebGPU device call.

## Tests and CI

Final head: `4b0305d930abba6518e926f3ec6c058952a04c81`

Local validation run during the fix loop:

- `GIT_PAGER=cat git --no-pager diff --check -- . ':(exclude)node_modules'`
- `pnpm test packages/wgsl-std/tests/math.test.ts`
- `pnpm vitest run packages/render/tests/pipeline.test.ts packages/render/tests/frame.test.ts packages/render/tests/render-bundle.test.ts`
- `pnpm typecheck`
- `pnpm bundle-check`
- `pnpm test:docker`

GitHub CI is green on the final head:

- `test-fast`
- `wgsl-loader-bundler-tests`
- `test-integration`
- `wgsl-cachekey-determinism` on Ubuntu, Ubuntu ARM, and macOS
- `wgsl-turbopack-smoke`
- Socket and Wiz checks

## Frontend impact

No `front` files were changed. This PR is limited to the VGPU repository and docs/tests for the new render APIs.
