### PR TITLE
fix(cli): expose newly generated guides in docs ls/cat

### DIFF
--- a/packages/vgpu-api/package.json
+++ b/packages/vgpu-api/package.json
@@ -67,7 +67,7 @@
   "scripts": {
     "build": "tsc -b && node scripts/copy-cli.mjs",
     "test": "cd ../.. && vitest run packages/vgpu-api",
-    "prepack": "pnpm --dir ../vgpu generate:docs && node scripts/copy-cli.mjs"
+    "prepack": "pnpm --dir ../vgpu generate:docs"
   },
   "dependencies": {
     "@vgpu/adapter-mock": "workspace:*",

--- a/packages/vgpu-api/tests/cli-pack.test.ts
+++ b/packages/vgpu-api/tests/cli-pack.test.ts
@@ -6,6 +6,7 @@ import { expect, test } from "vitest";
 
 const packageDir = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const workspaceRoot = resolve(packageDir, "../..");
+const cliDir = resolve(workspaceRoot, "packages/vgpu");
 
 const readJson = (path: string) => JSON.parse(readFileSync(path, "utf8"));
 
@@ -32,4 +33,29 @@ test("the vgpu tarball includes the full internal CLI", () => {
   expect(files).toContain("dist/cli/lib/generated/docs-manifest.generated.js");
   expect(files).toContain("dist/cli/lib/examples/run.js");
   expect(files).toContain("dist/cli/lib/examples/schemas/v1/discovery.schema.json");
+});
+
+test("generating docs refreshes the public CLI guide manifest", () => {
+  execFileSync("pnpm", ["--dir", cliDir, "generate:docs"], {
+    cwd: workspaceRoot,
+    stdio: "pipe",
+  });
+
+  const list = execFileSync("node", ["bin/vgpu.js", "docs", "ls", "/guides"], {
+    cwd: packageDir,
+    encoding: "utf8",
+  });
+  expect(list).toContain("shader-workflow.docs.md");
+  expect(list).toContain("shader-debugging.docs.md");
+
+  for (const [guide, heading] of [
+    ["shader-workflow.md", "# The default workflow for developing shaders with vgpu"],
+    ["shader-debugging.md", "# Debugging shaders by extracting internal values"],
+  ]) {
+    const output = execFileSync("node", ["bin/vgpu.js", "docs", "cat", guide], {
+      cwd: packageDir,
+      encoding: "utf8",
+    });
+    expect(output).toContain(heading);
+  }
 });

--- a/packages/vgpu/package.json
+++ b/packages/vgpu/package.json
@@ -36,7 +36,7 @@
     "LICENSE"
   ],
   "scripts": {
-    "generate:docs": "node lib/docs/generate/cli.js",
+    "generate:docs": "node lib/docs/generate/cli.js && node ../vgpu-api/scripts/copy-cli.mjs",
     "prepack": "node lib/docs/generate/cli.js",
     "test": "cd ../.. && vitest run packages/vgpu"
   },


### PR DESCRIPTION
## Root cause

`node_modules/.bin/vgpu` resolves to the public `vgpu` package, whose launcher imports the copied internal CLI from `packages/vgpu-api/dist/cli`. The docs generator refreshed only `packages/vgpu/lib/generated/docs-manifest.generated.js`; it did not refresh that public CLI copy, so the launcher continued to use its stale manifest.

## Fix

Make `pnpm -F @vgpu/cli generate:docs` regenerate the manifest and copy the internal CLI into the public package. The public package prepack now uses that single pipeline. Added a regression test that runs the public bin and checks the two guide names and contents.

## Repro / verification

Before: `node_modules/.bin/vgpu docs ls /guides` ended at `shader-fix-its.docs.md`, and `node_modules/.bin/vgpu docs cat shader-workflow.md` returned `Symbol not found`.

After `pnpm -F @vgpu/cli generate:docs`:

```sh
node_modules/.bin/vgpu docs ls /guides
# includes shader-workflow.docs.md and shader-debugging.docs.md
node_modules/.bin/vgpu docs cat shader-workflow.md
node_modules/.bin/vgpu docs cat shader-debugging.md
# both print their guides
```

Tests: `pnpm exec vitest run packages/vgpu/tests/cli.test.ts packages/vgpu-api/tests/cli-pack.test.ts`