### PR TITLE
chore: bump render and cli to 0.0.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # vgpu
 
-> ⚠️ **0.0.6 — early preview. API will shift before 0.1.0.**
+> ⚠️ **0.0.7 — early preview. API will shift before 0.1.0.**
 
-Agentic-first WebGPU library. Run the same code on Node (Dawn), the web (browser WebGPU), and serverless platforms with linux-arm64 prebuilts. vgpu keeps the surface area small in 0.0.6: core device and resource primitives, a thin render layer, WGSL tooling, and adapters for real Node runtimes or deterministic tests.
+Agentic-first WebGPU library. Run the same code on Node (Dawn), the web (browser WebGPU), and serverless platforms with linux-arm64 prebuilts. vgpu keeps the surface area small in 0.0.7: core device and resource primitives, a thin render layer, WGSL tooling, and adapters for real Node runtimes or deterministic tests.
 
 ## Packages
 
@@ -81,7 +81,7 @@ device.destroy();
 
 ## Capability matrix
 
-- ✅ **In 0.0.6**
+- ✅ **In 0.0.7**
   - device / buffer / texture / shader primitives
   - render pipeline + render pass
   - WGSL compile + loaders for webpack and vite

--- a/packages/adapter-mock/README.md
+++ b/packages/adapter-mock/README.md
@@ -1,6 +1,6 @@
 # @vgpu/adapter-mock
 
-> 0.0.6 — early preview
+> 0.0.7 — early preview
 
 `@vgpu/adapter-mock` provides a `VGPUAdapter` implementation for tests, snapshots, and development workflows where you want the vgpu API surface without a real GPU backend. It pairs well with `App.create()` from `@vgpu/core` and supports the same high-level device, buffer, and texture flows used in fast unit tests across the repository.
 

--- a/packages/adapter-mock/package.json
+++ b/packages/adapter-mock/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vgpu/adapter-mock",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "Mock GPU adapter for testing vgpu code without real WebGPU hardware.",
   "keywords": [
     "webgpu",

--- a/packages/adapter-node/README.md
+++ b/packages/adapter-node/README.md
@@ -1,6 +1,6 @@
 # @vgpu/adapter-node
 
-> 0.0.6 — early preview
+> 0.0.7 — early preview
 
 `@vgpu/adapter-node` connects vgpu to Node.js runtimes through the `webgpu` package's Dawn native prebuild. It exposes both a reusable adapter for `App.create()` and a convenience helper that creates a `Device` directly, making it the package to use for server-side rendering, CI image generation, and serverless deployments. This package depends on `webgpu@0.4.0`, and the release target includes linux-arm64 prebuilt support.
 

--- a/packages/adapter-node/package.json
+++ b/packages/adapter-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vgpu/adapter-node",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "Node.js GPU adapter for vgpu, using Dawn-based WebGPU bindings.",
   "keywords": [
     "webgpu",

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,8 +1,8 @@
 # @vgpu/core
 
-> 0.0.6 — early preview
+> 0.0.7 — early preview
 
-`@vgpu/core` is the runtime foundation for vgpu. It gives you a small wrapper layer around WebGPU devices, queues, buffers, textures, and shader modules, plus an `App.create()` entry point that asks an adapter for a device and returns a compact app instance. In 0.0.6 the goal is portability and a minimal public surface, not a fully opinionated engine.
+`@vgpu/core` is the runtime foundation for vgpu. It gives you a small wrapper layer around WebGPU devices, queues, buffers, textures, and shader modules, plus an `App.create()` entry point that asks an adapter for a device and returns a compact app instance. In 0.0.7 the goal is portability and a minimal public surface, not a fully opinionated engine.
 
 ## Install
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vgpu/core",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "Core WebGPU runtime primitives (device, buffer, texture, shader, queue) for vgpu.",
   "keywords": [
     "webgpu",

--- a/packages/render/README.md
+++ b/packages/render/README.md
@@ -1,6 +1,6 @@
 # @vgpu/render
 
-> 0.0.6 — early preview
+> 0.0.7 — early preview
 
 `@vgpu/render` is the small rendering layer on top of `@vgpu/core`. It focuses on explicit WebGPU-style control: create pipelines, encode standalone render passes, or build one frame command encoder with multiple user-ordered passes.
 

--- a/packages/render/package.json
+++ b/packages/render/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vgpu/render",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "Render pipeline + render pass abstractions for vgpu.",
   "keywords": [
     "webgpu",

--- a/packages/vgpu/package.json
+++ b/packages/vgpu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vgpu",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "Official VGPU CLI for docs, doctor, and WGSL utilities.",
   "keywords": [
     "webgpu",

--- a/packages/vgpu/tests/cli.test.ts
+++ b/packages/vgpu/tests/cli.test.ts
@@ -10,7 +10,7 @@ function success(args) {
 
 test("preserves root help, version, and placeholders", () => {
   expect(success(["--help"])).toContain("vgpu docs --help");
-  expect(success(["--version"])).toMatch(/^0\.0\.6\n$/u);
+  expect(success(["--version"])).toMatch(/^0\.0\.7\n$/u);
   expect(runCli(["doctor"])).toMatchObject({ code: 1, stderr: expect.stringContaining("coming soon") });
   expect(runCli(["wgsl"])).toMatchObject({ code: 1, stderr: expect.stringContaining("coming soon") });
 });

--- a/packages/wgsl-std/package.json
+++ b/packages/wgsl-std/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vgpu/wgsl-std",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "Pure WGSL utility snippets for vgpu shaders.",
   "keywords": [
     "webgpu",

--- a/packages/wgsl/package.json
+++ b/packages/wgsl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vgpu/wgsl",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "WGSL shader compilation, runtime resolution, and webpack/vite loaders for vgpu.",
   "keywords": [
     "webgpu",


### PR DESCRIPTION
## Summary

- Bump `@vgpu/render` from `0.0.6` to `0.0.7` so the render API/perf additions from #105 can publish.
- Bump `vgpu` from `0.0.6` to `0.0.7` so the generated docs manifest + bundled skill updates from #105 can publish.
- Update the root README release/version references and `packages/render/README.md` to `0.0.7`.
- Update the CLI `--version` test expectation to `0.0.7`.

## Package bump rationale

PR #105 merged render package public API changes (`@vgpu/render/perf`, raw descriptor pipeline helpers, `Uniform`, and `StorageBuffer`) and vgpu CLI docs/skill generation output. The other workspace packages remain at `0.0.6`; pnpm recursive publish publishes only workspace packages whose current version is not already in the registry, so this keeps the release scoped to the changed publishable packages.

## Validation

- `git diff --check`
- `pnpm install --lockfile-only`
- `pnpm install --frozen-lockfile`
- `pnpm -F @vgpu/render typecheck`
- `pnpm -F @vgpu/render test` — 66 passed, 15 skipped (326 tests passed, 53 skipped)
- `pnpm -F vgpu test` — 3 passed (13 tests passed)
- `node packages/vgpu/lib/docs/generate/cli.js` — no generated docs/skill diff

Note: local pnpm uses Node v20.20.0 and prints the repo engine warning (`wanted: {"node": ">=22 <23"}`); commands above still completed successfully.

## Publish notes

Do not publish from this PR. After merge, create/publish the GitHub Release/tag (for example `v0.0.7`) or run the repository release flow as appropriate so the Release workflow publishes the bumped packages via Trusted Publishing.
