### PR TITLE
Release 0.1.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
+## 0.1.6 — 2026-07-21
+
+### Added
+- **Add a native software renderer for portable, display-free Node rendering.** Provision it only with the explicit, consented `npx vgpu install-software-renderer` command; npm install, `vgpu doctor`, and `init()` never download it. Node callers can select `init({ adapter: "auto" | "hardware" | "software" })`, inspect `gpu.adapter`, or set the `VGPU_ADAPTER` environment override. Doctor prescriptions and the Node environment guide explain installation and adapter selection.
+- Publish portable Mesa lavapipe for Linux x64 and arm64 as the GitHub Release asset `lavapipe-v25.0.7-vgpu.1`, with build/validation infrastructure targeting a glibc 2.31 old-host ABI floor and portable Dawn validation.
+
+### Security
+- Harden the software-renderer trust boundary with bounded 32 MiB downloads and timeouts, an exact two-file tar allowlist, pinned archive and extracted-file hashes, private non-symlink cache validation, atomic/concurrent cache installation, and a forced-Vulkan critical section. The post-hardening security re-audit is clean.
+
+### Behavior and migration
+- The browser API is unchanged. This release adds no npm package or dependency: the optional lavapipe payload is a separately consented GitHub Release download. Existing Node defaults remain available; choose `adapter: "software"` or `VGPU_ADAPTER=software` only when the provisioned CPU renderer is required.
+
+### Examples and documentation
+- Add the Particles Ocean example with FFT waves, particles, bloom, gallery thumbnails, graph validation, and deterministic render checks.
+- Simplify example detail layout and strengthen gallery thumbnail/render CI alongside the new Node environment guidance.
+
 ## 0.1.5 — 2026-07-21
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # vgpu
 
-> 0.1.5 — early preview of the new public `vgpu` API
+> 0.1.6 — early preview of the new public `vgpu` API
 
 vgpu is an agentic-first WebGPU library for browsers, Node/Dawn, and deterministic mock tests. The public package is `vgpu`: one `Gpu` context with explicit WGSL reflection and performance-oriented defaults.
 

--- a/infra/lavapipe-build/README.md
+++ b/infra/lavapipe-build/README.md
@@ -42,7 +42,7 @@ Tarball SHA256: `eac1477d6404af2d63fc08104e980d0cbbf657470c966a0bc638099c00d3dca
 
 Both clean Bookworm and Trixie containers passed three fresh processes: 17 Dawn features including `shader-f16`, `maxComputeInvocationsPerWorkgroup` 1024, exact 64×64 readback (`[64,128,191,255]` center, `[0,0,0,255]` corner, 1,352 nonblack pixels), and no uncaptured errors.
 
-The asset also passed directly on the current Bookworm host using `vgpu@0.1.5` and its portable Dawn loader: `vgpu doctor` reported **healthy**, adapter **llvmpipe: Mesa 25.0.7 (LLVM 19.1.7)**, type `cpu`; host `ldd` resolved every dependency and render/dispose exited cleanly.
+The asset also passed directly on the current Bookworm host using `vgpu@0.1.6` and its portable Dawn loader: `vgpu doctor` reported **healthy**, adapter **llvmpipe: Mesa 25.0.7 (LLVM 19.1.7)**, type `cpu`; host `ldd` resolved every dependency and render/dispose exited cleanly.
 
 ## Build and runtime gotchas
 

--- a/packages/adapter-mock/README.md
+++ b/packages/adapter-mock/README.md
@@ -1,6 +1,6 @@
 # @vgpu/adapter-mock
 
-> 0.1.5 — deterministic adapter for `vgpu/mock`
+> 0.1.6 — deterministic adapter for `vgpu/mock`
 
 `@vgpu/adapter-mock` backs the `vgpu/mock` entrypoint for tests that need the public `Gpu` API without real GPU hardware.
 

--- a/packages/adapter-mock/package.json
+++ b/packages/adapter-mock/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vgpu/adapter-mock",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "Mock GPU adapter for testing vgpu code without real WebGPU hardware.",
   "keywords": [
     "webgpu",

--- a/packages/adapter-node/README.md
+++ b/packages/adapter-node/README.md
@@ -1,6 +1,6 @@
 # @vgpu/adapter-node
 
-> 0.1.5 — Dawn adapter for `vgpu/node`
+> 0.1.6 — Dawn adapter for `vgpu/node`
 
 `@vgpu/adapter-node` connects vgpu to Node.js through the `webgpu` Dawn native prebuild. Most callers should import `init` from `vgpu/node`; direct adapter/device helpers remain for core layer (`vgpu/core`) tooling.
 

--- a/packages/adapter-node/package.json
+++ b/packages/adapter-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vgpu/adapter-node",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "Node.js GPU adapter for vgpu, using Dawn-based WebGPU bindings.",
   "keywords": [
     "webgpu",

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,6 +1,6 @@
 # @vgpu/core
 
-> 0.1.5 — core layer (`vgpu/core`) runtime primitives
+> 0.1.6 — core layer (`vgpu/core`) runtime primitives
 
 `@vgpu/core` contains the low-level WebGPU wrappers used by `vgpu/core`: `Device`, `Buffer`, `Texture`, `Queue`, shader modules, bind-group helpers, resource identities, and validation errors. Most applications should start from `init()` in `vgpu`, `vgpu/node`, or `vgpu/mock` and drop to these primitives only for explicit native control.
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vgpu/core",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "Core WebGPU runtime primitives (device, buffer, texture, shader, queue) for vgpu.",
   "keywords": [
     "webgpu",

--- a/packages/render/README.md
+++ b/packages/render/README.md
@@ -1,6 +1,6 @@
 # @vgpu/render
 
-> 0.1.5 — slim legacy/utility render package
+> 0.1.6 — slim legacy/utility render package
 
 New applications should use the public `vgpu` package. `@vgpu/render` remains as a slim package for edit/inspect/utils/perf helpers and compatibility while the old thick render surface is removed from the public path.
 

--- a/packages/render/package.json
+++ b/packages/render/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vgpu/render",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "Render pipeline + render pass abstractions for vgpu.",
   "keywords": [
     "webgpu",

--- a/packages/vgpu-api/README.md
+++ b/packages/vgpu-api/README.md
@@ -1,6 +1,6 @@
 # vgpu
 
-> 0.1.5 — public main API (`vgpu`) preview
+> 0.1.6 — public main API (`vgpu`) preview
 
 `vgpu` is the public package for the new API. It is built around one `Gpu` context, explicit WGSL reflection, and `set()` ownership rules that make the fast path the default.
 

--- a/packages/vgpu-api/package.json
+++ b/packages/vgpu-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vgpu",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "Public VGPU API entrypoint scaffold for browser, Node, mock, scene, and client typing surfaces.",
   "keywords": [
     "webgpu",

--- a/packages/vgpu/package.json
+++ b/packages/vgpu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vgpu/cli",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "Official VGPU CLI for docs, doctor, and WGSL utilities.",
   "keywords": [
     "webgpu",
@@ -45,9 +45,9 @@
     "pngjs": "^7.0.0"
   },
   "peerDependencies": {
-    "@vgpu/adapter-node": "^0.1.5",
-    "@vgpu/wgsl": "^0.1.5",
-    "vgpu": "^0.1.5"
+    "@vgpu/adapter-node": "^0.1.6",
+    "@vgpu/wgsl": "^0.1.6",
+    "vgpu": "^0.1.6"
   },
   "peerDependenciesMeta": {
     "@vgpu/adapter-node": {

--- a/packages/wgsl-std/package.json
+++ b/packages/wgsl-std/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vgpu/wgsl-std",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "Pure WGSL utility snippets for vgpu shaders.",
   "keywords": [
     "webgpu",

--- a/packages/wgsl/package.json
+++ b/packages/wgsl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vgpu/wgsl",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "WGSL shader compilation, runtime resolution, and webpack/vite loaders for vgpu.",
   "keywords": [
     "webgpu",


### PR DESCRIPTION
## Summary

Prepare the synchronized VGPU 0.1.6 release, headlined by the consented native software renderer for portable display-free Node rendering.

| Package | Version |
| --- | --- |
| `vgpu` | `0.1.5` → `0.1.6` |
| `@vgpu/cli` (private) | `0.1.5` → `0.1.6` |
| `@vgpu/core` | `0.1.5` → `0.1.6` |
| `@vgpu/render` | `0.1.5` → `0.1.6` |
| `@vgpu/wgsl` | `0.1.5` → `0.1.6` |
| `@vgpu/wgsl-std` | `0.1.5` → `0.1.6` |
| `@vgpu/adapter-node` | `0.1.5` → `0.1.6` |
| `@vgpu/adapter-mock` | `0.1.5` → `0.1.6` |

### Release highlights

- Adds explicit `npx vgpu install-software-renderer`; npm install, doctor, and init never provision the optional renderer.
- Adds `init({ adapter: "auto" | "hardware" | "software" })`, `gpu.adapter`, and the `VGPU_ADAPTER` override for Node.
- Adds doctor prescriptions and the Node environment guide.
- Ships lavapipe as the separate `lavapipe-v25.0.7-vgpu.1` GitHub Release asset for Linux x64/arm64 with a glibc 2.31 ABI floor.
- Hardens provisioning with 32 MiB/time bounds, an exact tar allowlist, archive/extracted hashes, non-symlink verification, atomic/concurrent cache handling, and a forced-Vulkan critical section; security re-audit is clean.
- Browser behavior is unchanged; there is no new npm package or dependency.
- Adds Particles Ocean and updates the examples layout/gallery render CI.

### Packed-tarball E2E transcript

All seven publishable `0.1.6` tarballs were installed together on Linux arm64. `VK_ICD_FILENAMES`, `VK_DRIVER_FILES`, `VGPU_ADAPTER`, and `VGPU_DAWN_FLAGS` were unset throughout; `VGPU_CACHE_DIR` was an entirely fresh temp directory.

```text
packed vgpu dependencies:
  @vgpu/adapter-mock 0.1.6
  @vgpu/adapter-node 0.1.6
  @vgpu/core 0.1.6
  @vgpu/wgsl 0.1.6

first `npx vgpu doctor`:
  exit=1
  verdict=unhealthy
  adapter=null
  software-renderer-cache=skip: not cached; installed only with explicit consent
  prescription=run: npx vgpu install-software-renderer
  software-renderer cache absent

`npx vgpu install-software-renderer`:
  Downloaded .../software-renderer/25.0.7-vgpu.1/linux-arm64/lvp_icd.json
  archive=20,568,206 bytes
  libvulkan_lvp.so=56,864,480 bytes
  lvp_icd.json=124 bytes

second `npx vgpu doctor`:
  exit=0
  verdict=healthy
  adapter=llvmpipe: Mesa 25.0.7 (LLVM 19.1.7) 0.0.1
  adapter.type=cpu
  cached payload=sha256-verified
  render=16x16 offscreen readback OK

packed SDK render/readback/dispose:
  init({ adapter: "software" })
  adapter.type=cpu
  bytes=256
  sample=[64,128,191,255]
  dispose=clean exit
```

### Verification

- `pnpm install --frozen-lockfile`
- `pnpm run typecheck`
- `pnpm run build`
- `VGPU_CACHE_DIR=$(mktemp -d) pnpm exec vitest run` — 798 passed, 122 skipped
- `pnpm run bundle-check`
- `pnpm run docs:verify-snippets` — 403 snippets
- isolated guide-runtime snippets — 2 passed
- docs generation ×2 and example ingestion ×2 — idempotent
- source and bundled CLI both report 0.1.6
