### PR TITLE
fix(vgpu): keep CLI bin link stable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,7 @@ jobs:
             -e CI=true \
             vgpu-test-dev:ci \
             sh -lc 'Xvfb :99 -screen 0 1024x768x24 >/tmp/xvfb.log 2>&1 & xp=$!; \
-              pnpm --filter @vgpu/cli exec vgpu snapshot --ci; \
+              node packages/vgpu/bin/vgpu.js snapshot --ci; \
               s=$?; kill $xp; exit $s'
 
   wgsl-cachekey-determinism:

--- a/packages/vgpu-api/bin/vgpu.js
+++ b/packages/vgpu-api/bin/vgpu.js
@@ -2,18 +2,14 @@
 import { existsSync } from "node:fs";
 
 const cliUrl = new URL("../dist/cli/bin/vgpu.js", import.meta.url);
-let runCli;
 
 if (!existsSync(cliUrl)) {
   process.stderr.write("vgpu CLI is not built. Run `pnpm build` before using it from a workspace checkout.\n");
-  process.exitCode = 1;
-} else {
-  ({ runCli } = await import(cliUrl.href));
+  process.exit(1);
 }
 
-if (runCli) {
-  const result = await Promise.resolve(runCli(process.argv.slice(2)));
-  if (result.stdout) process.stdout.write(result.stdout);
-  if (result.stderr) process.stderr.write(result.stderr);
-  process.exitCode = result.code;
-}
+const { runCli } = await import(cliUrl.href);
+const result = await Promise.resolve(runCli(process.argv.slice(2)));
+if (result.stdout) process.stdout.write(result.stdout);
+if (result.stderr) process.stderr.write(result.stderr);
+process.exitCode = result.code;

--- a/packages/vgpu-api/bin/vgpu.js
+++ b/packages/vgpu-api/bin/vgpu.js
@@ -1,15 +1,14 @@
 #!/usr/bin/env node
+import { existsSync } from "node:fs";
 
+const cliUrl = new URL("../dist/cli/bin/vgpu.js", import.meta.url);
 let runCli;
-try {
-  ({ runCli } = await import("../dist/cli/bin/vgpu.js"));
-} catch (error) {
-  if (error?.code === "ERR_MODULE_NOT_FOUND") {
-    process.stderr.write("vgpu CLI is not built. Run `pnpm build` before using it from a workspace checkout.\n");
-    process.exitCode = 1;
-  } else {
-    throw error;
-  }
+
+if (!existsSync(cliUrl)) {
+  process.stderr.write("vgpu CLI is not built. Run `pnpm build` before using it from a workspace checkout.\n");
+  process.exitCode = 1;
+} else {
+  ({ runCli } = await import(cliUrl.href));
 }
 
 if (runCli) {

--- a/packages/vgpu-api/bin/vgpu.js
+++ b/packages/vgpu-api/bin/vgpu.js
@@ -1,0 +1,20 @@
+#!/usr/bin/env node
+
+let runCli;
+try {
+  ({ runCli } = await import("../dist/cli/bin/vgpu.js"));
+} catch (error) {
+  if (error?.code === "ERR_MODULE_NOT_FOUND") {
+    process.stderr.write("vgpu CLI is not built. Run `pnpm build` before using it from a workspace checkout.\n");
+    process.exitCode = 1;
+  } else {
+    throw error;
+  }
+}
+
+if (runCli) {
+  const result = await Promise.resolve(runCli(process.argv.slice(2)));
+  if (result.stdout) process.stdout.write(result.stdout);
+  if (result.stderr) process.stderr.write(result.stderr);
+  process.exitCode = result.code;
+}

--- a/packages/vgpu-api/package.json
+++ b/packages/vgpu-api/package.json
@@ -59,6 +59,7 @@
   },
   "files": [
     "client.d.ts",
+    "bin",
     "dist",
     "README.md",
     "LICENSE"
@@ -88,6 +89,6 @@
     "./core": 3584
   },
   "bin": {
-    "vgpu": "./dist/cli/bin/vgpu.js"
+    "vgpu": "./bin/vgpu.js"
   }
 }

--- a/packages/vgpu-api/tests/cli-pack.test.ts
+++ b/packages/vgpu-api/tests/cli-pack.test.ts
@@ -1,5 +1,5 @@
 import { execFileSync } from "node:child_process";
-import { readFileSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { expect, test } from "vitest";
@@ -13,7 +13,8 @@ test("vgpu owns the CLI bin and the internal CLI cannot be published", () => {
   const vgpu = readJson(resolve(packageDir, "package.json"));
   const cli = readJson(resolve(workspaceRoot, "packages/vgpu/package.json"));
 
-  expect(vgpu.bin).toEqual({ vgpu: "./dist/cli/bin/vgpu.js" });
+  expect(vgpu.bin).toEqual({ vgpu: "./bin/vgpu.js" });
+  expect(existsSync(resolve(packageDir, "bin/vgpu.js"))).toBe(true);
   expect(cli.name).toBe("@vgpu/cli");
   expect(cli.private).toBe(true);
 });
@@ -26,6 +27,7 @@ test("the vgpu tarball includes the full internal CLI", () => {
   const [pack] = JSON.parse(output.slice(output.indexOf("[")));
   const files = pack.files.map((file: { path: string }) => file.path);
 
+  expect(files).toContain("bin/vgpu.js");
   expect(files).toContain("dist/cli/bin/vgpu.js");
   expect(files).toContain("dist/cli/lib/generated/docs-manifest.generated.js");
 });


### PR DESCRIPTION
## Summary

- point `vgpu`'s package bin at a checked-in launcher that exists when `pnpm install` creates workspace bin links
- delegate from the stable launcher to the full generated CLI under `dist/cli` after build/prepack
- print an actionable `pnpm build` error when a workspace checkout invokes the launcher before building
- extend packaging regression coverage to require the checkout launcher and both launcher/runtime files in the tarball

## CI failure

Fixes the `docker-gpu` failure in [run 29854613878](https://github.com/vercel-labs/vgpu/actions/runs/29854613878):

```text
ERR_PNPM_RECURSIVE_EXEC_FIRST_FAIL Command "vgpu" not found
```

`vgpu` previously pointed its bin directly at `./dist/cli/bin/vgpu.js`. That generated file did not exist during `pnpm install`, so pnpm skipped creating workspace bin links. Building the file later could not restore links that were never created.

## Local reproduction and proof

On current main after a fresh install, before this fix:

```text
$ pnpm --filter @vgpu/cli exec vgpu snapshot --ci
ERR_PNPM_RECURSIVE_EXEC_FIRST_FAIL Command "vgpu" not found
```

With this fix, a forced clean relink while `dist/cli` was removed produced both `node_modules/.bin/vgpu` and `packages/vgpu/node_modules/.bin/vgpu`, with zero `Failed to create bin` warnings. Invoking before build reached the checked-in launcher and returned:

```text
vgpu CLI is not built. Run `pnpm build` before using it from a workspace checkout.
```

After build, the exact CI Docker command passed:

```text
Snapshot matched: /workspace/packages/vgpu-api/tests/__snapshots__/representative-gradient.png
```

## Gates

- [x] exact failing docker-gpu snapshot command
- [x] typecheck
- [x] build
- [x] vitest with isolated Dawn cache (`138 passed`, `21 skipped` files; `760 passed`, `118 skipped` tests)
- [x] test:docker (`157 passed`, `2 skipped` files; `873 passed`, `5 skipped` tests)
- [x] bundle-check — unchanged: `vgpu 30268`, `vgpu/node 30316`, `vgpu/mock 30350`
- [x] npm pack includes `package/bin/vgpu.js` and `package/dist/cli/bin/vgpu.js`
- [x] clean tarball install: `npx vgpu --help` and `npx vgpu docs ls`


## CI follow-up: build-independent snapshot entry

The internal private `@vgpu/cli` still owns its source bin, but `pnpm --filter @vgpu/cli exec vgpu` resolves executables from that package's dependency `.bin`; because it dev-depends on public `vgpu`, it selected the public launcher rather than linking the package's own bin to itself. The docker-gpu job intentionally does not run the root build/copy step, so the generated public CLI is absent.

The snapshot step now invokes the internal private CLI explicitly:

```sh
node packages/vgpu/bin/vgpu.js snapshot --ci
```

This preserves the snapshot test's intent and runs directly from the internal CLI sources without requiring public-package build artifacts. The public npm launcher remains unchanged for consumers.

Exact fresh-sequence reproduction removed `packages/vgpu-api/dist/cli`, then ran the same CI setup (`pnpm install --force --frozen-lockfile`, `pnpm -w typecheck`, Dockerfile.dev build) and the updated container command. It passed:

```text
Snapshot matched: /workspace/packages/vgpu-api/tests/__snapshots__/representative-gradient.png
```

The public launcher's missing-build branch was also simplified to exit immediately, eliminating the stray `undefined` output from the failing CI route.