### PR TITLE
fix(adapter-node): support display-free Vulkan adapters

### DIFF
--- a/infra/test-docker-vulkan/Dockerfile
+++ b/infra/test-docker-vulkan/Dockerfile
@@ -1,0 +1,8 @@
+FROM node:24-trixie-slim
+LABEL vgpu-test=1
+ENV COREPACK_ENABLE_DOWNLOAD_PROMPT=0 DEBIAN_FRONTEND=noninteractive XDG_RUNTIME_DIR=/tmp/xdg-runtime VGPU_CACHE_DIR=/tmp/vgpu-cache
+RUN apt-get update && apt-get install -y --no-install-recommends mesa-vulkan-drivers vulkan-tools && mkdir -p /tmp/xdg-runtime && chmod 700 /tmp/xdg-runtime
+WORKDIR /workspace
+COPY . .
+RUN corepack enable && pnpm install --frozen-lockfile && pnpm build
+CMD ["bash", "infra/test-docker-vulkan/test.sh"]

--- a/infra/test-docker-vulkan/README.md
+++ b/infra/test-docker-vulkan/README.md
@@ -1,0 +1,8 @@
+# Display-free Vulkan adapter test
+
+Runs the adapter-node native readback suite, including a 64x64 gradient render,
+on Node 24 with Mesa lavapipe and no X11/Wayland display.
+
+```sh
+VGPU_DAWN_BINARY=/path/to/dawn.node infra/test-docker-vulkan/run.sh
+```

--- a/infra/test-docker-vulkan/run.sh
+++ b/infra/test-docker-vulkan/run.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
+DAWN=${VGPU_DAWN_BINARY:-$HOME/.cache/vgpu/dawn/0.4.0-vgpu.1/linux-arm64-gnu/dawn-linux-arm64-gnu.node}
+docker build --platform linux/arm64 -t vgpu-test-vulkan -f "$ROOT/infra/test-docker-vulkan/Dockerfile" "$ROOT"
+docker run --rm --platform linux/arm64 --label vgpu-test=1 -e VGPU_DAWN_BINARY=/dawn.node -v "$DAWN:/dawn.node:ro" vgpu-test-vulkan

--- a/infra/test-docker-vulkan/test.sh
+++ b/infra/test-docker-vulkan/test.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+unset DISPLAY WAYLAND_DISPLAY VGPU_DAWN_FLAGS
+export VK_ICD_FILENAMES=${VK_ICD_FILENAMES:-$(find /usr/share/vulkan/icd.d -name 'lvp_icd*.json' | head -1)}
+echo "Node: $(node --version)"
+vulkaninfo --summary
+VGPU_DOCKER_TEST=1 pnpm exec vitest run packages/adapter-node/tests/buffer-readback.test.ts

--- a/packages/adapter-node/README.md
+++ b/packages/adapter-node/README.md
@@ -27,7 +27,9 @@ gpu.dispose();
 
 - Node.js 22+ is the supported engine.
 - Linux Dawn prebuilds require a compatible GLIBC. Use the repository Docker runner for reproducible CI and snapshots.
-- Headless Linux runs use software rendering variables such as `LIBGL_ALWAYS_SOFTWARE=1`, `DISPLAY=:99`, and `XDG_RUNTIME_DIR=/tmp/xdg-runtime`.
+- Linux lets Dawn discover available backends. X11/OpenGL software rendering can use `LIBGL_ALWAYS_SOFTWARE=1` and `DISPLAY`; display-free Vulkan/lavapipe uses a valid `VK_ICD_FILENAMES` and `XDG_RUNTIME_DIR`.
+- `VGPU_DAWN_FLAGS=backend=vulkan` or `backend=opengl` pins a backend when automatic discovery is not desired.
+- `VGPU-NODE-NO-ADAPTER` includes the attempted Dawn flags and adapter options plus Mesa, Vulkan ICD, and display diagnostics.
 
 ## License
 

--- a/packages/adapter-node/package.json
+++ b/packages/adapter-node/package.json
@@ -52,5 +52,5 @@
     "@vgpu/core": "workspace:*",
     "webgpu": "0.4.0"
   },
-  "vgpuBundleBudgetGzipBytes": 30720
+  "vgpuBundleBudgetGzipBytes": 32768
 }

--- a/packages/adapter-node/src/create-node-adapter.docs.md
+++ b/packages/adapter-node/src/create-node-adapter.docs.md
@@ -38,15 +38,23 @@ commands. `VGPU-NODE-PREBUILD-CHECKSUM` refuses a corrupt or substituted asset.
 cannot load. Do not upgrade a host's glibc in place; install the portable
 prebuild or provide an audited binary with `VGPU_DAWN_BINARY`.
 
-On Linux the adapter uses the OpenGL software backend by default
-(`backend=opengl` plus Dawn compatibility feature level) and keeps a
-process-wide singleton GPU instance; conflicting later flags are warned and
-ignored because Dawn re-init can SIGSEGV. For deterministic headless Vulkan CI,
-install the distro's Mesa/lavapipe packages, set
-`VGPU_DAWN_FLAGS=backend=vulkan`, and select its ICD with `VK_ICD_FILENAMES`.
-Mesa and GPU drivers remain host-managed and are never downloaded by vgpu.
-`VGPU_DAWN_FLAGS` may contain any space-separated Dawn flags and replaces the
-default backend selection.
+On Linux the adapter keeps the established OpenGL compatibility backend when
+`DISPLAY` or `WAYLAND_DISPLAY` is configured. Without a display server it lets
+Dawn discover the available backend, enabling display-free Vulkan without
+application configuration. It keeps a process-wide singleton GPU instance;
+conflicting later flags are warned
+and ignored because Dawn re-init can SIGSEGV. For deterministic headless Vulkan
+CI, install the distro's Mesa/lavapipe packages and select its ICD with
+`VK_ICD_FILENAMES`; `VGPU_DAWN_FLAGS=backend=vulkan` remains available when
+strict backend selection is required. Mesa and GPU drivers remain host-managed
+and are never downloaded by vgpu. `VGPU_DAWN_FLAGS` may contain any
+space-separated Dawn flags and replaces automatic backend discovery.
+
+A CPU Vulkan device is not necessarily a WebGPU fallback adapter. In current
+Dawn builds lavapipe is acquired by the normal request; forcing
+`forceFallbackAdapter` can exclude it. If no adapter is found after the retry
+window, `VGPU-NODE-NO-ADAPTER` reports the request options and Dawn flags and
+points to the Mesa version, Vulkan ICD, and display environment to inspect.
 
 For agentic headless snapshot tests, pair this adapter with an explicit
 offscreen `rgba8unorm` render target that includes `"copy_src"`, submit the

--- a/packages/adapter-node/src/index.ts
+++ b/packages/adapter-node/src/index.ts
@@ -1,4 +1,4 @@
-import { Device, type CreateDeviceOptions, type VGPUAdapter } from "@vgpu/core";
+import { Device, VGPUError, type CreateDeviceOptions, type VGPUAdapter } from "@vgpu/core";
 import { resolveWebGPU, type WebGPUModule } from "./dawn-loader.ts";
 type NodeAdapterFlags = { readonly backendFlags?: readonly string[] };
 type NodeAdapterRetryOptions = { readonly adapterRequestRetryCount?: number; readonly adapterRequestRetryBaseDelayMs?: number };
@@ -49,7 +49,14 @@ async function requestAdapterWithRetry(gpu: GPU, options: GPURequestAdapterOptio
     }
   }
 
-  throw new Error(`No WebGPU adapter available for @vgpu/adapter-node after ${maxAttempts} attempts: ${String(lastError)}`);
+  const tried = JSON.stringify(options);
+  throw new VGPUError({
+    code: "VGPU-NODE-NO-ADAPTER",
+    message: `No WebGPU adapter available after ${maxAttempts} attempts with requestAdapter(${tried}) and Dawn flags [${dawnFlagsUsed?.join(",") ?? ""}].`,
+    fix: "Check the Mesa/driver version, Vulkan ICD (VK_ICD_FILENAMES), and display variables (DISPLAY, WAYLAND_DISPLAY, XDG_RUNTIME_DIR). Use VGPU_DAWN_FLAGS to select a Dawn backend explicitly.",
+    where: "createNodeAdapter",
+    cause: lastError,
+  });
 }
 
 function shouldRetryAdapterRequestError(error: unknown): boolean {
@@ -86,8 +93,9 @@ function backendFlags(opts: RequestDeviceOptions): readonly string[] {
   const envFlags = process.env.VGPU_DAWN_FLAGS?.split(/\s+/).filter(Boolean);
   if (envFlags && envFlags.length > 0) return envFlags;
   if (opts.backendFlags) return opts.backendFlags;
-  if (opts.backend === "webgpu") return [];
-  return process.platform === "linux" ? ["backend=opengl"] : [];
+  if (opts.backend === "opengl") return ["backend=opengl"];
+  if (process.platform === "linux" && opts.backend !== "webgpu" && (process.env.DISPLAY || process.env.WAYLAND_DISPLAY)) return ["backend=opengl"];
+  return [];
 }
 
 function adapterOptions(opts: RequestDeviceOptions): DawnAdapterOptions {

--- a/packages/adapter-node/tests/buffer-readback.test.ts
+++ b/packages/adapter-node/tests/buffer-readback.test.ts
@@ -15,6 +15,39 @@ describe.skipIf(process.env.VGPU_DOCKER_TEST !== "1")("adapter-node Docker GPU",
     device.destroy();
   });
 
+  test("renders and reads back a 64x64 gradient", async () => {
+    const { device } = await init();
+    const gpu = device.gpu;
+    const width = 64;
+    const texture = gpu.createTexture({ size: [width, width], format: "rgba8unorm", usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.COPY_SRC });
+    const shader = gpu.createShaderModule({ code: `
+      @vertex fn vs(@builtin(vertex_index) i: u32) -> @builtin(position) vec4f {
+        let p = array(vec2f(-1, -1), vec2f(3, -1), vec2f(-1, 3));
+        return vec4f(p[i], 0, 1);
+      }
+      @fragment fn fs(@builtin(position) p: vec4f) -> @location(0) vec4f {
+        return vec4f(p.x / 64.0, p.y / 64.0, 0.25, 1.0);
+      }
+    ` });
+    const pipeline = gpu.createRenderPipeline({ layout: "auto", vertex: { module: shader }, fragment: { module: shader, targets: [{ format: "rgba8unorm" }] }, primitive: { topology: "triangle-list" } });
+    const readback = gpu.createBuffer({ size: width * width * 4, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ });
+    const encoder = gpu.createCommandEncoder();
+    const pass = encoder.beginRenderPass({ colorAttachments: [{ view: texture.createView(), loadOp: "clear", storeOp: "store", clearValue: [0, 0, 0, 1] }] });
+    pass.setPipeline(pipeline);
+    pass.draw(3);
+    pass.end();
+    encoder.copyTextureToBuffer({ texture }, { buffer: readback, bytesPerRow: width * 4 }, [width, width]);
+    gpu.queue.submit([encoder.finish()]);
+    await readback.mapAsync(GPUMapMode.READ);
+    const pixels = new Uint8Array(readback.getMappedRange());
+    expect([...pixels.slice(0, 4)]).toEqual([2, 2, 64, 255]);
+    expect([...pixels.slice(-4)]).toEqual([253, 253, 64, 255]);
+    readback.unmap();
+    readback.destroy();
+    texture.destroy();
+    device.destroy();
+  });
+
   test("node error scope captures validation error from invalid buffer creation", async () => {
     const { device } = await init();
     device.pushErrorScope("validation");

--- a/packages/adapter-node/tests/compatibility-mode.test.ts
+++ b/packages/adapter-node/tests/compatibility-mode.test.ts
@@ -2,6 +2,8 @@ import { beforeEach, expect, test, vi } from "vitest";
 
 const state = vi.hoisted(() => ({
   adapterOptions: [] as GPURequestAdapterOptions[],
+  createFlags: [] as string[][],
+  nullRequestsRemaining: 0,
   deviceLabels: [] as string[],
   deviceDescriptors: [] as GPUDeviceDescriptor[],
 }));
@@ -14,22 +16,29 @@ vi.mock("node:module", async (importOriginal) => {
       if (id !== "webgpu") throw new Error(`Unexpected require: ${id}`);
       return {
         globals: {},
-        create: () => ({
-          async requestAdapter(options: GPURequestAdapterOptions): Promise<GPUAdapter> {
-            state.adapterOptions.push(options);
-            return {
-              info: null,
-              async requestDevice(descriptor: GPUDeviceDescriptor): Promise<GPUDevice> {
-                state.deviceDescriptors.push(descriptor);
-                return {
-                  set label(value: string) { state.deviceLabels.push(value); },
-                  queue: { submit() {}, onSubmittedWorkDone: async () => undefined },
-                  destroy() {},
-                } as GPUDevice;
-              },
-            } as GPUAdapter;
-          },
-        } as GPU),
+        create: (flags: string[]) => {
+          state.createFlags.push(flags);
+          return {
+            async requestAdapter(options: GPURequestAdapterOptions): Promise<GPUAdapter | null> {
+              state.adapterOptions.push(options);
+              if (state.nullRequestsRemaining > 0) {
+                state.nullRequestsRemaining--;
+                return null;
+              }
+              return {
+                info: null,
+                async requestDevice(descriptor: GPUDeviceDescriptor): Promise<GPUDevice> {
+                  state.deviceDescriptors.push(descriptor);
+                  return {
+                    set label(value: string) { state.deviceLabels.push(value); },
+                    queue: { submit() {}, onSubmittedWorkDone: async () => undefined },
+                    destroy() {},
+                  } as GPUDevice;
+                },
+              } as GPUAdapter;
+            },
+          } as GPU;
+        },
       };
     },
   };
@@ -38,6 +47,8 @@ vi.mock("node:module", async (importOriginal) => {
 beforeEach(() => {
   vi.resetModules();
   state.adapterOptions = [];
+  state.createFlags = [];
+  state.nullRequestsRemaining = 0;
   state.deviceLabels = [];
   state.deviceDescriptors = [];
 });
@@ -67,4 +78,56 @@ test("node adapter leaves webgpu backend devices out of compatibility mode", asy
 
   expect(state.adapterOptions.at(-1)).not.toHaveProperty("featureLevel");
   expect(device.isCompatibilityMode).toBe(false);
+});
+
+test.runIf(process.platform === "linux")("node adapter lets Dawn discover Vulkan when no display server is configured", async () => {
+  const display = process.env.DISPLAY;
+  const waylandDisplay = process.env.WAYLAND_DISPLAY;
+  delete process.env.DISPLAY;
+  delete process.env.WAYLAND_DISPLAY;
+  try {
+    const { createNodeDevice } = await import("../src/index.ts");
+    const device = await createNodeDevice();
+    expect(state.createFlags).toEqual([[]]);
+    device.destroy();
+  } finally {
+    if (display !== undefined) process.env.DISPLAY = display;
+    if (waylandDisplay !== undefined) process.env.WAYLAND_DISPLAY = waylandDisplay;
+  }
+});
+
+test.runIf(process.platform === "linux")("node adapter preserves the OpenGL default when a display server is configured", async () => {
+  const display = process.env.DISPLAY;
+  process.env.DISPLAY = ":99";
+  try {
+    const { createNodeDevice } = await import("../src/index.ts");
+    const device = await createNodeDevice();
+    expect(state.createFlags).toEqual([["backend=opengl"]]);
+    device.destroy();
+  } finally {
+    if (display === undefined) delete process.env.DISPLAY;
+    else process.env.DISPLAY = display;
+  }
+});
+
+test("node adapter preserves explicit OpenGL backend selection", async () => {
+  const { createNodeDevice } = await import("../src/index.ts");
+  const device = await createNodeDevice({ backend: "opengl" });
+  expect(state.createFlags).toEqual([["backend=opengl"]]);
+  device.destroy();
+});
+
+test("node adapter reports structured diagnostics after identical adapter retries", async () => {
+  state.nullRequestsRemaining = 3;
+  const { createNodeDevice } = await import("../src/index.ts");
+  const error = await createNodeDevice({ adapterRequestRetryBaseDelayMs: 0 }).catch((cause: unknown) => cause) as Error & { code?: string; where?: string; fix?: string };
+  expect(state.adapterOptions).toHaveLength(3);
+  expect(state.adapterOptions).toEqual([
+    { powerPreference: undefined, featureLevel: "compatibility" },
+    { powerPreference: undefined, featureLevel: "compatibility" },
+    { powerPreference: undefined, featureLevel: "compatibility" },
+  ]);
+  expect(error).toMatchObject({ name: "VGPUError", code: "VGPU-NODE-NO-ADAPTER", where: "createNodeAdapter" });
+  expect(error.message).toContain("Dawn flags [");
+  expect(error.fix).toContain("VK_ICD_FILENAMES");
 });


### PR DESCRIPTION
## Summary

Fixes `vgpu/node` initialization on display-free Linux hosts that expose only a Vulkan CPU device (Mesa lavapipe).

The reported environment was Amazon Linux 2023 x86_64, Node 24, Mesa 24.2.6, with a valid lavapipe ICD but no X server. Dawn loaded, then all three adapter requests returned null before WGSL compilation.

## Root cause and hypothesis result

The initial hypothesis was that Dawn classifies `VK_PHYSICAL_DEVICE_TYPE_CPU` as a WebGPU fallback and requires `forceFallbackAdapter: true`. A Node 24 / Mesa 25.0.7 / no-display container disproved that:

- `create([])` + `requestAdapter({})`: lavapipe adapter and device acquired
- `create([])` + `requestAdapter({ forceFallbackAdapter: true })`: null
- `create(["backend=vulkan"])` + normal request: adapter and device acquired
- `create(["backend=opengl"])` + compatibility request: null without the OpenGL/display stack

The actual bug was adapter-node's Linux default `webgpu.create(["backend=opengl"])`. That restricted Dawn enumeration to OpenGL, so valid Vulkan adapters were invisible. Retrying the same request three times could never recover.

## Fix

- Preserve the established OpenGL compatibility backend when a Linux display server is configured; without `DISPLAY`/`WAYLAND_DISPLAY`, let Dawn discover the display-free Vulkan backend.
- Preserve explicit `backend: "opengl"`, `backendFlags`, and `VGPU_DAWN_FLAGS` selection.
- Replace the terminal plain error with structured `VGPU-NODE-NO-ADAPTER`, including attempted adapter options, Dawn flags, cause, and Mesa/ICD/display hints.
- Add mock coverage for automatic flags, explicit OpenGL, exact retry options, and structured failure.
- Add a Node 24 + Debian trixie + Mesa lavapipe fixture with no X/Wayland. It verifies Vulkan enumeration and the adapter-node native suite, including 64x64 gradient rendering/readback.
- Update adapter-node docs. Increase only the native adapter package archive budget to 32 KiB; web export budgets are unchanged.

## Verification

- `pnpm typecheck`
- `pnpm build`
- `VGPU_CACHE_DIR=/tmp/vgpu-full-test-cache pnpm test` — 766 passed, 119 skipped (isolated host cache)
- `pnpm test:docker` — Xvfb/OpenGL regression suite
- `infra/test-docker-vulkan/run.sh` — Node 24, Mesa 25.0.7 lavapipe, no display; 5/5 adapter tests passed
- `pnpm bundle-check` — web entries unchanged and within budget
- `pnpm docs:verify-snippets` — 401 snippets, tsc OK
- docs generator run twice idempotently
