### PR TITLE
ci: use portable Dawn for arm64 Lavapipe validation

### DIFF
--- a/.github/workflows/lavapipe-build.yml
+++ b/.github/workflows/lavapipe-build.yml
@@ -46,10 +46,20 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p dawn-validation
-          package=$(npm pack webgpu@0.4.0 --pack-destination /tmp --silent)
-          tar -xzf "/tmp/$package" -C dawn-validation --strip-components=2 \
-            "package/dist/linux-${ARCH}.dawn.node"
-          mv "dawn-validation/linux-${ARCH}.dawn.node" dawn-validation/dawn.node
+          if [ "$ARCH" = arm64 ]; then
+            curl -fsSL \
+              https://github.com/vercel-labs/vgpu/releases/download/dawn-v0.4.0-vgpu.1/dawn-linux-arm64-gnu.node \
+              -o dawn-validation/dawn.node
+            echo '1d78020a40e1d5291c1bf8349155487ccbef7e123753fd4a5bbb3fe19a9e4277  dawn-validation/dawn.node' \
+              | sha256sum --check -
+            max_glibc=$(objdump -T dawn-validation/dawn.node | grep -o 'GLIBC_[0-9.]*' | sort -V | tail -1)
+            test "$(printf '%s\n' GLIBC_2.31 "$max_glibc" | sort -V | tail -1)" = GLIBC_2.31
+          else
+            package=$(npm pack webgpu@0.4.0 --pack-destination /tmp --silent)
+            tar -xzf "/tmp/$package" -C dawn-validation --strip-components=2 \
+              "package/dist/linux-${ARCH}.dawn.node"
+            mv "dawn-validation/linux-${ARCH}.dawn.node" dawn-validation/dawn.node
+          fi
 
       - name: Verify archive and per-file checksums
         env:

--- a/infra/lavapipe-build/validate.sh
+++ b/infra/lavapipe-build/validate.sh
@@ -12,6 +12,7 @@ DAWN=$(realpath "$DAWN")
 rm -rf "$RESULTS_DIR"
 mkdir -p "$RESULTS_DIR"
 RESULTS_DIR=$(realpath "$RESULTS_DIR")
+status=0
 docker run --rm --label vgpu-lavapipe-build=1 \
   -v "$DAWN:/cache/dawn.node:ro" \
   -v "$ARCHIVE:/input/lavapipe.tar.gz:ro" \
@@ -42,5 +43,15 @@ printf "GLIBC=%s\nGLIBCXX=%s\nCXXABI=%s\n" "$max_glibc" "${max_glibcxx:-none}" "
 for run in 1 2 3; do
   node /work/dump-render.mjs > "/out/lavapipe-run${run}.json" 2> "/out/lavapipe-run${run}.stderr"
 done
-'
+' || status=$?
+if (( status != 0 )); then
+  echo "Validation failed in $VALIDATION_IMAGE (exit $status); captured diagnostics:" >&2
+  for file in "$RESULTS_DIR"/clean-container-ldd.txt "$RESULTS_DIR"/symbol-version-floor.txt \
+    "$RESULTS_DIR"/lavapipe-run*.json "$RESULTS_DIR"/lavapipe-run*.stderr; do
+    [[ -f "$file" ]] || continue
+    printf '\n===== %s =====\n' "$(basename "$file")" >&2
+    cat "$file" >&2
+  done
+  exit "$status"
+fi
 printf 'Validation passed in %s: GLIBC <= 2.31, 17 features, shader-f16, compute 1024, exact 64x64 readback\n' "$VALIDATION_IMAGE"


### PR DESCRIPTION
## Summary

- use the pinned portable Dawn arm64 prebuild for the Bookworm compatibility proof instead of `webgpu@0.4.0`'s stock arm64 addon
- verify the portable addon's release SHA256 and enforce its GLIBC <= 2.31 contract before validation
- print captured `ldd`, symbol-floor, render JSON, and Dawn stderr when clean-container validation fails

## Root cause

Main workflow run [29957152240](https://github.com/vercel-labs/vgpu/actions/runs/29957152240) used the stock npm `webgpu@0.4.0` arm64 Dawn addon. That addon requires GLIBC 2.38, so it cannot load in the intended Bookworm/glibc 2.36 proof container:

```text
Error: /lib/aarch64-linux-gnu/libc.so.6: version `GLIBC_2.38' not found (required by /cache/dawn.node)
```

The exact hidden failure was exposed by diagnostic branch run [29957717064](https://github.com/vercel-labs/vgpu/actions/runs/29957717064). The renderer itself was healthy in that run: all dependencies resolved, max GLIBC was 2.29, and no GLIBCXX/CXXABI requirements were present.

## Verification

Branch workflow run [29958350430](https://github.com/vercel-labs/vgpu/actions/runs/29958350430) is fully green:

- Linux x64: build, Trixie validation, checksum verification, artifact upload passed
- Linux arm64: build, Bookworm validation, Trixie validation, checksum verification, artifact upload passed
- portable Dawn SHA256: `1d78020a40e1d5291c1bf8349155487ccbef7e123753fd4a5bbb3fe19a9e4277`
- `actionlint` and `git diff --check` passed

No release or release-draft steps are added.
