### PR TITLE
chore: bump wgsl-std to 0.0.6

### DIFF
--- a/packages/wgsl-std/package.json
+++ b/packages/wgsl-std/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vgpu/wgsl-std",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "Pure WGSL utility snippets for vgpu shaders.",
   "keywords": [
     "webgpu",


### PR DESCRIPTION
## Summary
- bump `@vgpu/wgsl-std` package version from `0.0.5` to `0.0.6`
- leave the existing `v0.0.6` tag/release untouched

## Validation
- `git diff --check`
- `npm pack --dry-run` from `packages/wgsl-std`

## Publish note
After this PR is merged, publish only `@vgpu/wgsl-std@0.0.6` from the merged main commit (do not republish the already-published `0.0.6` packages and do not move `v0.0.6`).