### PR TITLE
Release 0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 0.1.2 — 2026-07-21
+
+### Changed
+- `vgpu docs` now leads agents to the getting-started guide, presents packages and guides in a curated learning order, and lists `/guides` with getting started first.
+- Rewrite getting-started, effect, pass, frame, surface, target, and performance examples around valid structured bindings, resize-owned updates, frame batching, and filterable texture sampling.
+
+### Added
+- Add runtime tests that execute getting-started and corrected performance/post-processing snippets against `vgpu/mock` so documentation examples cannot silently drift from the public API.
+
 ## 0.1.1 — 2026-07-21
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # vgpu
 
-> 0.1.0 — early preview of the new public `vgpu` API
+> 0.1.2 — early preview of the new public `vgpu` API
 
 vgpu is an agentic-first WebGPU library for browsers, Node/Dawn, and deterministic mock tests. The public package is `vgpu`: one `Gpu` context with explicit WGSL reflection and performance-oriented defaults.
 

--- a/packages/adapter-mock/README.md
+++ b/packages/adapter-mock/README.md
@@ -1,6 +1,6 @@
 # @vgpu/adapter-mock
 
-> 0.1.0 — deterministic adapter for `vgpu/mock`
+> 0.1.2 — deterministic adapter for `vgpu/mock`
 
 `@vgpu/adapter-mock` backs the `vgpu/mock` entrypoint for tests that need the public `Gpu` API without real GPU hardware.
 

--- a/packages/adapter-mock/package.json
+++ b/packages/adapter-mock/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vgpu/adapter-mock",
-  "version": "0.1.0",
+  "version": "0.1.2",
   "description": "Mock GPU adapter for testing vgpu code without real WebGPU hardware.",
   "keywords": [
     "webgpu",

--- a/packages/adapter-node/README.md
+++ b/packages/adapter-node/README.md
@@ -1,6 +1,6 @@
 # @vgpu/adapter-node
 
-> 0.1.0 — Dawn adapter for `vgpu/node`
+> 0.1.2 — Dawn adapter for `vgpu/node`
 
 `@vgpu/adapter-node` connects vgpu to Node.js through the `webgpu` Dawn native prebuild. Most callers should import `init` from `vgpu/node`; direct adapter/device helpers remain for core layer (`vgpu/core`) tooling.
 

--- a/packages/adapter-node/package.json
+++ b/packages/adapter-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vgpu/adapter-node",
-  "version": "0.1.0",
+  "version": "0.1.2",
   "description": "Node.js GPU adapter for vgpu, using Dawn-based WebGPU bindings.",
   "keywords": [
     "webgpu",

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,6 +1,6 @@
 # @vgpu/core
 
-> 0.1.0 — core layer (`vgpu/core`) runtime primitives
+> 0.1.2 — core layer (`vgpu/core`) runtime primitives
 
 `@vgpu/core` contains the low-level WebGPU wrappers used by `vgpu/core`: `Device`, `Buffer`, `Texture`, `Queue`, shader modules, bind-group helpers, resource identities, and validation errors. Most applications should start from `init()` in `vgpu`, `vgpu/node`, or `vgpu/mock` and drop to these primitives only for explicit native control.
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vgpu/core",
-  "version": "0.1.0",
+  "version": "0.1.2",
   "description": "Core WebGPU runtime primitives (device, buffer, texture, shader, queue) for vgpu.",
   "keywords": [
     "webgpu",

--- a/packages/render/README.md
+++ b/packages/render/README.md
@@ -1,6 +1,6 @@
 # @vgpu/render
 
-> 0.1.0 — slim legacy/utility render package
+> 0.1.2 — slim legacy/utility render package
 
 New applications should use the public `vgpu` package. `@vgpu/render` remains as a slim package for edit/inspect/utils/perf helpers and compatibility while the old thick render surface is removed from the public path.
 

--- a/packages/render/package.json
+++ b/packages/render/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vgpu/render",
-  "version": "0.1.0",
+  "version": "0.1.2",
   "description": "Render pipeline + render pass abstractions for vgpu.",
   "keywords": [
     "webgpu",

--- a/packages/vgpu-api/README.md
+++ b/packages/vgpu-api/README.md
@@ -1,6 +1,6 @@
 # vgpu
 
-> 0.1.0 — public main API (`vgpu`) preview
+> 0.1.2 — public main API (`vgpu`) preview
 
 `vgpu` is the public package for the new API. It is built around one `Gpu` context, explicit WGSL reflection, and `set()` ownership rules that make the fast path the default.
 

--- a/packages/vgpu-api/package.json
+++ b/packages/vgpu-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vgpu",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Public VGPU API entrypoint scaffold for browser, Node, mock, scene, and client typing surfaces.",
   "keywords": [
     "webgpu",
@@ -70,10 +70,10 @@
     "prepack": "pnpm --dir ../vgpu generate:docs && node scripts/copy-cli.mjs"
   },
   "dependencies": {
-    "@vgpu/adapter-mock": "0.1.0",
-    "@vgpu/adapter-node": "0.1.0",
-    "@vgpu/core": "0.1.0",
-    "@vgpu/wgsl": "0.1.0",
+    "@vgpu/adapter-mock": "workspace:*",
+    "@vgpu/adapter-node": "workspace:*",
+    "@vgpu/core": "workspace:*",
+    "@vgpu/wgsl": "workspace:*",
     "wgpu-matrix": "^3.4.2",
     "@webgpu/types": "^0.1.69",
     "pixelmatch": "^7.2.0",

--- a/packages/vgpu/package.json
+++ b/packages/vgpu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vgpu/cli",
-  "version": "0.1.0",
+  "version": "0.1.2",
   "description": "Official VGPU CLI for docs, doctor, and WGSL utilities.",
   "keywords": [
     "webgpu",
@@ -45,9 +45,9 @@
     "pngjs": "^7.0.0"
   },
   "peerDependencies": {
-    "@vgpu/adapter-node": "^0.1.0",
-    "@vgpu/wgsl": "^0.1.0",
-    "vgpu": "^0.1.0"
+    "@vgpu/adapter-node": "^0.1.2",
+    "@vgpu/wgsl": "^0.1.2",
+    "vgpu": "^0.1.2"
   },
   "peerDependenciesMeta": {
     "@vgpu/adapter-node": {

--- a/packages/wgsl-std/package.json
+++ b/packages/wgsl-std/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vgpu/wgsl-std",
-  "version": "0.1.0",
+  "version": "0.1.2",
   "description": "Pure WGSL utility snippets for vgpu shaders.",
   "keywords": [
     "webgpu",

--- a/packages/wgsl/package.json
+++ b/packages/wgsl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vgpu/wgsl",
-  "version": "0.1.0",
+  "version": "0.1.2",
   "description": "WGSL shader compilation, runtime resolution, and webpack/vite loaders for vgpu.",
   "keywords": [
     "webgpu",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -321,17 +321,17 @@ importers:
   packages/vgpu-api:
     dependencies:
       '@vgpu/adapter-mock':
-        specifier: 0.1.0
-        version: 0.1.0
+        specifier: workspace:*
+        version: link:../adapter-mock
       '@vgpu/adapter-node':
-        specifier: 0.1.0
-        version: 0.1.0
+        specifier: workspace:*
+        version: link:../adapter-node
       '@vgpu/core':
-        specifier: 0.1.0
-        version: 0.1.0
+        specifier: workspace:*
+        version: link:../core
       '@vgpu/wgsl':
-        specifier: 0.1.0
-        version: 0.1.0
+        specifier: workspace:*
+        version: link:../wgsl
       '@webgpu/types':
         specifier: ^0.1.69
         version: 0.1.69
@@ -1002,18 +1002,6 @@ packages:
 
   '@ungap/structured-clone@1.3.2':
     resolution: {integrity: sha512-5jsZFwgR5rTdKwidH9Qmat75RKwqfpKlWWB1frDkljN127mwqBu8K0PYo7/hFpF03IEJpfVPpCQDY/eDx3iHvA==}
-
-  '@vgpu/adapter-mock@0.1.0':
-    resolution: {integrity: sha512-cxp2z8FZWxP/OfNePS9lqnwoJTW1PFxRsuN2qE8OL1VELion5qsrRwnRo+u3IZI8G/Kx0VfHDVkPZ4f7fyRLZg==}
-
-  '@vgpu/adapter-node@0.1.0':
-    resolution: {integrity: sha512-NkhatZosaSC7v9OAGGUQQQAq0gWm32oMqQwySsfIlN+GYP4asjEqdEXsAA2dbe+yt/zScFNt9BnUuV1dWBixew==}
-
-  '@vgpu/core@0.1.0':
-    resolution: {integrity: sha512-eT9kGtM+J8+xtOQi9FzV6mePC/RZR/yvNHTNsnDSRMq8g8vhgBlvwyZ45FsRH9oloFMCoqvnwz0/0T3sD8nGwQ==}
-
-  '@vgpu/wgsl@0.1.0':
-    resolution: {integrity: sha512-V1NvCgxgOYVPiLbS4ovIx3vs/XU03969rNDp4/Z7iLw9XBDs2azkF/46pxNLHHuZ8TOu84nzQ2e8HZ1jixfcjw==}
 
   '@vitest/expect@2.1.9':
     resolution: {integrity: sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==}
@@ -2790,23 +2778,6 @@ snapshots:
   '@types/unist@3.0.3': {}
 
   '@ungap/structured-clone@1.3.2': {}
-
-  '@vgpu/adapter-mock@0.1.0':
-    dependencies:
-      '@vgpu/core': 0.1.0
-
-  '@vgpu/adapter-node@0.1.0':
-    dependencies:
-      '@vgpu/core': 0.1.0
-      webgpu: 0.4.0
-    transitivePeerDependencies:
-      - supports-color
-
-  '@vgpu/core@0.1.0':
-    dependencies:
-      '@vgpu/wgsl': 0.1.0
-
-  '@vgpu/wgsl@0.1.0': {}
 
   '@vitest/expect@2.1.9':
     dependencies:


### PR DESCRIPTION
## Summary

Prepare the synchronized VGPU 0.1.2 release from the agent-first CLI documentation work merged after `v0.1.1`.

| Package | Version |
| --- | --- |
| `vgpu` | `0.1.1` → `0.1.2` |
| `@vgpu/cli` (private) | `0.1.0` → `0.1.2` |
| `@vgpu/core` | `0.1.0` → `0.1.2` |
| `@vgpu/render` | `0.1.0` → `0.1.2` |
| `@vgpu/wgsl` | `0.1.0` → `0.1.2` |
| `@vgpu/wgsl-std` | `0.1.0` → `0.1.2` |
| `@vgpu/adapter-node` | `0.1.0` → `0.1.2` |
| `@vgpu/adapter-mock` | `0.1.0` → `0.1.2` |

- Updates README version banners and CLI peer ranges to 0.1.2.
- Uses `workspace:*` for `vgpu`'s synchronized internal packages; `pnpm pack` verifies these publish as exact `0.1.2` dependencies.
- Adds the 0.1.2 changelog entry for agent-first CLI help/routing, curated guide discovery, corrected runtime-valid examples, and the runtime snippet gate.
- Runs docs generation and example ingestion twice; both are idempotent with no generated diff.
- Preserves upstream Dawn/WebGPU versions, engine/type-version fields, private app versions, and historical changelog entries.

## Verification

- `pnpm install --frozen-lockfile`
- `pnpm run typecheck`
- `pnpm run build`
- `VGPU_CACHE_DIR=$(mktemp -d) pnpm exec vitest run` — 763 passed, 118 skipped
- `pnpm run bundle-check`
- `pnpm run docs:verify-snippets` — 401 snippets
- `pnpm --dir packages/vgpu-api pack` — packed dependencies and both CLI entrypoints report 0.1.2
