### PR TITLE
Release 0.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 0.1.3 — 2026-07-21
+
+### Fixed
+- `@vgpu/adapter-node`: let Dawn discover display-free Vulkan adapters on headless Linux instead of always forcing OpenGL, while preserving the OpenGL compatibility default when a display server is configured and honoring explicit backend flags.
+- `@vgpu/adapter-node`: report failed adapter discovery as structured `VGPU-NODE-NO-ADAPTER` diagnostics with the attempted options, Dawn flags, and actionable Mesa, Vulkan ICD, and display checks.
+
+### Added
+- Add a Vulkan-only Docker fixture and render/readback coverage for lavapipe in headless environments such as Amazon Linux 2023.
+
 ## 0.1.2 — 2026-07-21
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # vgpu
 
-> 0.1.2 — early preview of the new public `vgpu` API
+> 0.1.3 — early preview of the new public `vgpu` API
 
 vgpu is an agentic-first WebGPU library for browsers, Node/Dawn, and deterministic mock tests. The public package is `vgpu`: one `Gpu` context with explicit WGSL reflection and performance-oriented defaults.
 

--- a/packages/adapter-mock/README.md
+++ b/packages/adapter-mock/README.md
@@ -1,6 +1,6 @@
 # @vgpu/adapter-mock
 
-> 0.1.2 — deterministic adapter for `vgpu/mock`
+> 0.1.3 — deterministic adapter for `vgpu/mock`
 
 `@vgpu/adapter-mock` backs the `vgpu/mock` entrypoint for tests that need the public `Gpu` API without real GPU hardware.
 

--- a/packages/adapter-mock/package.json
+++ b/packages/adapter-mock/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vgpu/adapter-mock",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Mock GPU adapter for testing vgpu code without real WebGPU hardware.",
   "keywords": [
     "webgpu",

--- a/packages/adapter-node/README.md
+++ b/packages/adapter-node/README.md
@@ -1,6 +1,6 @@
 # @vgpu/adapter-node
 
-> 0.1.2 — Dawn adapter for `vgpu/node`
+> 0.1.3 — Dawn adapter for `vgpu/node`
 
 `@vgpu/adapter-node` connects vgpu to Node.js through the `webgpu` Dawn native prebuild. Most callers should import `init` from `vgpu/node`; direct adapter/device helpers remain for core layer (`vgpu/core`) tooling.
 

--- a/packages/adapter-node/package.json
+++ b/packages/adapter-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vgpu/adapter-node",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Node.js GPU adapter for vgpu, using Dawn-based WebGPU bindings.",
   "keywords": [
     "webgpu",

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,6 +1,6 @@
 # @vgpu/core
 
-> 0.1.2 — core layer (`vgpu/core`) runtime primitives
+> 0.1.3 — core layer (`vgpu/core`) runtime primitives
 
 `@vgpu/core` contains the low-level WebGPU wrappers used by `vgpu/core`: `Device`, `Buffer`, `Texture`, `Queue`, shader modules, bind-group helpers, resource identities, and validation errors. Most applications should start from `init()` in `vgpu`, `vgpu/node`, or `vgpu/mock` and drop to these primitives only for explicit native control.
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vgpu/core",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Core WebGPU runtime primitives (device, buffer, texture, shader, queue) for vgpu.",
   "keywords": [
     "webgpu",

--- a/packages/render/README.md
+++ b/packages/render/README.md
@@ -1,6 +1,6 @@
 # @vgpu/render
 
-> 0.1.2 — slim legacy/utility render package
+> 0.1.3 — slim legacy/utility render package
 
 New applications should use the public `vgpu` package. `@vgpu/render` remains as a slim package for edit/inspect/utils/perf helpers and compatibility while the old thick render surface is removed from the public path.
 

--- a/packages/render/package.json
+++ b/packages/render/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vgpu/render",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Render pipeline + render pass abstractions for vgpu.",
   "keywords": [
     "webgpu",

--- a/packages/vgpu-api/README.md
+++ b/packages/vgpu-api/README.md
@@ -1,6 +1,6 @@
 # vgpu
 
-> 0.1.2 — public main API (`vgpu`) preview
+> 0.1.3 — public main API (`vgpu`) preview
 
 `vgpu` is the public package for the new API. It is built around one `Gpu` context, explicit WGSL reflection, and `set()` ownership rules that make the fast path the default.
 

--- a/packages/vgpu-api/package.json
+++ b/packages/vgpu-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vgpu",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Public VGPU API entrypoint scaffold for browser, Node, mock, scene, and client typing surfaces.",
   "keywords": [
     "webgpu",

--- a/packages/vgpu/package.json
+++ b/packages/vgpu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vgpu/cli",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Official VGPU CLI for docs, doctor, and WGSL utilities.",
   "keywords": [
     "webgpu",
@@ -45,9 +45,9 @@
     "pngjs": "^7.0.0"
   },
   "peerDependencies": {
-    "@vgpu/adapter-node": "^0.1.2",
-    "@vgpu/wgsl": "^0.1.2",
-    "vgpu": "^0.1.2"
+    "@vgpu/adapter-node": "^0.1.3",
+    "@vgpu/wgsl": "^0.1.3",
+    "vgpu": "^0.1.3"
   },
   "peerDependenciesMeta": {
     "@vgpu/adapter-node": {

--- a/packages/wgsl-std/package.json
+++ b/packages/wgsl-std/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vgpu/wgsl-std",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Pure WGSL utility snippets for vgpu shaders.",
   "keywords": [
     "webgpu",

--- a/packages/wgsl/package.json
+++ b/packages/wgsl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vgpu/wgsl",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "WGSL shader compilation, runtime resolution, and webpack/vite loaders for vgpu.",
   "keywords": [
     "webgpu",


### PR DESCRIPTION
## Summary

Prepare the synchronized VGPU 0.1.3 release for display-free Vulkan adapter support merged in PR #158.

| Package | Version |
| --- | --- |
| `vgpu` | `0.1.2` → `0.1.3` |
| `@vgpu/cli` (private) | `0.1.2` → `0.1.3` |
| `@vgpu/core` | `0.1.2` → `0.1.3` |
| `@vgpu/render` | `0.1.2` → `0.1.3` |
| `@vgpu/wgsl` | `0.1.2` → `0.1.3` |
| `@vgpu/wgsl-std` | `0.1.2` → `0.1.3` |
| `@vgpu/adapter-node` | `0.1.2` → `0.1.3` |
| `@vgpu/adapter-mock` | `0.1.2` → `0.1.3` |

- Updates README version banners and CLI optional peer ranges to 0.1.3.
- Preserves `workspace:*` internal dependencies; `pnpm pack` verifies they publish as exact `0.1.3` dependencies.
- Adds the 0.1.3 changelog entry for display-free Vulkan/lavapipe discovery, structured no-adapter diagnostics, and the Vulkan-only E2E fixture.
- Runs docs generation and example ingestion twice; both are idempotent with no generated diff.
- Preserves upstream Dawn/WebGPU versions, engine/type-version fields, private app versions, and historical changelog entries.

## Verification

- `pnpm install --frozen-lockfile`
- `pnpm run typecheck`
- `pnpm run build`
- `VGPU_CACHE_DIR=$(mktemp -d) pnpm exec vitest run` — 767 passed, 119 skipped
- `pnpm run bundle-check`
- `pnpm run docs:verify-snippets` — 401 snippets
- `pnpm --dir packages/vgpu-api pack` — packed dependencies and both CLI entrypoints report 0.1.3
