### PR TITLE
build: add portable Lavapipe workflow

### DIFF
--- a/.github/workflows/lavapipe-build.yml
+++ b/.github/workflows/lavapipe-build.yml
@@ -1,0 +1,87 @@
+name: Build portable Lavapipe renderer
+
+on:
+  workflow_dispatch:
+    inputs:
+      mesa_version:
+        description: Mesa release version
+        required: true
+        default: 25.0.7
+        type: string
+      mesa_sha256:
+        description: Trusted archive SHA256 (must be updated when overriding Mesa version)
+        required: true
+        default: 592272df3cf01e85e7db300c449df5061092574d099da275d19e97ef0510f8a6
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Linux ${{ matrix.arch }}
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 120
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: x64
+            os: ubuntu-24.04
+          - arch: arm64
+            os: ubuntu-24.04-arm
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build pinned Mesa Lavapipe
+        env:
+          ARCH: ${{ matrix.arch }}
+          MESA_VERSION: ${{ inputs.mesa_version }}
+          MESA_SHA256: ${{ inputs.mesa_sha256 }}
+        run: infra/lavapipe-build/build.sh
+
+      - name: Acquire Dawn validation addon
+        env:
+          ARCH: ${{ matrix.arch }}
+        run: |
+          set -euo pipefail
+          mkdir -p dawn-validation
+          package=$(npm pack webgpu@0.4.0 --pack-destination /tmp --silent)
+          tar -xzf "/tmp/$package" -C dawn-validation --strip-components=2 \
+            "package/dist/linux-${ARCH}.dawn.node"
+          mv "dawn-validation/linux-${ARCH}.dawn.node" dawn-validation/dawn.node
+
+      - name: Verify archive and per-file checksums
+        env:
+          ARCH: ${{ matrix.arch }}
+          MESA_VERSION: ${{ inputs.mesa_version }}
+        run: |
+          set -euo pipefail
+          archive="mesa-lavapipe-${MESA_VERSION}-linux-${ARCH}.tar.gz"
+          (cd lavapipe-out && sha256sum --check "$archive.sha256")
+          (cd lavapipe-out/asset && sha256sum --check SHA256SUMS)
+          tar -tzf "lavapipe-out/$archive" | diff -u \
+            <(printf 'libvulkan_lvp.so\nlvp_icd.json\n') -
+
+      - name: Validate in a clean container
+        env:
+          ARCH: ${{ matrix.arch }}
+          MESA_VERSION: ${{ inputs.mesa_version }}
+        run: |
+          infra/lavapipe-build/validate.sh \
+            "lavapipe-out/mesa-lavapipe-${MESA_VERSION}-linux-${ARCH}.tar.gz" \
+            dawn-validation/dawn.node \
+            lavapipe-validation
+
+      - name: Upload renderer, checksums, and validation evidence
+        uses: actions/upload-artifact@v4
+        with:
+          name: mesa-lavapipe-${{ inputs.mesa_version }}-linux-${{ matrix.arch }}
+          if-no-files-found: error
+          retention-days: 14
+          path: |
+            lavapipe-out/mesa-lavapipe-${{ inputs.mesa_version }}-linux-${{ matrix.arch }}.tar.gz
+            lavapipe-out/mesa-lavapipe-${{ inputs.mesa_version }}-linux-${{ matrix.arch }}.tar.gz.sha256
+            lavapipe-out/asset/SHA256SUMS
+            lavapipe-out/evidence/
+            lavapipe-validation/

--- a/.github/workflows/lavapipe-build.yml
+++ b/.github/workflows/lavapipe-build.yml
@@ -63,15 +63,28 @@ jobs:
           tar -tzf "lavapipe-out/$archive" | diff -u \
             <(printf 'libvulkan_lvp.so\nlvp_icd.json\n') -
 
-      - name: Validate in a clean container
+      - name: Validate on the glibc 2.36 Bookworm floor proof
+        if: matrix.arch == 'arm64'
         env:
           ARCH: ${{ matrix.arch }}
           MESA_VERSION: ${{ inputs.mesa_version }}
+          VALIDATION_IMAGE: node:24-bookworm
         run: |
           infra/lavapipe-build/validate.sh \
             "lavapipe-out/mesa-lavapipe-${MESA_VERSION}-linux-${ARCH}.tar.gz" \
             dawn-validation/dawn.node \
-            lavapipe-validation
+            lavapipe-validation-bookworm
+
+      - name: Validate on current Trixie
+        env:
+          ARCH: ${{ matrix.arch }}
+          MESA_VERSION: ${{ inputs.mesa_version }}
+          VALIDATION_IMAGE: node:24-trixie
+        run: |
+          infra/lavapipe-build/validate.sh \
+            "lavapipe-out/mesa-lavapipe-${MESA_VERSION}-linux-${ARCH}.tar.gz" \
+            dawn-validation/dawn.node \
+            lavapipe-validation-trixie
 
       - name: Upload renderer, checksums, and validation evidence
         uses: actions/upload-artifact@v4
@@ -84,4 +97,5 @@ jobs:
             lavapipe-out/mesa-lavapipe-${{ inputs.mesa_version }}-linux-${{ matrix.arch }}.tar.gz.sha256
             lavapipe-out/asset/SHA256SUMS
             lavapipe-out/evidence/
-            lavapipe-validation/
+            lavapipe-validation-bookworm/
+            lavapipe-validation-trixie/

--- a/infra/lavapipe-build/Dockerfile
+++ b/infra/lavapipe-build/Dockerfile
@@ -1,16 +1,38 @@
 # syntax=docker/dockerfile:1
-ARG DEBIAN_RELEASE=trixie
+# Debian 11 supplies the GLIBC 2.31 compatibility floor. LLVM 19 comes from
+# apt.llvm.org's official Bullseye repository because Bullseye predates LLVM 19.
+ARG DEBIAN_RELEASE=bullseye-slim
 FROM debian:${DEBIAN_RELEASE} AS build
 ARG MESA_VERSION=25.0.7
 ARG MESA_SHA256=592272df3cf01e85e7db300c449df5061092574d099da275d19e97ef0510f8a6
-ENV DEBIAN_FRONTEND=noninteractive
+ARG LIBDRM_VERSION=2.4.124
+ARG LIBDRM_SHA256=ac36293f61ca4aafaf4b16a2a7afff312aa4f5c37c9fbd797de9e3c0863ca379
+ENV DEBIAN_FRONTEND=noninteractive \
+    LDFLAGS="-static-libstdc++ -static-libgcc"
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    ca-certificates curl xz-utils build-essential meson ninja-build pkg-config \
-    python3 python3-mako python3-yaml python3-packaging flex bison gettext \
+    ca-certificates curl gnupg \
+ && curl -fsSL https://apt.llvm.org/llvm-snapshot.gpg.key \
+    | gpg --dearmor -o /usr/share/keyrings/apt.llvm.org.gpg \
+ && echo 'deb [signed-by=/usr/share/keyrings/apt.llvm.org.gpg] https://apt.llvm.org/bullseye/ llvm-toolchain-bullseye-19 main' \
+    > /etc/apt/sources.list.d/llvm.list \
+ && apt-get update && apt-get install -y --no-install-recommends \
+    xz-utils build-essential ninja-build pkg-config binutils \
+    python3 python3-pip python3-mako python3-yaml python3-packaging flex bison gettext \
     llvm-19-dev libclang-cpp19-dev libpolly-19-dev libdrm-dev libudev-dev libexpat1-dev libelf-dev \
     libunwind-dev libzstd-dev zlib1g-dev libxml2-dev libffi-dev libedit-dev libncurses-dev \
-    libvulkan-dev glslang-tools glslang-dev spirv-tools
+    libvulkan-dev glslang-tools glslang-dev spirv-tools \
+ && pip3 install --no-cache-dir meson==1.7.0
 WORKDIR /src
+# Mesa 25 requires libdrm >= 2.4.109; Bullseye ships 2.4.104. Build the
+# pinned newer libdrm in the old userspace so it retains the GLIBC 2.31 floor.
+RUN curl -fsSLO "https://dri.freedesktop.org/libdrm/libdrm-${LIBDRM_VERSION}.tar.xz" \
+ && echo "${LIBDRM_SHA256}  libdrm-${LIBDRM_VERSION}.tar.xz" | sha256sum -c - \
+ && tar -xf "libdrm-${LIBDRM_VERSION}.tar.xz" \
+ && meson setup libdrm-build "libdrm-${LIBDRM_VERSION}" --prefix=/usr/local --libdir=lib \
+    -Dtests=false -Dman-pages=disabled \
+ && ninja -C libdrm-build \
+ && ninja -C libdrm-build install \
+ && ldconfig
 RUN curl -fsSLO "https://archive.mesa3d.org/mesa-${MESA_VERSION}.tar.xz" \
  && echo "${MESA_SHA256}  mesa-${MESA_VERSION}.tar.xz" | sha256sum -c - \
  && tar -xf "mesa-${MESA_VERSION}.tar.xz"
@@ -31,11 +53,21 @@ RUN mkdir -p /out \
  && strip --strip-unneeded /out/libvulkan_lvp.so \
  && llvm-config-19 --link-static --libs native engine mcjit orcjit core analysis scalaropts transformutils instcombine target bitreader bitwriter irreader asmparser > /out/llvm-static-link-libs.txt \
  && ldd /out/libvulkan_lvp.so > /out/ldd.txt \
- && readelf -d /out/libvulkan_lvp.so > /out/readelf-dynamic.txt
+ && readelf -d /out/libvulkan_lvp.so > /out/readelf-dynamic.txt \
+ && readelf --version-info /out/libvulkan_lvp.so > /out/readelf-version-info.txt \
+ && objdump -T /out/libvulkan_lvp.so > /out/objdump-dynamic-symbols.txt \
+ && max_glibc=$(grep -o 'GLIBC_[0-9.]*' /out/objdump-dynamic-symbols.txt | sort -V | tail -1) \
+ && test "$(printf '%s\n' GLIBC_2.31 "$max_glibc" | sort -V | tail -1)" = GLIBC_2.31 \
+ && max_glibcxx=$(grep -o 'GLIBCXX_[0-9.]*' /out/objdump-dynamic-symbols.txt | sort -V | tail -1 || true) \
+ && test -z "$max_glibcxx" \
+ && max_cxxabi=$(grep -o 'CXXABI_[0-9.]*' /out/objdump-dynamic-symbols.txt | sort -V | tail -1 || true) \
+ && test -z "$max_cxxabi" \
+ && printf 'GLIBC=%s\nGLIBCXX=none (static libstdc++)\nCXXABI=none (static libstdc++)\n' "$max_glibc" > /out/symbol-version-floor.txt
 
 FROM debian:${DEBIAN_RELEASE} AS artifact
 ARG MESA_VERSION
 LABEL org.opencontainers.image.title="vgpu Lavapipe build" \
       org.opencontainers.image.version="${MESA_VERSION}" \
-      org.opencontainers.image.source="https://github.com/vercel-labs/vgpu"
+      org.opencontainers.image.source="https://github.com/vercel-labs/vgpu" \
+      dev.vgpu.glibc-floor="2.31"
 COPY --from=build /out /out

--- a/infra/lavapipe-build/Dockerfile
+++ b/infra/lavapipe-build/Dockerfile
@@ -1,0 +1,41 @@
+# syntax=docker/dockerfile:1
+ARG DEBIAN_RELEASE=trixie
+FROM debian:${DEBIAN_RELEASE} AS build
+ARG MESA_VERSION=25.0.7
+ARG MESA_SHA256=592272df3cf01e85e7db300c449df5061092574d099da275d19e97ef0510f8a6
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates curl xz-utils build-essential meson ninja-build pkg-config \
+    python3 python3-mako python3-yaml python3-packaging flex bison gettext \
+    llvm-19-dev libclang-cpp19-dev libpolly-19-dev libdrm-dev libudev-dev libexpat1-dev libelf-dev \
+    libunwind-dev libzstd-dev zlib1g-dev libxml2-dev libffi-dev libedit-dev libncurses-dev \
+    libvulkan-dev glslang-tools glslang-dev spirv-tools
+WORKDIR /src
+RUN curl -fsSLO "https://archive.mesa3d.org/mesa-${MESA_VERSION}.tar.xz" \
+ && echo "${MESA_SHA256}  mesa-${MESA_VERSION}.tar.xz" | sha256sum -c - \
+ && tar -xf "mesa-${MESA_VERSION}.tar.xz"
+WORKDIR /src/mesa-${MESA_VERSION}
+RUN meson setup build --prefix=/opt/lavapipe --libdir=lib --buildtype=release \
+    -Db_lto=true -Db_ndebug=true -Dstrip=true \
+    -Dvulkan-drivers=swrast -Dgallium-drivers=llvmpipe -Dshared-llvm=disabled \
+    -Dglx=disabled -Degl=disabled -Dgbm=disabled -Dplatforms=[] \
+    -Dgles1=disabled -Dgles2=disabled -Dopengl=false -Dglvnd=disabled \
+    -Dllvm=enabled -Dshared-glapi=disabled -Dvalgrind=disabled \
+    -Dlibunwind=disabled -Dlmsensors=disabled -Dzstd=disabled \
+    -Dbuild-tests=false -Dinstall-mesa-clc=false \
+ && ninja -C build -v \
+ && ninja -C build install
+RUN mkdir -p /out \
+ && cp /opt/lavapipe/lib/libvulkan_lvp.so /out/libvulkan_lvp.so \
+ && printf '{\n  "file_format_version": "1.0.0",\n  "ICD": {\n    "library_path": "./libvulkan_lvp.so",\n    "api_version": "1.4.305"\n  }\n}\n' > /out/lvp_icd.json \
+ && strip --strip-unneeded /out/libvulkan_lvp.so \
+ && llvm-config-19 --link-static --libs native engine mcjit orcjit core analysis scalaropts transformutils instcombine target bitreader bitwriter irreader asmparser > /out/llvm-static-link-libs.txt \
+ && ldd /out/libvulkan_lvp.so > /out/ldd.txt \
+ && readelf -d /out/libvulkan_lvp.so > /out/readelf-dynamic.txt
+
+FROM debian:${DEBIAN_RELEASE} AS artifact
+ARG MESA_VERSION
+LABEL org.opencontainers.image.title="vgpu Lavapipe build" \
+      org.opencontainers.image.version="${MESA_VERSION}" \
+      org.opencontainers.image.source="https://github.com/vercel-labs/vgpu"
+COPY --from=build /out /out

--- a/infra/lavapipe-build/README.md
+++ b/infra/lavapipe-build/README.md
@@ -1,0 +1,41 @@
+# Lavapipe portable renderer build
+
+This recipe builds Mesa Lavapipe with LLVM statically linked, packages the renderer and relative-path Vulkan ICD manifest, and validates the result against Dawn in a clean container with no distro Mesa driver installed.
+
+## Build and validate
+
+```bash
+# Defaults: Mesa 25.0.7 and the host architecture.
+infra/lavapipe-build/build.sh
+
+# Explicit matrix target (run this on the matching native runner).
+MESA_VERSION=25.0.7 ARCH=arm64 infra/lavapipe-build/build.sh
+
+infra/lavapipe-build/validate.sh \
+  lavapipe-out/mesa-lavapipe-25.0.7-linux-arm64.tar.gz \
+  "$HOME/.cache/vgpu/dawn/0.4.0-vgpu.1/linux-arm64-gnu/dawn-linux-arm64-gnu.node"
+```
+
+`OUTPUT_DIR` controls the build output. For a Mesa version other than 25.0.7, set both `MESA_VERSION` and the archive's trusted `MESA_SHA256`; the default checksum is only valid for 25.0.7. Builds are native: use an arm64 host for `ARCH=arm64` and an x64 host for `ARCH=x64`.
+
+## Validated Mesa 25.0.7 result
+
+The arm64 prototype produced:
+
+| File | Raw bytes | gzip-9 bytes |
+|---|---:|---:|
+| `libvulkan_lvp.so` | 57,364,920 | 20,510,852 |
+| `lvp_icd.json` | 124 | 131 |
+| release-shaped tarball | — | **20,576,758 (20.58 MB)** |
+
+Its tarball SHA256 was `86a4093d97f1a307fd1c6af96ecac09d4983b0ff3459b4dfc551e6ffdd70774a`. The clean-container harness passed three fresh processes: 17 Dawn features including `shader-f16`, `maxComputeInvocationsPerWorkgroup` 1024, exact 64×64 readback (`[64,128,191,255]` center, `[0,0,0,255]` corner, 1,352 nonblack pixels), and no uncaptured errors. Cold/warm timings were 144.689 ms, 31.980 ms, and 22.919 ms.
+
+## Build and runtime gotchas
+
+- Mesa 25.0.7 has **no `.sha256sum` sidecar**. The Dockerfile therefore pins the archive SHA256 inline: `592272df3cf01e85e7db300c449df5061092574d099da275d19e97ef0510f8a6`.
+- `-Dshared-llvm=disabled` requires `llvm-19-dev` **and `libpolly-19-dev`**. Debian's static LLVM metadata references Polly; omitting its static archives fails the final link with `cannot find -lPolly` / `cannot find -lPollyISL`.
+- `-Db_lto=true` is validated. The selected static target is native-only rather than every LLVM backend.
+- Mesa reports `GALLIVM_USE_ORCJIT=0` in this configuration. llvmpipe uses MCJIT, even though LLVM JIT/execution components are statically present.
+- Static LLVM does not make the renderer fully static. At runtime the system must provide the Vulkan loader (`libvulkan.so.1`, required by Dawn), `libzstd.so.1`, and `libz.so.1`, plus normal libc/libstdc++ and device-support libraries. **This loader/runtime dependency closure is a design input for phase 2**, not something the renderer artifact can silently avoid.
+
+The build records `ldd`, `readelf -d`, and LLVM static-link component evidence under `lavapipe-out/evidence/`. The archive contains only `libvulkan_lvp.so` and `lvp_icd.json`; checksums are emitted beside the archive and under `asset/SHA256SUMS`.

--- a/infra/lavapipe-build/README.md
+++ b/infra/lavapipe-build/README.md
@@ -1,6 +1,17 @@
 # Lavapipe portable renderer build
 
-This recipe builds Mesa Lavapipe with LLVM statically linked, packages the renderer and relative-path Vulkan ICD manifest, and validates the result against Dawn in a clean container with no distro Mesa driver installed.
+This recipe builds Mesa Lavapipe with LLVM and the C++ runtime statically linked, packages the renderer plus a relative-path Vulkan ICD manifest, and validates the result against Dawn without a distro Mesa driver.
+
+## Portability baseline
+
+The builder is **Debian 11 Bullseye (glibc 2.31)**, matching the portable Dawn prebuild's old-host strategy. The original Trixie prototype required `GLIBC_2.38` and could not load on the current Debian 12/Bookworm sandbox (glibc 2.36). The Bullseye build's measured maximum is **GLIBC 2.29**; `validate.sh` rejects anything above the documented 2.31 floor. `libstdc++` and `libgcc` are linked statically, so the artifact has no `GLIBCXX` or `CXXABI` requirements.
+
+Bullseye predates required build dependencies, so the recipe deliberately:
+
+- installs LLVM 19.1.7 from apt.llvm.org's official Bullseye repository;
+- installs `libpolly-19-dev`, whose package was audited to contain both `libPolly.a` and `libPollyISL.a`;
+- builds pinned libdrm 2.4.124 from source in the Bullseye userspace because Mesa 25 requires >=2.4.109 while Bullseye ships 2.4.104; and
+- installs Meson 1.7.0 explicitly.
 
 ## Build and validate
 
@@ -8,34 +19,36 @@ This recipe builds Mesa Lavapipe with LLVM statically linked, packages the rende
 # Defaults: Mesa 25.0.7 and the host architecture.
 infra/lavapipe-build/build.sh
 
-# Explicit matrix target (run this on the matching native runner).
-MESA_VERSION=25.0.7 ARCH=arm64 infra/lavapipe-build/build.sh
-
-infra/lavapipe-build/validate.sh \
-  lavapipe-out/mesa-lavapipe-25.0.7-linux-arm64.tar.gz \
-  "$HOME/.cache/vgpu/dawn/0.4.0-vgpu.1/linux-arm64-gnu/dawn-linux-arm64-gnu.node"
+# Run both compatibility proofs with the portable Dawn addon.
+VALIDATION_IMAGE=node:24-bookworm infra/lavapipe-build/validate.sh \
+  lavapipe-out/mesa-lavapipe-25.0.7-linux-arm64.tar.gz /path/to/portable-dawn.node \
+  lavapipe-validation-bookworm
+VALIDATION_IMAGE=node:24-trixie infra/lavapipe-build/validate.sh \
+  lavapipe-out/mesa-lavapipe-25.0.7-linux-arm64.tar.gz /path/to/portable-dawn.node \
+  lavapipe-validation-trixie
 ```
 
-`OUTPUT_DIR` controls the build output. For a Mesa version other than 25.0.7, set both `MESA_VERSION` and the archive's trusted `MESA_SHA256`; the default checksum is only valid for 25.0.7. Builds are native: use an arm64 host for `ARCH=arm64` and an x64 host for `ARCH=x64`.
+`OUTPUT_DIR` controls output. For a Mesa version other than 25.0.7, set both `MESA_VERSION` and its trusted `MESA_SHA256`. Builds are native: use an arm64 host for `ARCH=arm64` and x64 for `ARCH=x64`.
 
-## Validated Mesa 25.0.7 result
+## Validated Mesa 25.0.7 arm64 result
 
-The arm64 prototype produced:
+| File | Bytes |
+|---|---:|
+| `libvulkan_lvp.so` | **56,864,480** |
+| `lvp_icd.json` | 124 |
+| release-shaped tarball | **20,568,206 (20.57 MB)** |
 
-| File | Raw bytes | gzip-9 bytes |
-|---|---:|---:|
-| `libvulkan_lvp.so` | 57,364,920 | 20,510,852 |
-| `lvp_icd.json` | 124 | 131 |
-| release-shaped tarball | — | **20,576,758 (20.58 MB)** |
+Tarball SHA256: `eac1477d6404af2d63fc08104e980d0cbbf657470c966a0bc638099c00d3dcac`.
 
-Its tarball SHA256 was `86a4093d97f1a307fd1c6af96ecac09d4983b0ff3459b4dfc551e6ffdd70774a`. The clean-container harness passed three fresh processes: 17 Dawn features including `shader-f16`, `maxComputeInvocationsPerWorkgroup` 1024, exact 64×64 readback (`[64,128,191,255]` center, `[0,0,0,255]` corner, 1,352 nonblack pixels), and no uncaptured errors. Cold/warm timings were 144.689 ms, 31.980 ms, and 22.919 ms.
+Both clean Bookworm and Trixie containers passed three fresh processes: 17 Dawn features including `shader-f16`, `maxComputeInvocationsPerWorkgroup` 1024, exact 64×64 readback (`[64,128,191,255]` center, `[0,0,0,255]` corner, 1,352 nonblack pixels), and no uncaptured errors.
+
+The asset also passed directly on the current Bookworm host using `vgpu@0.1.5` and its portable Dawn loader: `vgpu doctor` reported **healthy**, adapter **llvmpipe: Mesa 25.0.7 (LLVM 19.1.7)**, type `cpu`; host `ldd` resolved every dependency and render/dispose exited cleanly.
 
 ## Build and runtime gotchas
 
-- Mesa 25.0.7 has **no `.sha256sum` sidecar**. The Dockerfile therefore pins the archive SHA256 inline: `592272df3cf01e85e7db300c449df5061092574d099da275d19e97ef0510f8a6`.
-- `-Dshared-llvm=disabled` requires `llvm-19-dev` **and `libpolly-19-dev`**. Debian's static LLVM metadata references Polly; omitting its static archives fails the final link with `cannot find -lPolly` / `cannot find -lPollyISL`.
-- `-Db_lto=true` is validated. The selected static target is native-only rather than every LLVM backend.
-- Mesa reports `GALLIVM_USE_ORCJIT=0` in this configuration. llvmpipe uses MCJIT, even though LLVM JIT/execution components are statically present.
-- Static LLVM does not make the renderer fully static. At runtime the system must provide the Vulkan loader (`libvulkan.so.1`, required by Dawn), `libzstd.so.1`, and `libz.so.1`, plus normal libc/libstdc++ and device-support libraries. **This loader/runtime dependency closure is a design input for phase 2**, not something the renderer artifact can silently avoid.
+- Mesa 25.0.7 has no `.sha256sum` sidecar. Its archive SHA256 is pinned inline: `592272df3cf01e85e7db300c449df5061092574d099da275d19e97ef0510f8a6`.
+- Omitting Polly static archives fails the final link with `cannot find -lPolly` / `cannot find -lPollyISL`.
+- `-Dshared-llvm=disabled` and `-Db_lto=true` are validated. Mesa reports `GALLIVM_USE_ORCJIT=0`, so llvmpipe uses MCJIT.
+- Static LLVM does not make the renderer fully static. Runtime dependencies include the Vulkan loader (`libvulkan.so.1`, required by Dawn), `libzstd.so.1`, `libz.so.1`, libdrm, libudev, libm, and libc. **This dependency closure is a phase-2 design input.**
 
-The build records `ldd`, `readelf -d`, and LLVM static-link component evidence under `lavapipe-out/evidence/`. The archive contains only `libvulkan_lvp.so` and `lvp_icd.json`; checksums are emitted beside the archive and under `asset/SHA256SUMS`.
+The build records `ldd`, dynamic/version symbol audits, and LLVM static-link components under `lavapipe-out/evidence/`. The archive itself contains only `libvulkan_lvp.so` and `lvp_icd.json`.

--- a/infra/lavapipe-build/build.sh
+++ b/infra/lavapipe-build/build.sh
@@ -29,7 +29,9 @@ docker cp "$container:/out/." "$OUTPUT_DIR/asset"
 docker rm "$container" >/dev/null
 container=
 mv "$OUTPUT_DIR/asset/ldd.txt" "$OUTPUT_DIR/asset/llvm-static-link-libs.txt" \
-  "$OUTPUT_DIR/asset/readelf-dynamic.txt" "$OUTPUT_DIR/evidence/"
+  "$OUTPUT_DIR/asset/readelf-dynamic.txt" "$OUTPUT_DIR/asset/readelf-version-info.txt" \
+  "$OUTPUT_DIR/asset/objdump-dynamic-symbols.txt" "$OUTPUT_DIR/asset/symbol-version-floor.txt" \
+  "$OUTPUT_DIR/evidence/"
 archive="mesa-lavapipe-${MESA_VERSION}-linux-${ARCH}.tar.gz"
 tar --sort=name --mtime='UTC 1970-01-01' --owner=0 --group=0 --numeric-owner \
   -C "$OUTPUT_DIR/asset" -czf "$OUTPUT_DIR/$archive" libvulkan_lvp.so lvp_icd.json

--- a/infra/lavapipe-build/build.sh
+++ b/infra/lavapipe-build/build.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -euo pipefail
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
+MESA_VERSION=${MESA_VERSION:-${1:-25.0.7}}
+ARCH=${ARCH:-${2:-$(uname -m)}}
+MESA_SHA256=${MESA_SHA256:-592272df3cf01e85e7db300c449df5061092574d099da275d19e97ef0510f8a6}
+OUTPUT_DIR=${OUTPUT_DIR:-$ROOT/lavapipe-out}
+case "$ARCH" in
+  arm64|aarch64) ARCH=arm64 ;;
+  x64|x86_64|amd64) ARCH=x64 ;;
+  *) echo "Unsupported architecture: $ARCH" >&2; exit 2 ;;
+esac
+IMAGE="vgpu-lavapipe-build:${MESA_VERSION}-${ARCH}"
+container=
+cleanup() {
+  if [[ -n "$container" ]]; then docker rm -f "$container" >/dev/null 2>&1 || true; fi
+  docker image rm "$IMAGE" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+rm -rf "$OUTPUT_DIR"
+mkdir -p "$OUTPUT_DIR/asset" "$OUTPUT_DIR/evidence"
+docker build --pull \
+  --label vgpu-lavapipe-build=1 \
+  --build-arg "MESA_VERSION=$MESA_VERSION" \
+  --build-arg "MESA_SHA256=$MESA_SHA256" \
+  --tag "$IMAGE" --file "$ROOT/infra/lavapipe-build/Dockerfile" "$ROOT"
+container=$(docker create --label vgpu-lavapipe-build=1 "$IMAGE")
+docker cp "$container:/out/." "$OUTPUT_DIR/asset"
+docker rm "$container" >/dev/null
+container=
+mv "$OUTPUT_DIR/asset/ldd.txt" "$OUTPUT_DIR/asset/llvm-static-link-libs.txt" \
+  "$OUTPUT_DIR/asset/readelf-dynamic.txt" "$OUTPUT_DIR/evidence/"
+archive="mesa-lavapipe-${MESA_VERSION}-linux-${ARCH}.tar.gz"
+tar --sort=name --mtime='UTC 1970-01-01' --owner=0 --group=0 --numeric-owner \
+  -C "$OUTPUT_DIR/asset" -czf "$OUTPUT_DIR/$archive" libvulkan_lvp.so lvp_icd.json
+(
+  cd "$OUTPUT_DIR"
+  sha256sum "$archive" > "$archive.sha256"
+  cd asset
+  sha256sum libvulkan_lvp.so lvp_icd.json > SHA256SUMS
+)
+printf 'Built %s (%s bytes)\n' "$OUTPUT_DIR/$archive" "$(stat -c %s "$OUTPUT_DIR/$archive")"

--- a/infra/lavapipe-build/dump-render.mjs
+++ b/infra/lavapipe-build/dump-render.mjs
@@ -1,0 +1,55 @@
+import assert from 'node:assert/strict';
+import { createRequire } from 'node:module';
+import { performance } from 'node:perf_hooks';
+const require = createRequire(import.meta.url);
+const binding = require(process.env.DAWN_NODE ?? '/cache/dawn.node');
+Object.assign(globalThis, binding.globals);
+const start = performance.now();
+const flags = (process.env.DAWN_FLAGS ?? 'backend=vulkan').split(/\s+/).filter(Boolean);
+const gpu = binding.create(flags);
+const adapter = await gpu.requestAdapter({ powerPreference: 'high-performance' });
+assert(adapter, 'Dawn returned a null adapter');
+const features = [...adapter.features].sort();
+const limits = {
+  maxComputeInvocationsPerWorkgroup: adapter.limits.maxComputeInvocationsPerWorkgroup,
+};
+const info = {};
+for (const key of ['vendor', 'architecture', 'device', 'description', 'backendType', 'adapterType']) {
+  if (adapter.info?.[key] !== undefined) info[key] = adapter.info[key];
+}
+assert.equal(features.length, 17, `expected 17 Dawn features, got ${features.length}`);
+assert(features.includes('shader-f16'), 'expected shader-f16 feature');
+assert.equal(limits.maxComputeInvocationsPerWorkgroup, 1024);
+const device = await adapter.requestDevice();
+const uncaptured = [];
+device.addEventListener?.('uncapturederror', event => uncaptured.push(String(event.error)));
+const W = 64, H = 64, BPR = 256;
+const texture = device.createTexture({ size: [W, H], format: 'rgba8unorm', usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.COPY_SRC });
+const readback = device.createBuffer({ size: BPR * H, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ });
+const shader = device.createShaderModule({ code: `
+@vertex fn vs(@builtin(vertex_index) i:u32)->@builtin(position) vec4f {
+ var p=array<vec2f,3>(vec2f(-0.8,-0.8),vec2f(0.8,-0.8),vec2f(0.0,0.8)); return vec4f(p[i],0,1);
+}
+@fragment fn fs()->@location(0) vec4f { return vec4f(0.25,0.5,0.75,1.0); }
+` });
+const pipeline = device.createRenderPipeline({ layout: 'auto', vertex: { module: shader, entryPoint: 'vs' }, fragment: { module: shader, entryPoint: 'fs', targets: [{ format: 'rgba8unorm' }] }, primitive: { topology: 'triangle-list' } });
+const encoder = device.createCommandEncoder();
+const pass = encoder.beginRenderPass({ colorAttachments: [{ view: texture.createView(), clearValue: { r: 0, g: 0, b: 0, a: 1 }, loadOp: 'clear', storeOp: 'store' }] });
+pass.setPipeline(pipeline); pass.draw(3); pass.end();
+encoder.copyTextureToBuffer({ texture }, { buffer: readback, bytesPerRow: BPR }, [W, H]);
+device.queue.submit([encoder.finish()]);
+await readback.mapAsync(GPUMapMode.READ);
+const bytes = new Uint8Array(readback.getMappedRange());
+const center = [...bytes.slice(32 * BPR + 32 * 4, 32 * BPR + 32 * 4 + 4)];
+const corner = [...bytes.slice(0, 4)];
+let nonblackPixels = 0;
+for (let y = 0; y < H; y++) for (let x = 0; x < W; x++) {
+  if (bytes[y * BPR + x * 4] || bytes[y * BPR + x * 4 + 1] || bytes[y * BPR + x * 4 + 2]) nonblackPixels++;
+}
+assert.deepEqual(center, [64, 128, 191, 255]);
+assert.deepEqual(corner, [0, 0, 0, 255]);
+assert.equal(nonblackPixels, 1352);
+assert.deepEqual(uncaptured, []);
+const elapsedMs = Number((performance.now() - start).toFixed(3));
+readback.unmap(); readback.destroy(); texture.destroy(); device.destroy();
+console.log(JSON.stringify({ ok: true, flags, info, featureCount: features.length, features, limits, render: { width: W, height: H, center, corner, nonblackPixels, elapsedMs, uncaptured } }, null, 2));

--- a/infra/lavapipe-build/validate.sh
+++ b/infra/lavapipe-build/validate.sh
@@ -4,6 +4,7 @@ ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
 ARCHIVE=${1:?usage: validate.sh ARCHIVE DAWN_NODE [RESULTS_DIR]}
 DAWN=${2:?usage: validate.sh ARCHIVE DAWN_NODE [RESULTS_DIR]}
 RESULTS_DIR=${3:-$ROOT/lavapipe-validation}
+VALIDATION_IMAGE=${VALIDATION_IMAGE:-node:24-trixie}
 [[ -f "$ARCHIVE" ]] || { echo "Archive not found: $ARCHIVE" >&2; exit 2; }
 [[ -f "$DAWN" ]] || { echo "Dawn addon not found: $DAWN" >&2; exit 2; }
 ARCHIVE=$(realpath "$ARCHIVE")
@@ -15,13 +16,13 @@ docker run --rm --label vgpu-lavapipe-build=1 \
   -v "$DAWN:/cache/dawn.node:ro" \
   -v "$ARCHIVE:/input/lavapipe.tar.gz:ro" \
   -v "$ROOT/infra/lavapipe-build/dump-render.mjs:/work/dump-render.mjs:ro" \
-  -v "$RESULTS_DIR:/out" node:24-trixie bash -c '
+  -v "$RESULTS_DIR:/out" "$VALIDATION_IMAGE" bash -c '
 set -euo pipefail
 ! dpkg-query -W mesa-vulkan-drivers >/dev/null 2>&1
 apt-get update -qq
-DEBIAN_FRONTEND=noninteractive apt-get install -y -qq --no-install-recommends libdrm2 libvulkan1 >/dev/null
+DEBIAN_FRONTEND=noninteractive apt-get install -y -qq --no-install-recommends binutils libdrm2 libvulkan1 >/dev/null
 ! dpkg-query -W mesa-vulkan-drivers >/dev/null 2>&1
-dpkg-query -W -f='"'"'${Package}=${Version}\n'"'"' libdrm2 libvulkan1 > /out/clean-container-packages.txt
+dpkg-query -W -f='"'"'${Package}=${Version}\n'"'"' binutils libdrm2 libvulkan1 > /out/clean-container-packages.txt
 mkdir -p /asset /tmp/runtime; chmod 700 /tmp/runtime
 tar -xzf /input/lavapipe.tar.gz -C /asset
 (cd /asset && sha256sum libvulkan_lvp.so lvp_icd.json > /out/asset-SHA256SUMS)
@@ -30,8 +31,16 @@ export DAWN_NODE=/cache/dawn.node DAWN_FLAGS=backend=vulkan
 export VK_ICD_FILENAMES=/asset/lvp_icd.json
 ldd /asset/libvulkan_lvp.so > /out/clean-container-ldd.txt
 ! grep "not found" /out/clean-container-ldd.txt
+objdump -T /asset/libvulkan_lvp.so > /out/objdump-dynamic-symbols.txt
+max_glibc=$(grep -o "GLIBC_[0-9.]*" /out/objdump-dynamic-symbols.txt | sort -V | tail -1)
+test "$(printf "%s\n" GLIBC_2.31 "$max_glibc" | sort -V | tail -1)" = GLIBC_2.31
+max_glibcxx=$( (grep -o "GLIBCXX_[0-9.]*" /out/objdump-dynamic-symbols.txt || true) | sort -V | tail -1)
+if test -n "$max_glibcxx"; then test "$(printf "%s\n" GLIBCXX_3.4.28 "$max_glibcxx" | sort -V | tail -1)" = GLIBCXX_3.4.28; fi
+max_cxxabi=$( (grep -o "CXXABI_[0-9.]*" /out/objdump-dynamic-symbols.txt || true) | sort -V | tail -1)
+if test -n "$max_cxxabi"; then test "$(printf "%s\n" CXXABI_1.3.12 "$max_cxxabi" | sort -V | tail -1)" = CXXABI_1.3.12; fi
+printf "GLIBC=%s\nGLIBCXX=%s\nCXXABI=%s\n" "$max_glibc" "${max_glibcxx:-none}" "${max_cxxabi:-none}" > /out/symbol-version-floor.txt
 for run in 1 2 3; do
   node /work/dump-render.mjs > "/out/lavapipe-run${run}.json" 2> "/out/lavapipe-run${run}.stderr"
 done
 '
-printf 'Validation passed: 17 features, shader-f16, compute 1024, exact 64x64 readback\n'
+printf 'Validation passed in %s: GLIBC <= 2.31, 17 features, shader-f16, compute 1024, exact 64x64 readback\n' "$VALIDATION_IMAGE"

--- a/infra/lavapipe-build/validate.sh
+++ b/infra/lavapipe-build/validate.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
+ARCHIVE=${1:?usage: validate.sh ARCHIVE DAWN_NODE [RESULTS_DIR]}
+DAWN=${2:?usage: validate.sh ARCHIVE DAWN_NODE [RESULTS_DIR]}
+RESULTS_DIR=${3:-$ROOT/lavapipe-validation}
+[[ -f "$ARCHIVE" ]] || { echo "Archive not found: $ARCHIVE" >&2; exit 2; }
+[[ -f "$DAWN" ]] || { echo "Dawn addon not found: $DAWN" >&2; exit 2; }
+ARCHIVE=$(realpath "$ARCHIVE")
+DAWN=$(realpath "$DAWN")
+rm -rf "$RESULTS_DIR"
+mkdir -p "$RESULTS_DIR"
+RESULTS_DIR=$(realpath "$RESULTS_DIR")
+docker run --rm --label vgpu-lavapipe-build=1 \
+  -v "$DAWN:/cache/dawn.node:ro" \
+  -v "$ARCHIVE:/input/lavapipe.tar.gz:ro" \
+  -v "$ROOT/infra/lavapipe-build/dump-render.mjs:/work/dump-render.mjs:ro" \
+  -v "$RESULTS_DIR:/out" node:24-trixie bash -c '
+set -euo pipefail
+! dpkg-query -W mesa-vulkan-drivers >/dev/null 2>&1
+apt-get update -qq
+DEBIAN_FRONTEND=noninteractive apt-get install -y -qq --no-install-recommends libdrm2 libvulkan1 >/dev/null
+! dpkg-query -W mesa-vulkan-drivers >/dev/null 2>&1
+dpkg-query -W -f='"'"'${Package}=${Version}\n'"'"' libdrm2 libvulkan1 > /out/clean-container-packages.txt
+mkdir -p /asset /tmp/runtime; chmod 700 /tmp/runtime
+tar -xzf /input/lavapipe.tar.gz -C /asset
+(cd /asset && sha256sum libvulkan_lvp.so lvp_icd.json > /out/asset-SHA256SUMS)
+export XDG_RUNTIME_DIR=/tmp/runtime DISPLAY=
+export DAWN_NODE=/cache/dawn.node DAWN_FLAGS=backend=vulkan
+export VK_ICD_FILENAMES=/asset/lvp_icd.json
+ldd /asset/libvulkan_lvp.so > /out/clean-container-ldd.txt
+! grep "not found" /out/clean-container-ldd.txt
+for run in 1 2 3; do
+  node /work/dump-render.mjs > "/out/lavapipe-run${run}.json" 2> "/out/lavapipe-run${run}.stderr"
+done
+'
+printf 'Validation passed: 17 features, shader-f16, compute 1024, exact 64x64 readback\n'


### PR DESCRIPTION
## Summary

- commit a portable Mesa Lavapipe build recipe with static LLVM/C++ runtime, native x64/arm64 packaging, checksums, and ABI/link evidence
- add strict Dawn validation covering 17 features, `shader-f16`, compute limit 1024, and exact 64×64 render readback
- add a manual-only GitHub Actions matrix on `ubuntu-24.04` and `ubuntu-24.04-arm` that builds, validates, and uploads artifacts without creating a release

## Old-host baseline rework

The original validated Trixie prototype was not portable to the current Bookworm sandbox: its renderer required `GLIBC_2.38`, while this host provides glibc 2.36.

The committed recipe now builds in **Debian Bullseye (glibc 2.31)**, matching the portable Dawn compatibility story:

- LLVM 19.1.7 comes from apt.llvm.org's official Bullseye repository.
- `libpolly-19-dev` was audited to include both required static Polly archives.
- Mesa 25 requires libdrm >=2.4.109, so pinned libdrm 2.4.124 is source-built inside Bullseye rather than importing a newer-glibc binary.
- libstdc++ and libgcc are static; the artifact has no GLIBCXX/CXXABI requirements.
- build and validation gates reject GLIBC requirements above 2.31. The measured maximum is GLIBC 2.29.

## Final arm64 evidence

- `libvulkan_lvp.so`: **56,864,480 bytes**
- release archive: **20,568,206 bytes (20.57 MB)**
- archive SHA256: `eac1477d6404af2d63fc08104e980d0cbbf657470c966a0bc638099c00d3dcac`
- two consecutive repository-recipe rebuilds were byte-for-byte identical
- clean Bookworm and Trixie containers both passed 17 features, `shader-f16`, compute 1024, exact readback, and clean disposal
- direct current-host proof using `vgpu@0.1.5` and portable Dawn passed: llvmpipe Mesa 25.0.7 / LLVM 19.1.7, `shader-f16`, exact `[64,128,191,255]` center render, clean dispose
- independent `vgpu doctor` result: **healthy**, CPU adapter; host `ldd` fully resolved

## Verification

- `actionlint` 1.7.7 passed
- `bash -n` passed
- `git diff --check` passed
- package manifests and lockfile unchanged
- archive/per-file checksums passed
- Docker hygiene: zero labeled containers/images

## Phase 2 preview

Pending published assets, phase 2 will integrate Lavapipe as adapter-node's last-resort backend, add the corresponding `doctor` prescription, and expose the CLI installation command. The Vulkan loader/runtime dependency closure (`libvulkan.so.1`, zstd, zlib, libdrm, and libudev) is an explicit integration design input.