### PR TITLE
ci: only publish npm on v* release tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,8 @@ on:
 
 jobs:
   publish:
+    # Binary-asset releases like dawn-* must not publish npm.
+    if: ${{ startsWith(github.event.release.tag_name, 'v') }}
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
Prevent the npm publishing workflow from running for binary-asset releases such as the upcoming `dawn-v0.4.0-vgpu.1` release.

Only release tags beginning with `v` (for example, `v0.1.0`) now publish npm packages.
