### PR TITLE
fix(vgpu): structured surface-frame and pipeline-layout errors

### DIFF
--- a/packages/vgpu-api/src/bundle.ts
+++ b/packages/vgpu-api/src/bundle.ts
@@ -3,7 +3,8 @@ import { InternalDraw, encodeDraw, registerDrawBundle, type BundleBackReference,
 import { InternalEffect, effectDraw, type Effect } from "./effect.ts";
 import type { CompileTarget, Target, TargetSignature } from "./target.ts";
 import { normalizeSignature, signatureKeyOf, validateTargetSignature } from "./pipeline-store.ts";
-import { VGPUError } from "./errors.ts";
+import { surfaceNotInFrameError, VGPUError } from "./errors.ts";
+import { isFrameActive, isSurface } from "./surface.ts";
 
 export interface BundleOptions {
   readonly target: CompileTarget;
@@ -25,6 +26,7 @@ let recordingDepth = 0;
 /** Records explicit WebGPU render bundles and keeps the R3 stale signature checked at replay time. */
 export function createBundle(device: { readonly gpu: GPUDevice }, opts: BundleOptions, record: (recorder: BundleRecorder) => void): Bundle {
   const id = opts.label ?? `bundle${nextBundleId++}`;
+  if (isSurface(opts.target) && !isFrameActive()) throw surfaceNotInFrameError("gpu.bundle");
   const signature = normalizeBundleSignature(opts.target);
   const bundle = new RecordedBundle(device, id, signature);
   bundle.record(record);

--- a/packages/vgpu-api/src/draw.ts
+++ b/packages/vgpu-api/src/draw.ts
@@ -9,7 +9,8 @@ import { bindGroupLayoutEntriesForGroup, bindGroupLayoutsForReflection, cachedBi
 import type { CompileTarget, Target, TargetSignature } from "./target.ts";
 import { normalizeSignature, pipelineKeyOf, signatureKeyOf, validateTargetSignature, createPipelineLayoutCache, createPipelineStore, createShaderModuleCache, type PipelineLayoutCache, type PipelineStore, type ShaderModuleCache } from "./pipeline-store.ts";
 import { isTarget } from "./target-utils.ts";
-import { blendInvalidError, claimedGroupNativeValidationError, meshRangeInvalidError, storageStageLimitError, targetRequiredError, VGPUError, writeMaskInvalidError } from "./errors.ts";
+import { blendInvalidError, claimedGroupNativeValidationError, meshRangeInvalidError, storageStageLimitError, surfaceNotInFrameError, targetRequiredError, VGPUError, writeMaskInvalidError } from "./errors.ts";
+import { isFrameActive, isSurface } from "./surface.ts";
 import { meshLayoutResolver, type MeshLayoutResolvable } from "./scene/mesh-descriptor.ts";
 
 export type BlendPreset = "alpha" | "additive" | "premultiplied";
@@ -139,7 +140,9 @@ export interface Draw {
   group(n: number, bindGroup: GPUBindGroup): this;
   layout(n: number, opts?: DrawLayoutOptions): GPUBindGroupLayout;
   draw(target?: Target | DrawCallOptions): void;
+  /** @throws VGPU-SURFACE-NOT-IN-FRAME when passed a Surface outside gpu.frame(). */
   compile(target?: CompileTarget): Promise<this>;
+  /** @throws VGPU-SURFACE-NOT-IN-FRAME when passed a Surface outside gpu.frame(). */
   compileSync(target?: CompileTarget): this;
 }
 
@@ -243,6 +246,7 @@ export class InternalDraw implements Draw {
     const state = drawState(this);
     const target = opts.target ?? state.defaultTarget;
     if (!target) throw targetRequiredError(`${this.label}.draw`);
+    assertSurfaceTargetInFrame(target, `${this.label}.draw`);
     const encoder = state.device.gpu.createCommandEncoder();
     const pass = encoder.beginRenderPass(target.renderPassDescriptor());
     const validations: ClaimedGroupValidationResult[] = [];
@@ -361,6 +365,7 @@ export class InternalDraw implements Draw {
     const state = drawState(this);
     const resolvedTarget = target ?? state.defaultTarget;
     if (!resolvedTarget) throw targetRequiredError(where);
+    assertSurfaceTargetInFrame(resolvedTarget, where);
     const signature = normalizeSignature(resolvedTarget);
     validateTargetSignature(signature, where);
     return signature;
@@ -619,4 +624,8 @@ function dynamicEntries(draw: InternalDraw, group: number): GPUBindGroupLayoutEn
 function dynamicEntry(entry: GPUBindGroupLayoutEntry): GPUBindGroupLayoutEntry {
   if (!entry.buffer) return entry;
   return { ...entry, buffer: { ...entry.buffer, hasDynamicOffset: true } };
+}
+
+function assertSurfaceTargetInFrame(target: CompileTarget, where: string): void {
+  if (isSurface(target) && !isFrameActive()) throw surfaceNotInFrameError(where);
 }

--- a/packages/vgpu-api/src/draw.ts
+++ b/packages/vgpu-api/src/draw.ts
@@ -302,7 +302,7 @@ export class InternalDraw implements Draw {
   }
 
   encode(pass: GPURenderPassEncoder, target: Target | TargetSignature, opts: DrawCallOptions = {}, claimValidation?: (result: ClaimedGroupValidationResult) => void): void {
-    const pipeline = this.pipelineFor(target);
+    const pipeline = this.pipelineFor(target, true);
     if (!pipeline) return;
     pass.setPipeline(pipeline);
     for (const binding of drawState(this).setCore.bindGroups()) this.#setBindGroup(pass, binding, opts, claimValidation);
@@ -341,8 +341,8 @@ export class InternalDraw implements Draw {
     return this;
   }
 
-  pipelineFor(target: Target | TargetSignature): GPURenderPipeline | undefined {
-    const { key, signature, signatureKey } = this.#compileKey(target, `${this.label}.pipelineFor`);
+  pipelineFor(target: Target | TargetSignature, allowSurface = false): GPURenderPipeline | undefined {
+    const { key, signature, signatureKey } = this.#compileKey(target, `${this.label}.pipelineFor`, allowSurface);
     const pipeline = drawState(this).pipelineStore.getSync(key, () => this.#createPipeline(signature), { where: `${this.label}.pipelineFor`, signature: signatureKey });
     if (pipeline) drawState(this).resolvedPipelineKeys.add(key);
     return pipeline;
@@ -355,17 +355,17 @@ export class InternalDraw implements Draw {
     return promise;
   }
 
-  #compileKey(target: CompileTarget | undefined, where: string): { readonly signature: TargetSignature; readonly signatureKey: string; readonly key: string } {
-    const signature = this.#signatureForKeyTarget(target, where);
+  #compileKey(target: CompileTarget | undefined, where: string, allowSurface = false): { readonly signature: TargetSignature; readonly signatureKey: string; readonly key: string } {
+    const signature = this.#signatureForKeyTarget(target, where, allowSurface);
     const signatureKey = signatureKeyOf(signature);
     return { signature, signatureKey, key: this.#pipelineKey(signature) };
   }
 
-  #signatureForKeyTarget(target: CompileTarget | undefined, where: string): TargetSignature {
+  #signatureForKeyTarget(target: CompileTarget | undefined, where: string, allowSurface = false): TargetSignature {
     const state = drawState(this);
     const resolvedTarget = target ?? state.defaultTarget;
     if (!resolvedTarget) throw targetRequiredError(where);
-    assertSurfaceTargetInFrame(resolvedTarget, where);
+    if (!allowSurface) assertSurfaceTargetInFrame(resolvedTarget, where);
     const signature = normalizeSignature(resolvedTarget);
     validateTargetSignature(signature, where);
     return signature;

--- a/packages/vgpu-api/src/effect.ts
+++ b/packages/vgpu-api/src/effect.ts
@@ -23,7 +23,9 @@ export interface Effect {
   readonly gpu: GPURenderPipeline | undefined;
   set(values: SetBag): this;
   draw(target?: Target | DrawCallOptions): void;
+  /** @throws VGPU-SURFACE-NOT-IN-FRAME when passed a Surface outside gpu.frame(). */
   compile(target?: CompileTarget): Promise<this>;
+  /** @throws VGPU-SURFACE-NOT-IN-FRAME when passed a Surface outside gpu.frame(). */
   compileSync(target?: CompileTarget): this;
 }
 

--- a/packages/vgpu-api/src/errors.ts
+++ b/packages/vgpu-api/src/errors.ts
@@ -151,6 +151,15 @@ export function meshFormatMismatchError(where: string, name: string, meshFormat:
   return meshError("VGPU-MESH-FORMAT-MISMATCH", where, `Attribute '${name}' ${meshFormat} != shader ${shaderType}.`, "Match the float/sint/uint shader base type; widths may differ.");
 }
 
+export function pipelineLayoutGapError(group: number): VGPUError {
+  return new VGPUError({
+    code: "VGPU-PIPELINE-LAYOUT-GAP",
+    message: `Pipeline bind group ${group} is missing.`,
+    fix: "Use consecutive @group() indices starting at 0.",
+    where: "pipeline layout",
+  });
+}
+
 export function compileFailedError(where: string, cause: unknown, signature?: string): VGPUError {
   return new VGPUError({
     code: "VGPU-COMPILE-FAILED",
@@ -184,6 +193,15 @@ export function targetSizeRequiredError(): VGPUError {
     code: "VGPU-TARGET-SIZE-REQUIRED",
     message: "Target size required. Fix: gpu.target({ size: [w,h] }); update surface-derived targets in onResize.",
     where: "gpu.target",
+  });
+}
+
+export function surfaceNotInFrameError(where: string): VGPUError {
+  return new VGPUError({
+    code: "VGPU-SURFACE-NOT-IN-FRAME",
+    message: "Surface targets are only available inside gpu.frame().",
+    fix: "surface passes must run inside gpu.frame(...); precompile against an offscreen gpu.target(...) instead",
+    where,
   });
 }
 

--- a/packages/vgpu-api/src/frame.ts
+++ b/packages/vgpu-api/src/frame.ts
@@ -6,7 +6,7 @@ import { encodeDraw, type Draw, type DrawCallOptions } from "./draw.ts";
 import { effectDraw, type Effect } from "./effect.ts";
 import type { Target } from "./target.ts";
 import { claimedGroupNativeValidationError, frameReentrantError, passPreserveMsaaError, surfaceNotInFrameError, targetRequiredError } from "./errors.ts";
-import { enterFrame, isFrameActive, isSurface, isSurfaceResizeCallbackActive, leaveFrame } from "./surface.ts";
+import { enterFrame, isSurface, isSurfaceResizeCallbackActive, leaveFrame } from "./surface.ts";
 import { isTarget, type ClearColor } from "./target-utils.ts";
 
 export interface FramePassOptions {
@@ -48,7 +48,7 @@ export class Frame {
     const cb = typeof body === "function" ? body : (p: FramePass) => p.draw(body);
     const resolvedTarget = targetOnly ? target : target.target ?? this.defaultTarget;
     if (!resolvedTarget) throw targetRequiredError("Frame.pass");
-    if (isSurface(resolvedTarget) && !isFrameActive()) throw surfaceNotInFrameError("Frame.pass");
+    if (isSurface(resolvedTarget) && this.#submitted) throw surfaceNotInFrameError("Frame.pass");
     const clear = targetOnly ? undefined : target.clear;
     const preserve = clear === false;
     if (preserve && resolvedTarget.sampleCount === 4) throw passPreserveMsaaError();

--- a/packages/vgpu-api/src/frame.ts
+++ b/packages/vgpu-api/src/frame.ts
@@ -5,8 +5,8 @@ import { replayBundles, type Bundle } from "./bundle.ts";
 import { encodeDraw, type Draw, type DrawCallOptions } from "./draw.ts";
 import { effectDraw, type Effect } from "./effect.ts";
 import type { Target } from "./target.ts";
-import { claimedGroupNativeValidationError, frameReentrantError, passPreserveMsaaError, targetRequiredError } from "./errors.ts";
-import { isSurfaceResizeCallbackActive } from "./surface.ts";
+import { claimedGroupNativeValidationError, frameReentrantError, passPreserveMsaaError, surfaceNotInFrameError, targetRequiredError } from "./errors.ts";
+import { enterFrame, isFrameActive, isSurface, isSurfaceResizeCallbackActive, leaveFrame } from "./surface.ts";
 import { isTarget, type ClearColor } from "./target-utils.ts";
 
 export interface FramePassOptions {
@@ -48,6 +48,7 @@ export class Frame {
     const cb = typeof body === "function" ? body : (p: FramePass) => p.draw(body);
     const resolvedTarget = targetOnly ? target : target.target ?? this.defaultTarget;
     if (!resolvedTarget) throw targetRequiredError("Frame.pass");
+    if (isSurface(resolvedTarget) && !isFrameActive()) throw surfaceNotInFrameError("Frame.pass");
     const clear = targetOnly ? undefined : target.clear;
     const preserve = clear === false;
     if (preserve && resolvedTarget.sampleCount === 4) throw passPreserveMsaaError();
@@ -136,6 +137,7 @@ export class FrameRunner {
   frame(cb?: (frame: Frame) => void): Frame {
     if (this.#running || isSurfaceResizeCallbackActive()) throw frameReentrantError();
     this.#running = true;
+    enterFrame();
     try {
       this.advance();
       const frame = this.createFrame();
@@ -145,6 +147,7 @@ export class FrameRunner {
       }
       return frame;
     } finally {
+      leaveFrame();
       this.#running = false;
     }
   }

--- a/packages/vgpu-api/src/pipeline-store.ts
+++ b/packages/vgpu-api/src/pipeline-store.ts
@@ -1,7 +1,7 @@
 import { bindGroupLayoutMetadata, type Device } from "@vgpu/core";
 import type { Target, CompileTarget, TargetSignature } from "./target.ts";
 import { isTarget } from "./target-utils.ts";
-import { compileDisposedError, compileFailedError, compileSignatureInvalidError, type VGPUError } from "./errors.ts";
+import { compileDisposedError, compileFailedError, compileSignatureInvalidError, pipelineLayoutGapError, type VGPUError } from "./errors.ts";
 
 export interface ErrorCtx {
   readonly where: string;
@@ -299,7 +299,7 @@ function contiguousLayouts(bindGroupLayouts: ReadonlyMap<number, GPUBindGroupLay
 
 function requiredLayout(bindGroupLayouts: ReadonlyMap<number, GPUBindGroupLayout>, group: number): GPUBindGroupLayout {
   const layout = bindGroupLayouts.get(group);
-  if (!layout) throw new Error(`Pipeline bind groups must be contiguous; missing group ${group}.`);
+  if (!layout) throw pipelineLayoutGapError(group);
   return layout;
 }
 

--- a/packages/vgpu-api/src/surface.ts
+++ b/packages/vgpu-api/src/surface.ts
@@ -39,7 +39,12 @@ export interface Surface extends Target {
 export type SurfaceCanvas = HTMLCanvasElement | OffscreenCanvas;
 
 let resizeCallbackDepth = 0;
+let frameDepth = 0;
 export function isSurfaceResizeCallbackActive(): boolean { return resizeCallbackDepth > 0; }
+export function isFrameActive(): boolean { return frameDepth > 0; }
+export function enterFrame(): void { frameDepth += 1; }
+export function leaveFrame(): void { frameDepth -= 1; }
+export function isSurface(target: unknown): target is CanvasSurface { return target instanceof CanvasSurface; }
 
 export class CanvasSurface implements Surface {
   readonly resourceIdentity = createResourceIdentity("render-target");

--- a/packages/vgpu-api/tests/bundle/screen-target-bundle.test.ts
+++ b/packages/vgpu-api/tests/bundle/screen-target-bundle.test.ts
@@ -13,7 +13,7 @@ test("surface bundles do not stale just because getCurrentTexture returns a fres
   const surface = gpu.surface(mockCanvas(), { size: [4, 4] });
   const draw = gpu.effect(SOLID, { label: "surfaceStatic" });
 
-  const bundle = gpu.bundle({ target: surface, label: "surfaceBundle" }, (b) => b.draw(draw));
+  const bundle = gpu.bundle({ target: { colors: [surface.format] }, label: "surfaceBundle" }, (b) => b.draw(draw));
 
   expect(() => gpu.frame((frame) => frame.pass({ target: surface }, (p) => p.bundles(bundle)))).not.toThrow();
   expect(() => gpu.frame((frame) => frame.pass({ target: surface }, (p) => p.bundles(bundle)))).not.toThrow();

--- a/packages/vgpu-api/tests/compile-api.test.ts
+++ b/packages/vgpu-api/tests/compile-api.test.ts
@@ -14,6 +14,44 @@ const FRAGMENT_ONLY = `
 @fragment fn fs_main() -> @location(0) vec4f { return vec4f(1.0); }
 `;
 
+function surfaceCanvas(): HTMLCanvasElement {
+  const canvas: Record<string, unknown> = { width: 4, height: 4 };
+  canvas.getContext = (kind: string) => kind === "webgpu" ? {
+    configure: () => undefined,
+    getCurrentTexture: () => ({ createView: () => ({}) }),
+  } : null;
+  return canvas as HTMLCanvasElement;
+}
+
+function expectOutsideFrame(fn: () => unknown): void {
+  try { fn(); }
+  catch (error) {
+    expect(error).toMatchObject({
+      code: "VGPU-SURFACE-NOT-IN-FRAME",
+      fix: "surface passes must run inside gpu.frame(...); precompile against an offscreen gpu.target(...) instead",
+    });
+    return;
+  }
+  throw new Error("Expected VGPU-SURFACE-NOT-IN-FRAME");
+}
+
+test("surface pipeline creation is rejected outside gpu.frame with an offscreen precompile hint", async () => {
+  const gpu = await init();
+  const surface = gpu.surface(surfaceCanvas());
+  const draw = gpu.draw({ shader: WGSL });
+  const effect = gpu.effect(FRAGMENT_ONLY);
+
+  expectOutsideFrame(() => draw.compile(surface));
+  expectOutsideFrame(() => draw.compileSync(surface));
+  expectOutsideFrame(() => draw.draw(surface));
+  expectOutsideFrame(() => effect.compile(surface));
+  expectOutsideFrame(() => effect.compileSync(surface));
+  expectOutsideFrame(() => effect.draw(surface));
+  expectOutsideFrame(() => gpu.bundle({ target: surface }, () => undefined));
+  expect(() => gpu.frame((frame) => frame.pass(surface, draw))).not.toThrow();
+  gpu.dispose();
+});
+
 test("Draw.compile warms the shared store so later draw does not sync-create", async () => {
   const gpu = await init();
   const target = gpu.target({ size: [4, 4] });

--- a/packages/vgpu-api/tests/surface-mock.test.ts
+++ b/packages/vgpu-api/tests/surface-mock.test.ts
@@ -229,15 +229,15 @@ test("surface bundle survives resize, and re-recording from onResize is usable i
   const gpu = await initBrowser({ adapter: createMockAdapter() });
   const manual = gpu.surface(canvasLike(10, 10), { autoResize: false });
   const effect = gpu.effect(SOLID);
-  const resizeBundle = gpu.bundle({ target: manual, label: "surfaceBundle" }, (b) => b.draw(effect));
+  const resizeBundle = gpu.bundle({ target: { colors: [manual.format] }, label: "surfaceBundle" }, (b) => b.draw(effect));
 
   manual.resize([12, 12]);
   expect(() => gpu.frame((f) => f.pass({ target: manual }, (p) => p.bundles(resizeBundle)))).not.toThrow();
 
   const canvas = canvasLike(10, 10);
   const surface = gpu.surface(canvas);
-  let bundle = gpu.bundle({ target: surface, label: "surfaceBundleFresh" }, (b) => b.draw(effect));
-  surface.onResize(() => { bundle = gpu.bundle({ target: surface, label: "surfaceBundleFresh" }, (b) => b.draw(effect)); });
+  let bundle = gpu.bundle({ target: { colors: [surface.format] }, label: "surfaceBundleFresh" }, (b) => b.draw(effect));
+  surface.onResize(() => { bundle = gpu.bundle({ target: { colors: [surface.format] }, label: "surfaceBundleFresh" }, (b) => b.draw(effect)); });
   (canvas as unknown as { clientWidth: number; clientHeight: number }).clientWidth = 13;
   (canvas as unknown as { clientWidth: number; clientHeight: number }).clientHeight = 13;
   expect(() => gpu.frame((f) => f.pass({ target: surface }, (p) => p.bundles(bundle)))).not.toThrow();

--- a/packages/vgpu-api/tests/surface-mock.test.ts
+++ b/packages/vgpu-api/tests/surface-mock.test.ts
@@ -245,3 +245,14 @@ test("surface bundle survives resize, and re-recording from onResize is usable i
   expect(() => gpu.frame((f) => f.pass({ target: surface }, (p) => p.bundles(bundle)))).toThrowError(/VGPU-SURFACE-DISPOSED|disposed/);
   gpu.dispose();
 });
+
+test("a deferred frame can pass a surface before manual submit", async () => {
+  const gpu = await initBrowser({ adapter: createMockAdapter() });
+  const surface = gpu.surface(canvasLike(4, 4), { autoResize: false });
+  const effect = gpu.effect(SOLID);
+  const frame = gpu.frame();
+
+  expect(() => frame.pass(surface, effect)).not.toThrow();
+  frame.submit();
+  gpu.dispose();
+});


### PR DESCRIPTION
## Summary

Addresses external user feedback: using a canvas `Surface` as a compilation or one-shot target outside `gpu.frame()` previously reached opaque/native failures.

- Adds `VGPU-SURFACE-NOT-IN-FRAME` with an actionable offscreen-precompile hint.
- Covers `Draw.compile`, `Draw.compileSync`, `Draw.draw`, Effect equivalents, surface bundle recording, and defensive frame passes.
- Keeps surface work valid within `gpu.frame()` and updates prewarm bundle tests to use explicit target signatures.
- Converts the pipeline-store's generic bind-group-gap error into `VGPU-PIPELINE-LAYOUT-GAP`.

Origin: external user feedback (reported an hour lost diagnosing `effect.compile(surface)`).
