### PR TITLE
fix(vgpu): restore CLI bin and make @vgpu/cli internal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.1.1 — 2026-07-21
+
+### Fixed
+- `vgpu`: restore the `vgpu` executable with the complete bundled CLI, including offline documentation, snapshot, and Dawn installation commands.
+- `@vgpu/cli`: mark the extracted CLI package private so releases publish only the public `vgpu` package.
+
 ## 0.1.0 — 2026-07-21
 
 ### Breaking

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "node": ">=22 <23"
   },
   "scripts": {
-    "build": "tsc -b && node -e \"require('fs').copyFileSync('packages/wgsl/src/wgsl-types.d.ts', 'packages/wgsl/dist/wgsl-types.d.ts')\"",
+    "build": "tsc -b && node packages/vgpu-api/scripts/copy-cli.mjs && node -e \"require('fs').copyFileSync('packages/wgsl/src/wgsl-types.d.ts', 'packages/wgsl/dist/wgsl-types.d.ts')\"",
     "typecheck": "tsc -b && pnpm run typecheck:fixtures",
     "typecheck:fixtures": "tsc -p packages/core/tests/tsconfig.create-sampler-types.json && tsc -p packages/core/tests/tsconfig.types.json && tsc -p packages/vgpu-api/tests/uniforms/tsconfig.types.json",
     "docs:verify-snippets": "node scripts/verify-docs-snippets.mjs",

--- a/packages/vgpu-api/package.json
+++ b/packages/vgpu-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vgpu",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Public VGPU API entrypoint scaffold for browser, Node, mock, scene, and client typing surfaces.",
   "keywords": [
     "webgpu",
@@ -64,16 +64,19 @@
     "LICENSE"
   ],
   "scripts": {
-    "build": "tsc -b",
-    "test": "cd ../.. && vitest run packages/vgpu-api"
+    "build": "tsc -b && node scripts/copy-cli.mjs",
+    "test": "cd ../.. && vitest run packages/vgpu-api",
+    "prepack": "pnpm --dir ../vgpu generate:docs && node scripts/copy-cli.mjs"
   },
   "dependencies": {
-    "@vgpu/adapter-mock": "workspace:*",
-    "@vgpu/adapter-node": "workspace:*",
-    "@vgpu/core": "workspace:*",
-    "@vgpu/wgsl": "workspace:*",
+    "@vgpu/adapter-mock": "0.1.0",
+    "@vgpu/adapter-node": "0.1.0",
+    "@vgpu/core": "0.1.0",
+    "@vgpu/wgsl": "0.1.0",
     "wgpu-matrix": "^3.4.2",
-    "@webgpu/types": "^0.1.69"
+    "@webgpu/types": "^0.1.69",
+    "pixelmatch": "^7.2.0",
+    "pngjs": "^7.0.0"
   },
   "vgpuExportBundleBudgetNote": "Bundle-diet ceilings use 512-byte granularity with one rounded safety step above measured gzip sizes.",
   "vgpuExportBundleBudgetsGzipBytes": {
@@ -83,5 +86,8 @@
     "./scene": 5632,
     "./client": 512,
     "./core": 3584
+  },
+  "bin": {
+    "vgpu": "./dist/cli/bin/vgpu.js"
   }
 }

--- a/packages/vgpu-api/scripts/copy-cli.mjs
+++ b/packages/vgpu-api/scripts/copy-cli.mjs
@@ -1,0 +1,14 @@
+import { cpSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const packageDir = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const cliDir = resolve(packageDir, "../vgpu");
+const outputDir = resolve(packageDir, "dist/cli");
+const { version } = JSON.parse(readFileSync(resolve(packageDir, "package.json"), "utf8"));
+
+rmSync(outputDir, { recursive: true, force: true });
+mkdirSync(outputDir, { recursive: true });
+cpSync(resolve(cliDir, "bin"), resolve(outputDir, "bin"), { recursive: true });
+cpSync(resolve(cliDir, "lib"), resolve(outputDir, "lib"), { recursive: true });
+writeFileSync(resolve(outputDir, "package.json"), `${JSON.stringify({ type: "module", version }, null, 2)}\n`);

--- a/packages/vgpu-api/tests/cli-pack.test.ts
+++ b/packages/vgpu-api/tests/cli-pack.test.ts
@@ -1,0 +1,31 @@
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { expect, test } from "vitest";
+
+const packageDir = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const workspaceRoot = resolve(packageDir, "../..");
+
+const readJson = (path: string) => JSON.parse(readFileSync(path, "utf8"));
+
+test("vgpu owns the CLI bin and the internal CLI cannot be published", () => {
+  const vgpu = readJson(resolve(packageDir, "package.json"));
+  const cli = readJson(resolve(workspaceRoot, "packages/vgpu/package.json"));
+
+  expect(vgpu.bin).toEqual({ vgpu: "./dist/cli/bin/vgpu.js" });
+  expect(cli.name).toBe("@vgpu/cli");
+  expect(cli.private).toBe(true);
+});
+
+test("the vgpu tarball includes the full internal CLI", () => {
+  const output = execFileSync("npm", ["pack", "--dry-run", "--json"], {
+    cwd: packageDir,
+    encoding: "utf8",
+  });
+  const [pack] = JSON.parse(output.slice(output.indexOf("[")));
+  const files = pack.files.map((file: { path: string }) => file.path);
+
+  expect(files).toContain("dist/cli/bin/vgpu.js");
+  expect(files).toContain("dist/cli/lib/generated/docs-manifest.generated.js");
+});

--- a/packages/vgpu/package.json
+++ b/packages/vgpu/package.json
@@ -21,7 +21,7 @@
   },
   "license": "MIT",
   "author": "Matias Gonzalez <matiasngf@hotmail.com>",
-  "private": false,
+  "private": true,
   "publishConfig": {
     "access": "public"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -321,20 +321,26 @@ importers:
   packages/vgpu-api:
     dependencies:
       '@vgpu/adapter-mock':
-        specifier: workspace:*
-        version: link:../adapter-mock
+        specifier: 0.1.0
+        version: 0.1.0
       '@vgpu/adapter-node':
-        specifier: workspace:*
-        version: link:../adapter-node
+        specifier: 0.1.0
+        version: 0.1.0
       '@vgpu/core':
-        specifier: workspace:*
-        version: link:../core
+        specifier: 0.1.0
+        version: 0.1.0
       '@vgpu/wgsl':
-        specifier: workspace:*
-        version: link:../wgsl
+        specifier: 0.1.0
+        version: 0.1.0
       '@webgpu/types':
         specifier: ^0.1.69
         version: 0.1.69
+      pixelmatch:
+        specifier: ^7.2.0
+        version: 7.2.0
+      pngjs:
+        specifier: ^7.0.0
+        version: 7.0.0
       wgpu-matrix:
         specifier: ^3.4.2
         version: 3.4.2
@@ -996,6 +1002,18 @@ packages:
 
   '@ungap/structured-clone@1.3.2':
     resolution: {integrity: sha512-5jsZFwgR5rTdKwidH9Qmat75RKwqfpKlWWB1frDkljN127mwqBu8K0PYo7/hFpF03IEJpfVPpCQDY/eDx3iHvA==}
+
+  '@vgpu/adapter-mock@0.1.0':
+    resolution: {integrity: sha512-cxp2z8FZWxP/OfNePS9lqnwoJTW1PFxRsuN2qE8OL1VELion5qsrRwnRo+u3IZI8G/Kx0VfHDVkPZ4f7fyRLZg==}
+
+  '@vgpu/adapter-node@0.1.0':
+    resolution: {integrity: sha512-NkhatZosaSC7v9OAGGUQQQAq0gWm32oMqQwySsfIlN+GYP4asjEqdEXsAA2dbe+yt/zScFNt9BnUuV1dWBixew==}
+
+  '@vgpu/core@0.1.0':
+    resolution: {integrity: sha512-eT9kGtM+J8+xtOQi9FzV6mePC/RZR/yvNHTNsnDSRMq8g8vhgBlvwyZ45FsRH9oloFMCoqvnwz0/0T3sD8nGwQ==}
+
+  '@vgpu/wgsl@0.1.0':
+    resolution: {integrity: sha512-V1NvCgxgOYVPiLbS4ovIx3vs/XU03969rNDp4/Z7iLw9XBDs2azkF/46pxNLHHuZ8TOu84nzQ2e8HZ1jixfcjw==}
 
   '@vitest/expect@2.1.9':
     resolution: {integrity: sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==}
@@ -2772,6 +2790,23 @@ snapshots:
   '@types/unist@3.0.3': {}
 
   '@ungap/structured-clone@1.3.2': {}
+
+  '@vgpu/adapter-mock@0.1.0':
+    dependencies:
+      '@vgpu/core': 0.1.0
+
+  '@vgpu/adapter-node@0.1.0':
+    dependencies:
+      '@vgpu/core': 0.1.0
+      webgpu: 0.4.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@vgpu/core@0.1.0':
+    dependencies:
+      '@vgpu/wgsl': 0.1.0
+
+  '@vgpu/wgsl@0.1.0': {}
 
   '@vitest/expect@2.1.9':
     dependencies:


### PR DESCRIPTION
## Summary

- restore the `vgpu` executable on the public `vgpu` package
- copy the complete internal CLI (including the 3.84 MB generated docs manifest) into `vgpu` during build/prepack
- mark `@vgpu/cli` private so recursive releases skip it
- bump only `vgpu` to 0.1.1 and add package-wiring regression coverage

## Root cause

The extraction happened as a two-commit sequence:

1. `9e5981e3bb52db38cc8e781090b4841007b7490f` renamed the original `packages/vgpu` package from `vgpu` to `@vgpu/cli`; that package retained `"bin": { "vgpu": "./bin/vgpu.js" }`.
2. `942c534231cd9dc82ca7bffefdc10a91ac46aa5e` then scaffolded the new public `vgpu` package in `packages/vgpu-api` without a `bin` field.

Before extraction, `vgpu@0.0.8` owned the same `./bin/vgpu.js` executable. The 0.1.0 release therefore published the runtime package without the executable while attempting to publish the extracted CLI separately.

## Pack proof

Packed `vgpu@0.1.1` with `npm pack`, installed that tarball in a clean temporary project, and ran the installed executable:

- `npx --no-install vgpu --help` → `vgpu 0.1.1` and complete command help
- `npx --no-install vgpu docs ls` → offline package/guide listing from the bundled manifest
- `npx --no-install vgpu install-dawn --help` → structured usage output
- `npx --no-install vgpu install-dawn` → `Downloaded Dawn prebuild: /tmp/vgpu-clean/cache/vgpu/dawn/0.4.0-vgpu.1/linux-arm64-gnu/dawn-linux-arm64-gnu.node`
- clean install contains no `@vgpu/cli` runtime dependency

Tarball size:

| Version | Packed | Unpacked | Files |
| --- | ---: | ---: | ---: |
| 0.1.0 | 162,154 B | 776,780 B | 349 |
| 0.1.1 | 786,935 B | 4,660,371 B | 373 |
| Delta | +624,781 B | +3,883,591 B | +24 |

## Gates

- [x] build
- [x] typecheck
- [x] vitest (`138 passed`, `21 skipped`; isolated empty Dawn cache)
- [x] test:docker (CPU and GPU passes; GPU: `157 passed`, `2 skipped`)
- [x] bundle-check — web entries unchanged: `vgpu 30268`, `vgpu/node 30316`, `vgpu/mock 30350`
- [x] docs snippets (`snippets=400 tsc=OK`)
- [x] docs generation twice, byte-stable
- [x] clean tarball install/CLI smoke proof
