### PR TITLE
Fix RenderPass setBindGroup optional offsets

### DIFF
--- a/.changeset/quiet-bind-groups.md
+++ b/.changeset/quiet-bind-groups.md
@@ -1,0 +1,5 @@
+---
+"@vgpu/render": patch
+---
+
+Fix `RenderPass.setBindGroup` so omitted dynamic offsets are not forwarded to WebGPU as an explicit `undefined` argument.

--- a/packages/render/src/render-pass.ts
+++ b/packages/render/src/render-pass.ts
@@ -72,6 +72,10 @@ export class RenderPass {
   }
 
   setBindGroup(index: number, group: GPUBindGroup | null, dynamicOffsets?: RenderPassDynamicOffsets): void {
+    if (dynamicOffsets === undefined) {
+      this.gpu.setBindGroup(index, group);
+      return;
+    }
     this.gpu.setBindGroup(index, group, dynamicOffsets);
   }
 

--- a/packages/render/tests/render-pass.test.ts
+++ b/packages/render/tests/render-pass.test.ts
@@ -23,6 +23,18 @@ test("sets bind group at index", async () => {
   device.destroy();
 });
 
+test("omits dynamic offsets when none are provided", async () => {
+  const { device, passEncoder } = await createRenderPassFixture();
+  const bindGroup = {} as GPUBindGroup;
+  const pass = new RenderPass(device, { colorAttachments: [colorAttachment()] });
+
+  pass.setBindGroup(0, bindGroup);
+
+  expect(passEncoder.setBindGroup).toHaveBeenCalledWith(0, bindGroup);
+  expect(passEncoder.setBindGroup).not.toHaveBeenCalledWith(0, bindGroup, undefined);
+  device.destroy();
+});
+
 test("sets vertex buffer at slot", async () => {
   const { device, passEncoder } = await createRenderPassFixture();
   const vertexBuffer = {} as GPUBuffer;


### PR DESCRIPTION
## Summary
- Avoid forwarding an explicit \ dynamic offsets argument from \
- Preserve forwarding behavior when dynamic offsets are provided
- Add a regression test for omitted dynamic offsets

## Testing
- \
- \.                                        |  WARN  Unsupported engine: wanted: {"node":">=22 <23"} (current: {"node":"v20.20.0","pnpm":"9.15.4"})
None of the selected packages has a "build\" script
