### PR TITLE
docs: stack example preview above source

### DIFF
--- a/apps/docs/app/(nav)/examples/[slug]/page.tsx
+++ b/apps/docs/app/(nav)/examples/[slug]/page.tsx
@@ -27,7 +27,7 @@ export default async function ExampleDetailPage({ params, searchParams }: Exampl
 
   return (
     <div className="px-6 py-8 lg:px-8 xl:px-12">
-      <div className="mx-auto max-w-[1500px]">
+      <div className="mx-auto max-w-3xl">
         <Breadcrumbs items={getBreadcrumbs(pathname)} />
         <div className="mb-6 flex flex-wrap items-end justify-between gap-4">
           <div>
@@ -46,14 +46,9 @@ export default async function ExampleDetailPage({ params, searchParams }: Exampl
           </Link>
         </div>
 
-        <div className="grid gap-6 xl:grid-cols-[minmax(0,1fr)_minmax(420px,0.9fr)]">
-          <section>
-            <CodeViewer files={example.sources} activeFile={activeFile} />
-          </section>
-
-          <section>
-            <ExamplePreview slug={example.meta.slug} title={example.meta.title} poster={example.meta.hero} />
-          </section>
+        <div className="space-y-6">
+          <ExamplePreview slug={example.meta.slug} title={example.meta.title} poster={example.meta.hero} />
+          <CodeViewer files={example.sources} activeFile={activeFile} />
         </div>
         <PageNavigation prev={prev} next={next} />
       </div>

--- a/apps/docs/components/example-preview.tsx
+++ b/apps/docs/components/example-preview.tsx
@@ -44,7 +44,7 @@ export function ExamplePreview({ slug, title, poster }: ExamplePreviewProps) {
   }, [slug]);
 
   return (
-    <div className="relative h-[60vh] min-h-[420px] overflow-hidden rounded-lg border border-gray-4 bg-black shadow-2xl">
+    <div className="relative aspect-video w-full overflow-hidden rounded-lg border border-gray-4 bg-black shadow-2xl">
       <iframe
         title={`${title} preview`}
         src={`/preview/${slug}`}


### PR DESCRIPTION
## Summary
- constrain example detail content to `max-w-3xl`
- render the full-width `aspect-video` preview above the source viewer
- retain the fullscreen action and code viewer scroll cap

## Validation
- `pnpm install --frozen-lockfile`
- `pnpm run build && pnpm --filter docs typecheck && pnpm --filter docs build`
- `git diff --check`
- Agent-browser captures at 1440×1100:
  - `/home/user/examples-layout-video-validation/gradient-1440x1100.png`
  - `/home/user/examples-layout-video-validation/black-hole-1440x1100.png`
