### PR TITLE
Release 0.1.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 0.1.5 — 2026-07-21
+
+### Added
+- **Add `vgpu doctor` for agent-readable environment diagnostics.** It probes Dawn binary resolution and platform compatibility plus OS-specific graphics prerequisites, then performs a real init → render → readback → dispose check for a `healthy` or `unhealthy` verdict. Output is JSON by default with stable exit codes, `--pretty` is available for humans, and `--no-render` returns an explicit `unverified` verdict. Failures include executable Debian/Ubuntu, Fedora/RHEL/Amazon Linux, or generic prescriptions.
+- Add the project glossary and first ADR documenting why doctor health is determined by a real render, plus a getting-started static-render validation workflow and CLI help routing to doctor. `VGPU-NODE-NO-ADAPTER` now points directly to `npx vgpu doctor`.
+
+### Fixed
+- Fix surface prewarming in five docs example runners by compiling against explicit color-format signatures instead of live surfaces.
+- Harden example rendering CI with Node render proofs and uploaded artifacts, plus strict full-thumbnail comparisons across the docs example catalog.
+
 ## 0.1.4 — 2026-07-21
 
 ### Behavior change

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # vgpu
 
-> 0.1.4 — early preview of the new public `vgpu` API
+> 0.1.5 — early preview of the new public `vgpu` API
 
 vgpu is an agentic-first WebGPU library for browsers, Node/Dawn, and deterministic mock tests. The public package is `vgpu`: one `Gpu` context with explicit WGSL reflection and performance-oriented defaults.
 

--- a/packages/adapter-mock/README.md
+++ b/packages/adapter-mock/README.md
@@ -1,6 +1,6 @@
 # @vgpu/adapter-mock
 
-> 0.1.4 — deterministic adapter for `vgpu/mock`
+> 0.1.5 — deterministic adapter for `vgpu/mock`
 
 `@vgpu/adapter-mock` backs the `vgpu/mock` entrypoint for tests that need the public `Gpu` API without real GPU hardware.
 

--- a/packages/adapter-mock/package.json
+++ b/packages/adapter-mock/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vgpu/adapter-mock",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Mock GPU adapter for testing vgpu code without real WebGPU hardware.",
   "keywords": [
     "webgpu",

--- a/packages/adapter-node/README.md
+++ b/packages/adapter-node/README.md
@@ -1,6 +1,6 @@
 # @vgpu/adapter-node
 
-> 0.1.4 — Dawn adapter for `vgpu/node`
+> 0.1.5 — Dawn adapter for `vgpu/node`
 
 `@vgpu/adapter-node` connects vgpu to Node.js through the `webgpu` Dawn native prebuild. Most callers should import `init` from `vgpu/node`; direct adapter/device helpers remain for core layer (`vgpu/core`) tooling.
 

--- a/packages/adapter-node/package.json
+++ b/packages/adapter-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vgpu/adapter-node",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Node.js GPU adapter for vgpu, using Dawn-based WebGPU bindings.",
   "keywords": [
     "webgpu",

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,6 +1,6 @@
 # @vgpu/core
 
-> 0.1.4 — core layer (`vgpu/core`) runtime primitives
+> 0.1.5 — core layer (`vgpu/core`) runtime primitives
 
 `@vgpu/core` contains the low-level WebGPU wrappers used by `vgpu/core`: `Device`, `Buffer`, `Texture`, `Queue`, shader modules, bind-group helpers, resource identities, and validation errors. Most applications should start from `init()` in `vgpu`, `vgpu/node`, or `vgpu/mock` and drop to these primitives only for explicit native control.
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vgpu/core",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Core WebGPU runtime primitives (device, buffer, texture, shader, queue) for vgpu.",
   "keywords": [
     "webgpu",

--- a/packages/render/README.md
+++ b/packages/render/README.md
@@ -1,6 +1,6 @@
 # @vgpu/render
 
-> 0.1.4 — slim legacy/utility render package
+> 0.1.5 — slim legacy/utility render package
 
 New applications should use the public `vgpu` package. `@vgpu/render` remains as a slim package for edit/inspect/utils/perf helpers and compatibility while the old thick render surface is removed from the public path.
 

--- a/packages/render/package.json
+++ b/packages/render/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vgpu/render",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Render pipeline + render pass abstractions for vgpu.",
   "keywords": [
     "webgpu",

--- a/packages/vgpu-api/README.md
+++ b/packages/vgpu-api/README.md
@@ -1,6 +1,6 @@
 # vgpu
 
-> 0.1.4 — public main API (`vgpu`) preview
+> 0.1.5 — public main API (`vgpu`) preview
 
 `vgpu` is the public package for the new API. It is built around one `Gpu` context, explicit WGSL reflection, and `set()` ownership rules that make the fast path the default.
 

--- a/packages/vgpu-api/package.json
+++ b/packages/vgpu-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vgpu",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Public VGPU API entrypoint scaffold for browser, Node, mock, scene, and client typing surfaces.",
   "keywords": [
     "webgpu",

--- a/packages/vgpu/package.json
+++ b/packages/vgpu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vgpu/cli",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Official VGPU CLI for docs, doctor, and WGSL utilities.",
   "keywords": [
     "webgpu",
@@ -45,9 +45,9 @@
     "pngjs": "^7.0.0"
   },
   "peerDependencies": {
-    "@vgpu/adapter-node": "^0.1.4",
-    "@vgpu/wgsl": "^0.1.4",
-    "vgpu": "^0.1.4"
+    "@vgpu/adapter-node": "^0.1.5",
+    "@vgpu/wgsl": "^0.1.5",
+    "vgpu": "^0.1.5"
   },
   "peerDependenciesMeta": {
     "@vgpu/adapter-node": {

--- a/packages/wgsl-std/package.json
+++ b/packages/wgsl-std/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vgpu/wgsl-std",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Pure WGSL utility snippets for vgpu shaders.",
   "keywords": [
     "webgpu",

--- a/packages/wgsl/package.json
+++ b/packages/wgsl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vgpu/wgsl",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "WGSL shader compilation, runtime resolution, and webpack/vite loaders for vgpu.",
   "keywords": [
     "webgpu",


### PR DESCRIPTION
## Summary

Prepare the synchronized VGPU 0.1.5 release, headlined by the new agent-readable `vgpu doctor` environment diagnostics.

| Package | Version |
| --- | --- |
| `vgpu` | `0.1.4` → `0.1.5` |
| `@vgpu/cli` (private) | `0.1.4` → `0.1.5` |
| `@vgpu/core` | `0.1.4` → `0.1.5` |
| `@vgpu/render` | `0.1.4` → `0.1.5` |
| `@vgpu/wgsl` | `0.1.4` → `0.1.5` |
| `@vgpu/wgsl-std` | `0.1.4` → `0.1.5` |
| `@vgpu/adapter-node` | `0.1.4` → `0.1.5` |
| `@vgpu/adapter-mock` | `0.1.4` → `0.1.5` |

### Release highlights

- Adds `vgpu doctor`: JSON-first environment findings, stable exit codes, real-render health verdicts, `--pretty`/`--no-render`, and per-distribution prescriptions.
- Routes CLI/getting-started/no-adapter guidance to doctor and adds the glossary plus the real-render-verdict ADR.
- Fixes five docs example runners to prewarm from color-format signatures rather than live surfaces.
- Hardens example CI with Node render proofs/artifacts and strict full-thumbnail comparisons.
- Updates README banners and CLI optional peers to 0.1.5 while preserving `workspace:*` internals.
- Runs docs generation and example ingestion twice; both are idempotent.

## Verification

- `pnpm install --frozen-lockfile`
- `pnpm run typecheck`
- `pnpm run build`
- `VGPU_CACHE_DIR=$(mktemp -d) pnpm exec vitest run` — 786 passed, 122 skipped
- `pnpm run bundle-check`
- `pnpm run docs:verify-snippets` — 402 snippets
- Packed all publishable packages and installed them together; `vgpu` internals resolve to exact 0.1.5
- Ran `npx vgpu doctor --no-render` from the packed install — emitted valid `unverified` JSON and the documented exit code 1
