### PR TITLE
chore: prepare 0.0.8 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # vgpu
 
-> ⚠️ **0.0.7 — early preview. API will shift before 0.1.0.**
+> ⚠️ **0.1.0 — early preview. API remains unstable before 1.0.**
 
-Agentic-first WebGPU library. Run the same code on Node (Dawn), the web (browser WebGPU), and serverless platforms with linux-arm64 prebuilts. vgpu keeps the surface area small in 0.0.7: core device and resource primitives, a thin render layer, WGSL tooling, and adapters for real Node runtimes or deterministic tests.
+Agentic-first WebGPU library. Run the same code on Node (Dawn), the web (browser WebGPU), and serverless platforms with linux-arm64 prebuilts. vgpu keeps the surface area small in 0.1.0: core device and resource primitives, a thin render layer, WGSL tooling, and adapters for real Node runtimes or deterministic tests.
 
 ## Packages
 
@@ -81,12 +81,12 @@ device.destroy();
 
 ## Capability matrix
 
-- ✅ **In 0.0.7**
+- ✅ **In 0.1.0**
   - device / buffer / texture / shader primitives
   - render pipeline + render pass
   - WGSL compile + loaders for webpack and vite
   - node and mock adapters
-- 🚧 **Coming in 0.1.0**
+- 🚧 **Coming next**
   - MRT (multiple render targets)
   - texture sampling helpers
   - post-process passes
@@ -102,7 +102,7 @@ Releases are triggered by **GitHub Releases** — no bot commits or version-pack
 
 ### Steps
 
-1. **Bump versions** across all 5 packages:
+1. **Bump versions** across all published packages:
    ```bash
    pnpm bump:patch    # 0.0.1 → 0.0.2
    # or
@@ -120,7 +120,7 @@ Releases are triggered by **GitHub Releases** — no bot commits or version-pack
    - Install dependencies
    - Build all packages
    - Run fast tests
-   - Publish all 5 packages to npm via Trusted Publishing with provenance attestation
+   - Publish all packages to npm via Trusted Publishing with provenance attestation
 
 The first auto-published version after the manual bootstrap will show a **Provenance** badge on each package's npm page proving it was built and signed by GitHub Actions.
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # vgpu
 
-> ⚠️ **0.1.0 — early preview. API remains unstable before 1.0.**
+> ⚠️ **0.0.8 — early preview. API will shift before 0.1.0.**
 
-Agentic-first WebGPU library. Run the same code on Node (Dawn), the web (browser WebGPU), and serverless platforms with linux-arm64 prebuilts. vgpu keeps the surface area small in 0.1.0: core device and resource primitives, a thin render layer, WGSL tooling, and adapters for real Node runtimes or deterministic tests.
+Agentic-first WebGPU library. Run the same code on Node (Dawn), the web (browser WebGPU), and serverless platforms with linux-arm64 prebuilts. vgpu keeps the surface area small in 0.0.8: core device and resource primitives, a thin render layer, WGSL tooling, and adapters for real Node runtimes or deterministic tests.
 
 ## Packages
 
@@ -81,12 +81,12 @@ device.destroy();
 
 ## Capability matrix
 
-- ✅ **In 0.1.0**
+- ✅ **In 0.0.8**
   - device / buffer / texture / shader primitives
   - render pipeline + render pass
   - WGSL compile + loaders for webpack and vite
   - node and mock adapters
-- 🚧 **Coming next**
+- 🚧 **Coming in 0.1.0**
   - MRT (multiple render targets)
   - texture sampling helpers
   - post-process passes

--- a/packages/adapter-mock/README.md
+++ b/packages/adapter-mock/README.md
@@ -1,6 +1,6 @@
 # @vgpu/adapter-mock
 
-> 0.1.0 — early preview
+> 0.0.8 — early preview
 
 `@vgpu/adapter-mock` provides a `VGPUAdapter` implementation for tests, snapshots, and development workflows where you want the vgpu API surface without a real GPU backend. It pairs well with `App.create()` from `@vgpu/core` and supports the same high-level device, buffer, and texture flows used in fast unit tests across the repository.
 

--- a/packages/adapter-mock/README.md
+++ b/packages/adapter-mock/README.md
@@ -1,6 +1,6 @@
 # @vgpu/adapter-mock
 
-> 0.0.7 — early preview
+> 0.1.0 — early preview
 
 `@vgpu/adapter-mock` provides a `VGPUAdapter` implementation for tests, snapshots, and development workflows where you want the vgpu API surface without a real GPU backend. It pairs well with `App.create()` from `@vgpu/core` and supports the same high-level device, buffer, and texture flows used in fast unit tests across the repository.
 

--- a/packages/adapter-mock/package.json
+++ b/packages/adapter-mock/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vgpu/adapter-mock",
-  "version": "0.0.7",
+  "version": "0.1.0",
   "description": "Mock GPU adapter for testing vgpu code without real WebGPU hardware.",
   "keywords": [
     "webgpu",

--- a/packages/adapter-mock/package.json
+++ b/packages/adapter-mock/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vgpu/adapter-mock",
-  "version": "0.1.0",
+  "version": "0.0.8",
   "description": "Mock GPU adapter for testing vgpu code without real WebGPU hardware.",
   "keywords": [
     "webgpu",

--- a/packages/adapter-node/README.md
+++ b/packages/adapter-node/README.md
@@ -1,6 +1,6 @@
 # @vgpu/adapter-node
 
-> 0.0.7 — early preview
+> 0.1.0 — early preview
 
 `@vgpu/adapter-node` connects vgpu to Node.js runtimes through the `webgpu` package's Dawn native prebuild. It exposes both a reusable adapter for `App.create()` and a convenience helper that creates a `Device` directly, making it the package to use for server-side rendering, CI image generation, and serverless deployments. This package depends on `webgpu@0.4.0`, and the release target includes linux-arm64 prebuilt support.
 

--- a/packages/adapter-node/README.md
+++ b/packages/adapter-node/README.md
@@ -1,6 +1,6 @@
 # @vgpu/adapter-node
 
-> 0.1.0 — early preview
+> 0.0.8 — early preview
 
 `@vgpu/adapter-node` connects vgpu to Node.js runtimes through the `webgpu` package's Dawn native prebuild. It exposes both a reusable adapter for `App.create()` and a convenience helper that creates a `Device` directly, making it the package to use for server-side rendering, CI image generation, and serverless deployments. This package depends on `webgpu@0.4.0`, and the release target includes linux-arm64 prebuilt support.
 

--- a/packages/adapter-node/package.json
+++ b/packages/adapter-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vgpu/adapter-node",
-  "version": "0.1.0",
+  "version": "0.0.8",
   "description": "Node.js GPU adapter for vgpu, using Dawn-based WebGPU bindings.",
   "keywords": [
     "webgpu",

--- a/packages/adapter-node/package.json
+++ b/packages/adapter-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vgpu/adapter-node",
-  "version": "0.0.7",
+  "version": "0.1.0",
   "description": "Node.js GPU adapter for vgpu, using Dawn-based WebGPU bindings.",
   "keywords": [
     "webgpu",

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,8 +1,8 @@
 # @vgpu/core
 
-> 0.0.7 — early preview
+> 0.1.0 — early preview
 
-`@vgpu/core` is the runtime foundation for vgpu. It gives you a small wrapper layer around WebGPU devices, queues, buffers, textures, and shader modules, plus an `App.create()` entry point that asks an adapter for a device and returns a compact app instance. In 0.0.7 the goal is portability and a minimal public surface, not a fully opinionated engine.
+`@vgpu/core` is the runtime foundation for vgpu. It gives you a small wrapper layer around WebGPU devices, queues, buffers, textures, and shader modules, plus an `App.create()` entry point that asks an adapter for a device and returns a compact app instance. In 0.1.0 the goal is portability and a minimal public surface, not a fully opinionated engine.
 
 ## Install
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,8 +1,8 @@
 # @vgpu/core
 
-> 0.1.0 — early preview
+> 0.0.8 — early preview
 
-`@vgpu/core` is the runtime foundation for vgpu. It gives you a small wrapper layer around WebGPU devices, queues, buffers, textures, and shader modules, plus an `App.create()` entry point that asks an adapter for a device and returns a compact app instance. In 0.1.0 the goal is portability and a minimal public surface, not a fully opinionated engine.
+`@vgpu/core` is the runtime foundation for vgpu. It gives you a small wrapper layer around WebGPU devices, queues, buffers, textures, and shader modules, plus an `App.create()` entry point that asks an adapter for a device and returns a compact app instance. In 0.0.8 the goal is portability and a minimal public surface, not a fully opinionated engine.
 
 ## Install
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vgpu/core",
-  "version": "0.1.0",
+  "version": "0.0.8",
   "description": "Core WebGPU runtime primitives (device, buffer, texture, shader, queue) for vgpu.",
   "keywords": [
     "webgpu",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vgpu/core",
-  "version": "0.0.7",
+  "version": "0.1.0",
   "description": "Core WebGPU runtime primitives (device, buffer, texture, shader, queue) for vgpu.",
   "keywords": [
     "webgpu",

--- a/packages/render/README.md
+++ b/packages/render/README.md
@@ -1,6 +1,6 @@
 # @vgpu/render
 
-> 0.0.7 — early preview
+> 0.1.0 — early preview
 
 `@vgpu/render` is the small rendering layer on top of `@vgpu/core`. It focuses on explicit WebGPU-style control: create pipelines, encode standalone render passes, or build one frame command encoder with multiple user-ordered passes.
 

--- a/packages/render/README.md
+++ b/packages/render/README.md
@@ -1,6 +1,6 @@
 # @vgpu/render
 
-> 0.1.0 — early preview
+> 0.0.8 — early preview
 
 `@vgpu/render` is the small rendering layer on top of `@vgpu/core`. It focuses on explicit WebGPU-style control: create pipelines, encode standalone render passes, or build one frame command encoder with multiple user-ordered passes.
 

--- a/packages/render/package.json
+++ b/packages/render/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vgpu/render",
-  "version": "0.0.7",
+  "version": "0.1.0",
   "description": "Render pipeline + render pass abstractions for vgpu.",
   "keywords": [
     "webgpu",

--- a/packages/render/package.json
+++ b/packages/render/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vgpu/render",
-  "version": "0.1.0",
+  "version": "0.0.8",
   "description": "Render pipeline + render pass abstractions for vgpu.",
   "keywords": [
     "webgpu",

--- a/packages/vgpu/package.json
+++ b/packages/vgpu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vgpu",
-  "version": "0.1.0",
+  "version": "0.0.8",
   "description": "Official VGPU CLI for docs, doctor, and WGSL utilities.",
   "keywords": [
     "webgpu",

--- a/packages/vgpu/package.json
+++ b/packages/vgpu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vgpu",
-  "version": "0.0.7",
+  "version": "0.1.0",
   "description": "Official VGPU CLI for docs, doctor, and WGSL utilities.",
   "keywords": [
     "webgpu",

--- a/packages/vgpu/tests/cli.test.ts
+++ b/packages/vgpu/tests/cli.test.ts
@@ -1,5 +1,8 @@
+import { readFileSync } from "node:fs";
 import { expect, test } from "vitest";
 import { runCli } from "../bin/vgpu.js";
+
+const packageVersion = JSON.parse(readFileSync(new URL("../package.json", import.meta.url), "utf8")).version;
 
 function success(args) {
   const result = runCli(args);
@@ -10,7 +13,7 @@ function success(args) {
 
 test("preserves root help, version, and placeholders", () => {
   expect(success(["--help"])).toContain("vgpu docs --help");
-  expect(success(["--version"])).toMatch(/^0\.0\.7\n$/u);
+  expect(success(["--version"])).toBe(`${packageVersion}\n`);
   expect(runCli(["doctor"])).toMatchObject({ code: 1, stderr: expect.stringContaining("coming soon") });
   expect(runCli(["wgsl"])).toMatchObject({ code: 1, stderr: expect.stringContaining("coming soon") });
 });

--- a/packages/wgsl-std/package.json
+++ b/packages/wgsl-std/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vgpu/wgsl-std",
-  "version": "0.0.7",
+  "version": "0.1.0",
   "description": "Pure WGSL utility snippets for vgpu shaders.",
   "keywords": [
     "webgpu",

--- a/packages/wgsl-std/package.json
+++ b/packages/wgsl-std/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vgpu/wgsl-std",
-  "version": "0.1.0",
+  "version": "0.0.8",
   "description": "Pure WGSL utility snippets for vgpu shaders.",
   "keywords": [
     "webgpu",

--- a/packages/wgsl/package.json
+++ b/packages/wgsl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vgpu/wgsl",
-  "version": "0.1.0",
+  "version": "0.0.8",
   "description": "WGSL shader compilation, runtime resolution, and webpack/vite loaders for vgpu.",
   "keywords": [
     "webgpu",

--- a/packages/wgsl/package.json
+++ b/packages/wgsl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vgpu/wgsl",
-  "version": "0.0.7",
+  "version": "0.1.0",
   "description": "WGSL shader compilation, runtime resolution, and webpack/vite loaders for vgpu.",
   "keywords": [
     "webgpu",


### PR DESCRIPTION
## Summary
- Correct release prep from the mistaken 0.1.0 minor bump to the requested 0.0.8 patch bump
- Bump all published VGPU packages from 0.0.7 to 0.0.8 in the PR net diff
- Update current README/package README version references for 0.0.8
- Keep docs manifest and generated skill mirror in sync (regeneration produced no changes)

## Validation
- `node packages/vgpu/lib/docs/generate/cli.js` (using Node 22): passed
- `pnpm typecheck` (using Node 22): passed
- `pnpm test:fast` (using Node 22): 96 files passed, 16 skipped; 526 tests passed, 71 skipped
- `pnpm build` (using Node 22): passed
- `pnpm bundle-check` (using Node 22): passed
- `git diff --check`: passed
- published package version consistency check: passed; all seven published packages report 0.0.8
- private example check: `@vgpu/example-next-wgsl` remains private with no version field

## Notes
- This keeps PR #113 open to avoid creating a duplicate PR. The head branch remains `chore/release-0.1.0` because changing the source branch of an existing GitHub PR is not clean/safe from the CLI without closing/reopening, but the PR title, body, and net diff are corrected to 0.0.8.
- Historical/future-looking 0.1.0 references in README release instructions and CHANGELOG were left unchanged.