### PR TITLE
fix(docs): make docs app deployable

### DIFF
--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -5,12 +5,13 @@
   "scripts": {
     "predev": "node scripts/ingest-examples.mjs",
     "dev": "next dev --port 3001",
-    "prebuild": "node scripts/ingest-examples.mjs",
+    "prebuild": "pnpm run build:workspace && node scripts/ingest-examples.mjs",
     "build": "next build",
     "start": "next start --port 3001",
     "thumbs": "node scripts/render-example-thumbs.mjs --update",
     "thumbs:check": "node scripts/render-example-thumbs.mjs --check",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "build:workspace": "pnpm --dir ../.. run build"
   },
   "dependencies": {
     "@mdx-js/loader": "^3.1.1",
@@ -43,5 +44,8 @@
     "postcss": "^8.4.49",
     "tailwindcss": "^3.4.17",
     "typescript": "^5.7.3"
+  },
+  "engines": {
+    "node": ">=22 <23"
   }
 }


### PR DESCRIPTION
## Failure evidence

GitHub's Vercel status for production deployment `5542171929` at `d6dccec` is `failure`:

> Deployment has failed — run this Vercel CLI command: `npx vercel inspect dpl_DhdZkJBxSYcYK27Nkq9kPjn97Y3t --logs`

A later preview deployment (`5542472713`) failed the same way. The Vercel build logs require project access, so I reproduced the build from a clean worktree. After a root `pnpm install --frozen-lockfile`, running `next build` directly in `apps/docs` fails with:

> Cannot find module `apps/docs/node_modules/@vgpu/wgsl/dist/loader-webpack/index.js`

and repeated:

> Module not found: Can't resolve `vgpu`

## Root cause

The docs package's build only ran `next build`, but it imports workspace packages whose package exports and WGSL loader point to generated `dist/` files. Vercel starts from a clean checkout, so those artifacts do not exist. CI hid the issue because its docs job explicitly ran the root workspace build first.

## Fix

- Make the docs `prebuild` compile workspace dependencies before ingesting examples and invoking Next.
- Pin the docs app to the repository's supported Node 22 runtime so a Vercel project rooted at `apps/docs` does not miss the root engine constraint.

## Clean-room proof

From a fresh worktree with ignored artifacts removed:

```sh
npx --yes --package=node@22 -c 'node --version && pnpm --version && pnpm install --frozen-lockfile && pnpm --filter docs build'
```

Result: Next 16.2.10 compiled successfully and generated all 97 static pages. The existing Turbopack NFT tracing diagnostic remained a warning, not an error.

Additional gates:

- `pnpm run typecheck` — pass
- `pnpm run test:fast` — 66 files passed, 451 tests passed (8 files / 63 tests skipped)
- docs generator run twice — stable, no diff
- production server + agent-browser homepage smoke — pass

Main CI at `d6dccec` is green: https://github.com/vercel-labs/vgpu/actions/runs/29849739631
