### PR TITLE
feat(ci): tier bundle budgets by audience and measure dist bytes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,6 +15,23 @@ pnpm changeset
 
 Choose each affected `@vgpu/*` package, select the appropriate semver bump (`patch`, `minor`, or `major`), and write a short summary. That summary becomes the changelog entry for the release.
 
+## Bundle budgets
+
+`pnpm bundle-check` enforces gzip budgets stored in each package's `package.json`. Budgets are tiered by audience:
+
+- `"client"` (default when unclassified) — browser-facing entries. **Hard gate**: one byte over budget fails.
+- `"tooling"` — loaders, the Node runtime, the CLI and package tarballs. **Soft gate**: over budget warns, and only fails past `vgpuBundleBudgetGrowthThreshold` (default 5%).
+
+Classify with `vgpuBundleAudience` (package-wide) or `vgpuExportBundleAudiences` (per export subpath). Tarball budgets measure published dist bytes: `*.docs.md` files, sourcemap `sourcesContent` and the budget metadata itself are excluded, so documenting the API never competes with the size gate.
+
+When growth is intentional, re-baseline instead of hand-editing numbers:
+
+```bash
+pnpm bundle-check --update   # budget = next 512 B multiple at least 512 B above measured
+```
+
+Run `pnpm build` first, since budgets are measured from `dist`.
+
 ## PR checklist
 
 - [ ] Code changes to a published package include a `.changeset/*.md` file.

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "typecheck:fixtures": "tsc -p packages/core/tests/tsconfig.create-sampler-types.json && tsc -p packages/core/tests/tsconfig.types.json && tsc -p packages/vgpu-api/tests/uniforms/tsconfig.types.json",
     "docs:verify-snippets": "node scripts/verify-docs-snippets.mjs",
     "test": "vitest run",
-    "test:fast": "vitest run packages/adapter-mock packages/core packages/wgsl packages/render",
+    "test:fast": "vitest run packages/adapter-mock packages/core packages/wgsl packages/render scripts",
     "test:docker": "bash infra/test-docker/run.sh",
     "test:doctor:docker": "bash infra/test-docker-doctor/run.sh",
     "thumbs:docker": "bash infra/test-docker/thumbs.sh",

--- a/packages/adapter-mock/package.json
+++ b/packages/adapter-mock/package.json
@@ -45,5 +45,7 @@
   "dependencies": {
     "@vgpu/core": "workspace:*"
   },
-  "vgpuBundleBudgetGzipBytes": 13824
+  "vgpuBundleAudience": "tooling",
+  "vgpuBundleBudgetGzipBytes": 13824,
+  "vgpuBundleBudgetNote": "Gzip ceilings use 512-byte granularity: each budget is the next 512-byte multiple at least 512 B above the measured size, so headroom is never a rounding accident. Regenerate with `pnpm bundle-check --update`. vgpuBundleAudience/vgpuExportBundleAudiences select the gate: \"client\" entries ship to browsers and fail on any byte over budget; \"tooling\" entries (loaders, Node runtime, CLI, package tarballs) only warn until growth passes vgpuBundleBudgetGrowthThreshold (default 5%). Tarballs measure published dist bytes with sourcemap sourcesContent stripped and *.docs.md excluded."
 }

--- a/packages/adapter-node/package.json
+++ b/packages/adapter-node/package.json
@@ -56,5 +56,7 @@
     "@vgpu/core": "workspace:*",
     "webgpu": "0.4.0"
   },
-  "vgpuBundleBudgetGzipBytes": 40960
+  "vgpuBundleAudience": "tooling",
+  "vgpuBundleBudgetGzipBytes": 34304,
+  "vgpuBundleBudgetNote": "Gzip ceilings use 512-byte granularity: each budget is the next 512-byte multiple at least 512 B above the measured size, so headroom is never a rounding accident. Regenerate with `pnpm bundle-check --update`. vgpuBundleAudience/vgpuExportBundleAudiences select the gate: \"client\" entries ship to browsers and fail on any byte over budget; \"tooling\" entries (loaders, Node runtime, CLI, package tarballs) only warn until growth passes vgpuBundleBudgetGrowthThreshold (default 5%). Tarballs measure published dist bytes with sourcemap sourcesContent stripped and *.docs.md excluded."
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -44,7 +44,9 @@
   "scripts": {
     "build": "tsc -b"
   },
-  "vgpuBundleBudgetGzipBytes": 48640,
+  "vgpuBundleAudience": "tooling",
+  "vgpuBundleBudgetGzipBytes": 32768,
+  "vgpuBundleBudgetNote": "Gzip ceilings use 512-byte granularity: each budget is the next 512-byte multiple at least 512 B above the measured size, so headroom is never a rounding accident. Regenerate with `pnpm bundle-check --update`. vgpuBundleAudience/vgpuExportBundleAudiences select the gate: \"client\" entries ship to browsers and fail on any byte over budget; \"tooling\" entries (loaders, Node runtime, CLI, package tarballs) only warn until growth passes vgpuBundleBudgetGrowthThreshold (default 5%). Tarballs measure published dist bytes with sourcemap sourcesContent stripped and *.docs.md excluded.",
   "dependencies": {
     "@vgpu/wgsl": "workspace:*"
   }

--- a/packages/render/package.json
+++ b/packages/render/package.json
@@ -62,10 +62,17 @@
     "@vgpu/core": "workspace:*",
     "wgpu-matrix": "^3.4.2"
   },
+  "vgpuExportBundleAudiences": {
+    "./inspect": "client",
+    "./utils": "client",
+    "./edit": "client",
+    "./perf": "client"
+  },
   "vgpuExportBundleBudgetsGzipBytes": {
-    "./inspect": 2560,
-    "./utils": 1024,
-    "./edit": 12288,
-    "./perf": 1536
-  }
+    "./inspect": 3072,
+    "./utils": 1536,
+    "./edit": 12800,
+    "./perf": 2048
+  },
+  "vgpuExportBundleBudgetNote": "Gzip ceilings use 512-byte granularity: each budget is the next 512-byte multiple at least 512 B above the measured size, so headroom is never a rounding accident. Regenerate with `pnpm bundle-check --update`. vgpuBundleAudience/vgpuExportBundleAudiences select the gate: \"client\" entries ship to browsers and fail on any byte over budget; \"tooling\" entries (loaders, Node runtime, CLI, package tarballs) only warn until growth passes vgpuBundleBudgetGrowthThreshold (default 5%). Tarballs measure published dist bytes with sourcemap sourcesContent stripped and *.docs.md excluded."
 }

--- a/packages/vgpu-api/package.json
+++ b/packages/vgpu-api/package.json
@@ -79,14 +79,22 @@
     "pixelmatch": "^7.2.0",
     "pngjs": "^7.0.0"
   },
-  "vgpuExportBundleBudgetNote": "Bundle-diet ceilings use 512-byte granularity with one rounded safety step above measured gzip sizes.",
+  "vgpuExportBundleBudgetNote": "Gzip ceilings use 512-byte granularity: each budget is the next 512-byte multiple at least 512 B above the measured size, so headroom is never a rounding accident. Regenerate with `pnpm bundle-check --update`. vgpuBundleAudience/vgpuExportBundleAudiences select the gate: \"client\" entries ship to browsers and fail on any byte over budget; \"tooling\" entries (loaders, Node runtime, CLI, package tarballs) only warn until growth passes vgpuBundleBudgetGrowthThreshold (default 5%). Tarballs measure published dist bytes with sourcemap sourcesContent stripped and *.docs.md excluded.",
+  "vgpuExportBundleAudiences": {
+    ".": "client",
+    "./node": "tooling",
+    "./mock": "tooling",
+    "./scene": "client",
+    "./client": "client",
+    "./core": "client"
+  },
   "vgpuExportBundleBudgetsGzipBytes": {
-    ".": 44032,
-    "./node": 44032,
-    "./mock": 44032,
-    "./scene": 6144,
-    "./client": 512,
-    "./core": 3584
+    ".": 44544,
+    "./node": 44544,
+    "./mock": 44544,
+    "./scene": 6656,
+    "./client": 1024,
+    "./core": 4096
   },
   "bin": {
     "vgpu": "./bin/vgpu.js"

--- a/packages/wgsl/package.json
+++ b/packages/wgsl/package.json
@@ -72,11 +72,19 @@
     "vite": "^5.4.21",
     "webpack": "^5.97.1"
   },
+  "vgpuExportBundleAudiences": {
+    ".": "client",
+    "./runtime": "tooling",
+    "./loader-webpack": "tooling",
+    "./loader-vite": "tooling",
+    "./reflect-source": "tooling"
+  },
   "vgpuExportBundleBudgetsGzipBytes": {
-    ".": 1024,
-    "./runtime": 22016,
-    "./loader-webpack": 22528,
-    "./loader-vite": 22528,
-    "./reflect-source": 13824
-  }
+    ".": 1536,
+    "./runtime": 22528,
+    "./loader-webpack": 23040,
+    "./loader-vite": 23040,
+    "./reflect-source": 14336
+  },
+  "vgpuExportBundleBudgetNote": "Gzip ceilings use 512-byte granularity: each budget is the next 512-byte multiple at least 512 B above the measured size, so headroom is never a rounding accident. Regenerate with `pnpm bundle-check --update`. vgpuBundleAudience/vgpuExportBundleAudiences select the gate: \"client\" entries ship to browsers and fail on any byte over budget; \"tooling\" entries (loaders, Node runtime, CLI, package tarballs) only warn until growth passes vgpuBundleBudgetGrowthThreshold (default 5%). Tarballs measure published dist bytes with sourcemap sourcesContent stripped and *.docs.md excluded."
 }

--- a/scripts/bundle-budgets.test.ts
+++ b/scripts/bundle-budgets.test.ts
@@ -1,0 +1,228 @@
+import { spawnSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { expect, test } from "vitest";
+import {
+  BUDGET_NOTE,
+  DEFAULT_GROWTH_THRESHOLD,
+  evaluateBudget,
+  exportBudgetField,
+  formatFailure,
+  formatVerdictLine,
+  isMeasuredTarballEntry,
+  measuredTarballPayload,
+  nextBudgetBytes,
+  parseTarEntries,
+  resolveExportAudience,
+  resolvePackageAudience,
+  resolveThreshold,
+  softLimitBytes,
+  stripBudgetMetadata,
+  stripSourcesContent,
+} from "./lib/bundle-budgets.mjs";
+
+const script = fileURLToPath(new URL("./check-bundle-size.mjs", import.meta.url));
+
+test("a budget is the next 512 B multiple at least 512 B above measured", () => {
+  expect(nextBudgetBytes(0)).toBe(512);
+  expect(nextBudgetBytes(1)).toBe(1024);
+  expect(nextBudgetBytes(512)).toBe(1024);
+  expect(nextBudgetBytes(688)).toBe(1536);
+  expect(nextBudgetBytes(1023)).toBe(1536);
+  expect(nextBudgetBytes(21753)).toBe(22528);
+});
+
+test("every derived budget keeps at least 512 B of headroom and stays 512 B aligned", () => {
+  for (let measured = 0; measured < 4096; measured += 7) {
+    const budget = nextBudgetBytes(measured);
+    expect(budget % 512).toBe(0);
+    expect(budget - measured).toBeGreaterThanOrEqual(512);
+    expect(budget - measured).toBeLessThan(1024 + 512);
+  }
+});
+
+test("nextBudgetBytes rejects unmeasurable sizes", () => {
+  expect(() => nextBudgetBytes(Infinity)).toThrow(/cannot derive a budget/);
+  expect(() => nextBudgetBytes(-1)).toThrow(/cannot derive a budget/);
+});
+
+test("client budgets are a hard gate", () => {
+  expect(evaluateBudget({ measuredBytes: 1024, budgetBytes: 1024, audience: "client" }).status).toBe("ok");
+  const verdict = evaluateBudget({ measuredBytes: 1025, budgetBytes: 1024, audience: "client" });
+  expect(verdict).toMatchObject({ status: "fail", soft: false, limitBytes: 1024, overBudgetBytes: 1, suggestedBudgetBytes: 2048 });
+});
+
+test("tooling budgets warn inside the growth threshold and fail past it", () => {
+  const budgetBytes = 1000;
+  expect(softLimitBytes(budgetBytes)).toBe(1050);
+  expect(evaluateBudget({ measuredBytes: 1000, budgetBytes, audience: "tooling" }).status).toBe("ok");
+  expect(evaluateBudget({ measuredBytes: 1001, budgetBytes, audience: "tooling" }).status).toBe("warn");
+  expect(evaluateBudget({ measuredBytes: 1050, budgetBytes, audience: "tooling" }).status).toBe("warn");
+  const failed = evaluateBudget({ measuredBytes: 1051, budgetBytes, audience: "tooling" });
+  expect(failed).toMatchObject({ status: "fail", soft: true, limitBytes: 1050, overLimitBytes: 1 });
+});
+
+test("the growth threshold is configurable per package and by flag", () => {
+  expect(evaluateBudget({ measuredBytes: 1100, budgetBytes: 1000, audience: "tooling", threshold: 0.1 }).status).toBe("warn");
+  expect(evaluateBudget({ measuredBytes: 1101, budgetBytes: 1000, audience: "tooling", threshold: 0.1 }).status).toBe("fail");
+  expect(evaluateBudget({ measuredBytes: 1001, budgetBytes: 1000, audience: "tooling", threshold: 0 }).status).toBe("fail");
+  expect(resolveThreshold({ name: "x" })).toBe(DEFAULT_GROWTH_THRESHOLD);
+  expect(resolveThreshold({ name: "x", vgpuBundleBudgetGrowthThreshold: 0.2 })).toBe(0.2);
+  expect(resolveThreshold({ name: "x", vgpuBundleBudgetGrowthThreshold: 0.2 }, 0.01)).toBe(0.01);
+  expect(() => resolveThreshold({ name: "x", vgpuBundleBudgetGrowthThreshold: "5%" })).toThrow(/non-negative number/);
+});
+
+test("a missing artifact never passes a budget", () => {
+  const verdict = evaluateBudget({ measuredBytes: Infinity, budgetBytes: 1024, audience: "tooling" });
+  expect(verdict.status).toBe("fail");
+  expect(formatVerdictLine("@vgpu/gone", verdict)).toContain("missing artifact");
+});
+
+test("unclassified entries default to the hard client gate", () => {
+  expect(resolvePackageAudience({ name: "@vgpu/core" })).toBe("client");
+  expect(resolveExportAudience({ name: "@vgpu/wgsl" }, "./runtime")).toBe("client");
+  expect(resolveExportAudience({ name: "@vgpu/wgsl", vgpuBundleAudience: "tooling" }, "./runtime")).toBe("tooling");
+  expect(resolveExportAudience({ name: "@vgpu/wgsl", vgpuBundleAudience: "tooling", vgpuExportBundleAudiences: { ".": "client" } }, ".")).toBe("client");
+  expect(() => resolvePackageAudience({ name: "@vgpu/core", vgpuBundleAudience: "server" })).toThrow(/unknown audience/);
+});
+
+test("failures name the budget field, the entry, both sizes and the update command", () => {
+  const message = formatFailure({
+    label: "@vgpu/wgsl",
+    field: exportBudgetField("."),
+    manifestPath: "packages/wgsl/package.json",
+    verdict: evaluateBudget({ measuredBytes: 1600, budgetBytes: 1536, audience: "client" }),
+  });
+  expect(message).toContain("@vgpu/wgsl");
+  expect(message).toContain('packages/wgsl/package.json -> vgpuExportBundleBudgetsGzipBytes["."]');
+  expect(message).toContain("1600 B");
+  expect(message).toContain("1536 B");
+  expect(message).toContain("pnpm bundle-check --update");
+  expect(message).toContain("2560 B");
+});
+
+test("tarball measurement drops *.docs.md and sourcemap sourcesContent", () => {
+  expect(isMeasuredTarballEntry("package/src/buffer.docs.md")).toBe(false);
+  expect(isMeasuredTarballEntry("package/README.md")).toBe(true);
+  expect(isMeasuredTarballEntry("package/dist/index.js")).toBe(true);
+
+  const map = { version: 3, sources: ["../src/index.ts"], sourcesContent: ["const enormous = 1;".repeat(500)], mappings: "AAAA" };
+  const stripped = stripSourcesContent("package/dist/index.js.map", Buffer.from(JSON.stringify(map)));
+  expect(JSON.parse(stripped.toString()).sourcesContent).toBeUndefined();
+  expect(JSON.parse(stripped.toString()).mappings).toBe("AAAA");
+  expect(stripSourcesContent("package/dist/index.js", Buffer.from("not a map")).toString()).toBe("not a map");
+  expect(stripSourcesContent("package/dist/broken.js.map", Buffer.from("{oops")).toString()).toBe("{oops");
+});
+
+test("tarball measurement ignores the budget metadata it rewrites", () => {
+  const manifest = { name: "@vgpu/core", version: "1.0.0", vgpuBundleAudience: "tooling", vgpuBundleBudgetGzipBytes: 32768, vgpuExportBundleBudgetNote: BUDGET_NOTE };
+  const stripped = JSON.parse(stripBudgetMetadata("package/package.json", Buffer.from(JSON.stringify(manifest))).toString());
+  expect(stripped).toEqual({ name: "@vgpu/core", version: "1.0.0" });
+  const nested = Buffer.from(JSON.stringify(manifest));
+  expect(stripBudgetMetadata("package/dist/package.json", nested)).toBe(nested);
+});
+
+test("the measured payload is the filtered, stripped, path-sorted file bytes", () => {
+  const tarball = tar([
+    { path: "package/dist/index.js", contents: Buffer.from("export const a = 1;") },
+    { path: "package/src/index.docs.md", contents: Buffer.from("# docs\n".repeat(100)) },
+    { path: "package/dist/index.js.map", contents: Buffer.from(JSON.stringify({ version: 3, sourcesContent: ["huge"], mappings: "AAAA" })) },
+  ]);
+  const entries = parseTarEntries(tarball);
+  expect(entries.map((entry) => entry.path)).toEqual(["package/dist/index.js", "package/src/index.docs.md", "package/dist/index.js.map"]);
+  const payload = measuredTarballPayload(entries).toString();
+  expect(payload).toBe(`export const a = 1;${JSON.stringify({ version: 3, mappings: "AAAA" })}`);
+  expect(payload).not.toContain("docs");
+});
+
+test("bundle-check gates, warns and re-baselines a workspace", () => {
+  const root = writeFixture();
+  const manifest = join(root, "packages", "demo", "package.json");
+
+  const measured = Number(/(\d+) B gzip/.exec(run(root).stdout)?.[1]);
+  expect(measured).toBeGreaterThan(0);
+
+  // tooling entry, 1 B over budget: warning, exit 0.
+  patch(manifest, { vgpuExportBundleBudgetsGzipBytes: { ".": measured - 1 }, vgpuExportBundleAudiences: { ".": "tooling" } });
+  const warned = run(root);
+  expect(warned.status).toBe(0);
+  expect(warned.stdout).toContain("WARN demo [tooling]");
+  expect(warned.stdout).toContain("within the 5.0% tooling growth threshold");
+
+  // tooling entry past the threshold: hard failure with an actionable message.
+  patch(manifest, { vgpuExportBundleBudgetsGzipBytes: { ".": Math.floor(measured / 1.2) } });
+  const toolingFail = run(root);
+  expect(toolingFail.status).toBe(1);
+  expect(toolingFail.stdout).toContain("FAIL demo [tooling]");
+  expect(toolingFail.stderr).toContain("tooling soft limit");
+  expect(toolingFail.stderr).toContain('vgpuExportBundleBudgetsGzipBytes["."]');
+  expect(toolingFail.stderr).toContain("pnpm bundle-check --update");
+
+  // same size, unclassified entry: default client gate fails on the first byte over budget.
+  patch(manifest, { vgpuExportBundleBudgetsGzipBytes: { ".": measured - 1 }, vgpuExportBundleAudiences: undefined });
+  const clientFail = run(root);
+  expect(clientFail.status).toBe(1);
+  expect(clientFail.stdout).toContain("FAIL demo [client]");
+  expect(clientFail.stderr).toContain("hard client budget");
+
+  // --update rewrites budgets to the convention and documents it, then the check is green.
+  expect(run(root, "--update").status).toBe(0);
+  const updated = JSON.parse(readFileSync(manifest, "utf8"));
+  expect(updated.vgpuExportBundleBudgetsGzipBytes["."]).toBe(nextBudgetBytes(measured));
+  expect(updated.vgpuExportBundleBudgetNote).toBe(BUDGET_NOTE);
+  expect(run(root).status).toBe(0);
+  expect(run(root, "--update").stdout).toContain("nothing to update");
+});
+
+test("bundle-check honours --threshold and rejects nonsense flags", () => {
+  const root = writeFixture();
+  const manifest = join(root, "packages", "demo", "package.json");
+  const measured = Number(/(\d+) B gzip/.exec(run(root).stdout)?.[1]);
+  patch(manifest, { vgpuExportBundleBudgetsGzipBytes: { ".": measured - 1 }, vgpuExportBundleAudiences: { ".": "tooling" } });
+  expect(run(root, "--threshold=0%").status).toBe(1);
+  expect(run(root, "--threshold=50%").status).toBe(0);
+  const invalid = run(root, "--nope");
+  expect(invalid.status).toBe(2);
+  expect(invalid.stderr).toContain("Unknown argument --nope");
+});
+
+function writeFixture() {
+  const root = mkdtempSync(join(tmpdir(), "bundle-budgets-"));
+  const dist = join(root, "packages", "demo", "dist");
+  mkdirSync(dist, { recursive: true });
+  writeFileSync(join(dist, "index.js"), Array.from({ length: 200 }, (_, index) => `export const value${index} = "${index.toString(36).padStart(8, "0")}";`).join("\n"));
+  writeFileSync(
+    join(root, "packages", "demo", "package.json"),
+    `${JSON.stringify({ name: "demo", version: "0.0.0", exports: { ".": { types: "./dist/index.d.ts", import: "./dist/index.js" } }, vgpuExportBundleBudgetsGzipBytes: { ".": 1_000_000 } }, null, 2)}\n`,
+  );
+  return root;
+}
+
+function patch(manifestPath: string, fields: Record<string, unknown>) {
+  const manifest = { ...JSON.parse(readFileSync(manifestPath, "utf8")), ...fields };
+  for (const [key, value] of Object.entries(fields)) if (value === undefined) delete manifest[key];
+  writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
+}
+
+function run(cwd: string, ...args: string[]) {
+  return spawnSync(process.execPath, [script, ...args], { cwd, encoding: "utf8" });
+}
+
+/** Minimal ustar writer, so the tar reader is exercised against real headers. */
+function tar(files: { path: string; contents: Buffer }[]) {
+  const blocks = files.map(({ path, contents }) => {
+    const header = Buffer.alloc(512);
+    header.write(path, 0, 100, "utf8");
+    header.write("000644 \0", 100, 8, "utf8");
+    header.write(`${contents.length.toString(8).padStart(11, "0")}\0`, 124, 12, "utf8");
+    header.write("        ", 148, 8, "utf8");
+    header.write("0", 156, 1, "utf8");
+    header.write("ustar\x0000", 257, 8, "utf8");
+    const checksum = header.reduce((sum, byte) => sum + byte, 0);
+    header.write(`${checksum.toString(8).padStart(6, "0")}\0 `, 148, 8, "utf8");
+    return Buffer.concat([header, contents, Buffer.alloc((512 - (contents.length % 512)) % 512)]);
+  });
+  return Buffer.concat([...blocks, Buffer.alloc(1024)]);
+}

--- a/scripts/bundle-budgets.test.ts
+++ b/scripts/bundle-budgets.test.ts
@@ -3,6 +3,7 @@ import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
+import { gunzipSync } from "node:zlib";
 import { expect, test } from "vitest";
 import {
   BUDGET_NOTE,
@@ -137,6 +138,112 @@ test("the measured payload is the filtered, stripped, path-sorted file bytes", (
   expect(payload).not.toContain("docs");
 });
 
+test("the tar reader resolves GNU long names", () => {
+  const longPath = `package/dist/${"nested/".repeat(20)}index.js`;
+  expect(longPath.length).toBeGreaterThan(100);
+  const entries = parseTarEntries(
+    tar([
+      { path: "././@LongLink", type: "L", contents: Buffer.from(`${longPath}\0`) },
+      { path: longPath.slice(0, 100), contents: Buffer.from("export const a = 1;") },
+    ]),
+  );
+  expect(entries.map((entry) => entry.path)).toEqual([longPath]);
+});
+
+test("the tar reader resolves ustar prefix fields", () => {
+  const entries = parseTarEntries(tar([{ path: "index.js", prefix: "package/dist", contents: Buffer.from("a") }]));
+  expect(entries[0].path).toBe("package/dist/index.js");
+});
+
+test("the tar reader applies PAX path overrides, so filtering and stripping still see real paths", () => {
+  const manifest = { name: "@vgpu/core", version: "1.0.0", vgpuBundleAudience: "tooling", vgpuBundleBudgetGzipBytes: 32768 };
+  const buffer = tar([
+    { path: "PaxHeaders.0/package.json", type: "x", contents: paxRecords({ path: "package/package.json" }) },
+    { path: "truncated-name", contents: Buffer.from(JSON.stringify(manifest)) },
+    { path: "PaxHeaders.0/docs", type: "x", contents: paxRecords({ path: "package/src/index.docs.md" }) },
+    { path: "truncated-docs", contents: Buffer.from("# docs\n".repeat(100)) },
+  ]);
+  const entries = parseTarEntries(buffer);
+  expect(entries.map((entry) => entry.path)).toEqual(["package/package.json", "package/src/index.docs.md"]);
+  // The PAX path is what makes the docs file excludable and the manifest metadata strippable.
+  const payload = measuredTarballPayload(entries).toString();
+  expect(payload).not.toContain("docs");
+  expect(payload).not.toContain("vgpuBundleBudgetGzipBytes");
+  expect(JSON.parse(payload)).toEqual({ name: "@vgpu/core", version: "1.0.0" });
+});
+
+test("the tar reader honours PAX size overrides", () => {
+  const contents = Buffer.from("export const a = 1;");
+  const entries = parseTarEntries(
+    tar([
+      { path: "PaxHeaders.0/index.js", type: "x", contents: paxRecords({ size: `${contents.length}` }) },
+      { path: "package/dist/index.js", contents, sizeField: `${(0).toString(8).padStart(11, "0")}\0` },
+    ]),
+  );
+  expect(entries).toHaveLength(1);
+  expect(entries[0].contents.toString()).toBe("export const a = 1;");
+});
+
+test("the tar reader fails closed instead of under-measuring", () => {
+  const file = { path: "package/dist/index.js", contents: Buffer.from("export const a = 1;") };
+
+  // A malformed size field used to yield NaN, an empty body and a silently truncated walk.
+  expect(() => parseTarEntries(tar([{ ...file, sizeField: "not-octal!!!\0" }]))).toThrow(/malformed octal size field/);
+  expect(() => parseTarEntries(tar([{ ...file, sizeField: "000000000098\0" }]))).toThrow(/malformed octal size field/);
+
+  // A body larger than the archive used to be silently clipped.
+  expect(() => parseTarEntries(tar([{ ...file, sizeField: `${(4096).toString(8).padStart(11, "0")}\0` }]))).toThrow(/truncated archive/);
+  expect(() => parseTarEntries(tar([file]).subarray(0, 512))).toThrow(/truncated archive/);
+  expect(() => parseTarEntries(tar([file], { terminate: false }))).toThrow(/missing its end-of-archive marker/);
+
+  // Unknown entry types (and PAX globals that rewrite paths or sizes) must not be skipped quietly.
+  expect(() => parseTarEntries(tar([{ path: "package/link", type: "K", contents: Buffer.from("x") }, file]))).toThrow(/unsupported tar entry type "K"/);
+  expect(() => parseTarEntries(tar([{ path: "pax_global", type: "g", contents: paxRecords({ path: "package/elsewhere" }) }, file]))).toThrow(/global PAX header .* overrides "path"/);
+  expect(() => parseTarEntries(tar([{ path: "PaxHeaders.0/x", type: "x", contents: Buffer.from("999 path=package/x\n") }, file]))).toThrow(/invalid length/);
+  expect(() => parseTarEntries(tar([{ path: "PaxHeaders.0/x", type: "x", contents: Buffer.from("17 pathpackage/x\n") }, file]))).toThrow(/without "="/);
+  expect(() => parseTarEntries(tar([{ path: "PaxHeaders.0/x", type: "x", contents: paxRecords({ size: "-1" }) }, file]))).toThrow(/malformed size record/);
+
+  // An empty archive would measure zero bytes and pass every budget.
+  expect(() => parseTarEntries(Buffer.alloc(1024))).toThrow(/no files/);
+  expect(() => parseTarEntries(tar([{ path: "package/dist/", type: "5" }]))).toThrow(/no files/);
+
+  // Trailing junk after the end-of-archive marker means the walk stopped early.
+  expect(() => parseTarEntries(Buffer.concat([tar([file]), Buffer.from("junk")]))).toThrow(/data after its end-of-archive marker/);
+  expect(() => parseTarEntries(Buffer.concat([tar([file], { terminate: false }), Buffer.alloc(512)]))).toThrow(/expected at least two 512 B zero blocks/);
+
+  // Directory entries are still skipped, and real files after them are still measured.
+  expect(parseTarEntries(tar([{ path: "package/dist/", type: "5" }, file])).map((entry) => entry.path)).toEqual([file.path]);
+});
+
+test("the tar reader accepts what pnpm pack actually produces", () => {
+  const root = mkdtempSync(join(tmpdir(), "bundle-budgets-pack-"));
+  mkdirSync(join(root, "dist"));
+  mkdirSync(join(root, "src"));
+  writeFileSync(join(root, "dist", "index.js"), "export const a = 1;\n//# sourceMappingURL=index.js.map\n");
+  writeFileSync(join(root, "dist", "index.js.map"), JSON.stringify({ version: 3, sources: ["../src/index.ts"], sourcesContent: ["export const a = 1;".repeat(200)], mappings: "AAAA" }));
+  writeFileSync(join(root, "src", "index.docs.md"), "# docs\n".repeat(200));
+  writeFileSync(
+    join(root, "package.json"),
+    `${JSON.stringify({ name: "pack-sample", version: "0.0.0", files: ["dist", "src/**/*.docs.md"], vgpuBundleAudience: "tooling", vgpuBundleBudgetGzipBytes: 1024 }, null, 2)}\n`,
+  );
+  const packed = spawnSync("pnpm", ["--dir", root, "pack", "--pack-destination", root], { encoding: "utf8" });
+  expect(packed.status, packed.stderr).toBe(0);
+
+  const entries = parseTarEntries(gunzipSync(readFileSync(join(root, "pack-sample-0.0.0.tgz"))));
+  const paths = entries.map((entry) => entry.path);
+  expect(paths).toContain("package/package.json");
+  expect(paths).toContain("package/dist/index.js");
+  expect(paths).toContain("package/dist/index.js.map");
+  expect(paths).toContain("package/src/index.docs.md");
+  for (const entry of entries) expect(entry.contents.length).toBeGreaterThan(0);
+
+  const payload = measuredTarballPayload(entries).toString();
+  expect(payload).toContain("export const a = 1;");
+  expect(payload).not.toContain("# docs");
+  expect(payload).not.toContain("sourcesContent");
+  expect(payload).not.toContain("vgpuBundleBudgetGzipBytes");
+});
+
 test("bundle-check gates, warns and re-baselines a workspace", () => {
   const root = writeFixture();
   const manifest = join(root, "packages", "demo", "package.json");
@@ -210,19 +317,33 @@ function run(cwd: string, ...args: string[]) {
   return spawnSync(process.execPath, [script, ...args], { cwd, encoding: "utf8" });
 }
 
+type TarBlock = { path: string; contents?: Buffer; type?: string; sizeField?: string; prefix?: string };
+
 /** Minimal ustar writer, so the tar reader is exercised against real headers. */
-function tar(files: { path: string; contents: Buffer }[]) {
-  const blocks = files.map(({ path, contents }) => {
-    const header = Buffer.alloc(512);
-    header.write(path, 0, 100, "utf8");
-    header.write("000644 \0", 100, 8, "utf8");
-    header.write(`${contents.length.toString(8).padStart(11, "0")}\0`, 124, 12, "utf8");
-    header.write("        ", 148, 8, "utf8");
-    header.write("0", 156, 1, "utf8");
-    header.write("ustar\x0000", 257, 8, "utf8");
-    const checksum = header.reduce((sum, byte) => sum + byte, 0);
-    header.write(`${checksum.toString(8).padStart(6, "0")}\0 `, 148, 8, "utf8");
-    return Buffer.concat([header, contents, Buffer.alloc((512 - (contents.length % 512)) % 512)]);
-  });
-  return Buffer.concat([...blocks, Buffer.alloc(1024)]);
+function tarBlock({ path, contents = Buffer.alloc(0), type = "0", sizeField, prefix = "" }: TarBlock) {
+  const header = Buffer.alloc(512);
+  header.write(path, 0, 100, "utf8");
+  header.write("000644 \0", 100, 8, "utf8");
+  header.write(sizeField ?? `${contents.length.toString(8).padStart(11, "0")}\0`, 124, 12, "utf8");
+  header.write("        ", 148, 8, "utf8");
+  header.write(type, 156, 1, "utf8");
+  header.write("ustar\x0000", 257, 8, "utf8");
+  if (prefix) header.write(prefix, 345, 155, "utf8");
+  const checksum = header.reduce((sum, byte) => sum + byte, 0);
+  header.write(`${checksum.toString(8).padStart(6, "0")}\0 `, 148, 8, "utf8");
+  return Buffer.concat([header, contents, Buffer.alloc((512 - (contents.length % 512)) % 512)]);
+}
+
+function tar(files: TarBlock[], { terminate = true } = {}) {
+  return Buffer.concat([...files.map(tarBlock), ...(terminate ? [Buffer.alloc(1024)] : [])]);
+}
+
+function paxRecords(records: Record<string, string>) {
+  return Buffer.concat(
+    Object.entries(records).map(([key, value]) => {
+      const payload = ` ${key}=${value}\n`;
+      const length = `${payload.length + 1}`.length + payload.length;
+      return Buffer.from(`${length}${payload}`, "utf8");
+    }),
+  );
 }

--- a/scripts/check-bundle-size.mjs
+++ b/scripts/check-bundle-size.mjs
@@ -1,31 +1,69 @@
 import { execFileSync } from "node:child_process";
-import { createReadStream, existsSync, rmSync } from "node:fs";
+import { existsSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { readdir, readFile } from "node:fs/promises";
-import { join } from "node:path";
+import { join, relative } from "node:path";
 import { build } from "esbuild";
-import { createGzip } from "node:zlib";
+import { gunzipSync, gzipSync } from "node:zlib";
+import {
+  BUDGET_NOTE,
+  EXPORT_BUDGET_FIELD,
+  EXPORT_NOTE_FIELD,
+  PACKAGE_BUDGET_FIELD,
+  PACKAGE_NOTE_FIELD,
+  evaluateBudget,
+  exportBudgetField,
+  exportLabel,
+  formatFailure,
+  formatVerdictLine,
+  measuredTarballPayload,
+  nextBudgetBytes,
+  parseTarEntries,
+  resolveExportAudience,
+  resolvePackageAudience,
+  resolveThreshold,
+} from "./lib/bundle-budgets.mjs";
 
+const options = parseArgs(process.argv.slice(2));
 const root = process.cwd();
 const packagesDir = join(root, "packages");
-let failed = false;
+const failures = [];
+const warnings = [];
+const updates = [];
 
-for (const name of await readdir(packagesDir)) {
+for (const name of (await readdir(packagesDir)).sort()) {
   const dir = join(packagesDir, name);
-  const pkg = JSON.parse(await readFile(join(dir, "package.json"), "utf8"));
-  if (pkg.vgpuExportBundleBudgetsGzipBytes) await checkExportBudgets(dir, pkg);
-  else if (pkg.vgpuBundleBudgetGzipBytes) await checkPackageBudget(dir, pkg);
+  const manifestPath = join(dir, "package.json");
+  const pkg = JSON.parse(await readFile(manifestPath, "utf8"));
+  if (pkg[EXPORT_BUDGET_FIELD]) await checkExportBudgets(dir, manifestPath, pkg);
+  else if (pkg[PACKAGE_BUDGET_FIELD]) await checkPackageBudget(dir, manifestPath, pkg);
 }
 
-if (failed) process.exit(1);
+report();
 
-async function checkExportBudgets(dir, pkg) {
-  for (const [subpath, budget] of Object.entries(pkg.vgpuExportBundleBudgetsGzipBytes)) {
+async function checkExportBudgets(dir, manifestPath, pkg) {
+  const threshold = resolveThreshold(pkg, options.threshold);
+  const measured = {};
+  for (const [subpath, budget] of Object.entries(pkg[EXPORT_BUDGET_FIELD])) {
     const exportInfo = pkg.exports?.[subpath];
     const jsFile = typeof exportInfo === "object" ? exportInfo.import : exportInfo;
     const path = join(dir, jsFile.replace(/^\.\//, ""));
     const gzipBytes = existsSync(path) ? await bundledGzipSize(path) : Infinity;
-    console.log(`${pkg.name}${subpath === "." ? "" : subpath.slice(1)}: ${gzipBytes} B gzip / ${budget} B budget`);
-    if (gzipBytes > budget) failed = true;
+    measured[subpath] = gzipBytes;
+    record({
+      label: exportLabel(pkg.name, subpath),
+      field: exportBudgetField(subpath),
+      manifestPath: relative(root, manifestPath),
+      verdict: evaluateBudget({ measuredBytes: gzipBytes, budgetBytes: budget, audience: resolveExportAudience(pkg, subpath), threshold }),
+    });
+  }
+  if (options.update) {
+    updateManifest(manifestPath, pkg, (draft) => {
+      for (const [subpath, gzipBytes] of Object.entries(measured)) {
+        if (!Number.isFinite(gzipBytes)) throw new Error(`${exportLabel(pkg.name, subpath)}: cannot update the budget, the built artifact is missing (run \`pnpm build\` first)`);
+        draft[EXPORT_BUDGET_FIELD][subpath] = nextBudgetBytes(gzipBytes);
+      }
+      draft[EXPORT_NOTE_FIELD] = BUDGET_NOTE;
+    });
   }
 }
 
@@ -36,35 +74,98 @@ async function bundledGzipSize(entryPoint) {
     format: "esm",
     platform: "neutral",
     external: ["node:*", "webgpu", "@vgpu/*"],
-    mainFields: ["module", "main"],
     write: false,
     minify: true,
     mainFields: ["module", "main"],
   });
-  return gzipBytes(result.outputFiles[0].contents);
+  return gzipSync(result.outputFiles[0].contents).length;
 }
 
-async function checkPackageBudget(dir, pkg) {
+async function checkPackageBudget(dir, manifestPath, pkg) {
+  const bytes = packedDistGzipSize(dir, pkg);
+  record({
+    label: pkg.name,
+    field: PACKAGE_BUDGET_FIELD,
+    manifestPath: relative(root, manifestPath),
+    verdict: evaluateBudget({ measuredBytes: bytes, budgetBytes: pkg[PACKAGE_BUDGET_FIELD], audience: resolvePackageAudience(pkg), threshold: resolveThreshold(pkg, options.threshold) }),
+  });
+  if (options.update) {
+    updateManifest(manifestPath, pkg, (draft) => {
+      draft[PACKAGE_BUDGET_FIELD] = nextBudgetBytes(bytes);
+      draft[PACKAGE_NOTE_FIELD] = BUDGET_NOTE;
+    });
+  }
+}
+
+/**
+ * Gzip size of the published dist bytes: `pnpm pack` decides the file set, then `*.docs.md` files
+ * are dropped and sourcemap `sourcesContent` stripped before gzipping (issue #200 C), so docs and
+ * inlined sources never compete with the size gate.
+ */
+function packedDistGzipSize(dir, pkg) {
   execFileSync("pnpm", ["--dir", dir, "pack", "--pack-destination", dir], { stdio: "ignore" });
   const tarball = join(dir, `${pkg.name.replace("@", "").replace("/", "-")}-${pkg.version}.tgz`);
-  const bytes = await gzipSize(tarball);
-  rmSync(tarball, { force: true });
-  console.log(`${pkg.name}: ${bytes} B gzip / ${pkg.vgpuBundleBudgetGzipBytes} B budget`);
-  if (bytes > pkg.vgpuBundleBudgetGzipBytes) failed = true;
+  try {
+    const entries = parseTarEntries(gunzipSync(readFileSync(tarball)));
+    return gzipSync(measuredTarballPayload(entries)).length;
+  } finally {
+    rmSync(tarball, { force: true });
+  }
 }
 
-function gzipSize(path) {
-  return new Promise((resolve, reject) => {
-    let bytes = 0;
-    createReadStream(path).pipe(createGzip()).on("data", (chunk) => { bytes += chunk.length; }).on("end", () => resolve(bytes)).on("error", reject);
-  });
+function record(entry) {
+  console.log(formatVerdictLine(entry.label, entry.verdict));
+  if (entry.verdict.status === "fail") failures.push(entry);
+  if (entry.verdict.status === "warn") warnings.push(entry);
 }
 
-function gzipBytes(contents) {
-  return new Promise((resolve, reject) => {
-    let bytes = 0;
-    const gzip = createGzip();
-    gzip.on("data", (chunk) => { bytes += chunk.length; }).on("end", () => resolve(bytes)).on("error", reject);
-    gzip.end(contents);
-  });
+function updateManifest(manifestPath, pkg, mutate) {
+  const draft = JSON.parse(JSON.stringify(pkg));
+  mutate(draft);
+  const next = `${JSON.stringify(draft, null, 2)}\n`;
+  const previous = readFileSync(manifestPath, "utf8");
+  if (next === previous) return;
+  writeFileSync(manifestPath, next);
+  updates.push(relative(root, manifestPath));
+}
+
+function report() {
+  if (options.update) {
+    console.log(updates.length ? `\nUpdated budgets in:\n${updates.map((path) => `  ${path}`).join("\n")}` : "\nBudgets already match the convention, nothing to update.");
+    return;
+  }
+  if (warnings.length) {
+    console.log(`\n${warnings.length} tooling budget${warnings.length === 1 ? "" : "s"} exceeded within the growth threshold (warning only):`);
+    for (const warning of warnings) console.log(`  ${warning.label}: ${warning.verdict.measuredBytes} B gzip vs ${warning.verdict.budgetBytes} B budget (+${warning.verdict.overBudgetBytes} B) -> re-baseline with \`pnpm bundle-check --update\``);
+  }
+  if (!failures.length) return;
+  console.error(`\n${failures.length} bundle budget${failures.length === 1 ? "" : "s"} exceeded:\n`);
+  for (const failure of failures) console.error(`${formatFailure(failure)}\n`);
+  console.error("Run `pnpm bundle-check --update` to re-baseline every budget to the convention (next 512 B multiple at least 512 B above measured), then review the one-line diffs.");
+  process.exit(1);
+}
+
+function parseArgs(argv) {
+  const parsed = { update: false, threshold: undefined };
+  for (const arg of argv) {
+    if (arg === "--update") parsed.update = true;
+    else if (arg.startsWith("--threshold=")) parsed.threshold = parseThreshold(arg.slice("--threshold=".length));
+    else if (arg === "--help" || arg === "-h") {
+      console.log("Usage: pnpm bundle-check [--update] [--threshold=<fraction|percent%>]\n\n  --update             rewrite every budget to the convention (next 512 B multiple at least 512 B above measured)\n  --threshold=0.05     override the tooling growth threshold (accepts 0.05 or 5%)");
+      process.exit(0);
+    } else {
+      console.error(`Unknown argument ${arg}. Usage: pnpm bundle-check [--update] [--threshold=<fraction|percent%>]`);
+      process.exit(2);
+    }
+  }
+  return parsed;
+}
+
+function parseThreshold(raw) {
+  const value = raw.endsWith("%") ? Number(raw.slice(0, -1)) / 100 : Number(raw);
+  if (!Number.isFinite(value) || value < 0) {
+    console.error(`Invalid --threshold=${raw}: expected a non-negative fraction (0.05) or percentage (5%).`);
+    process.exit(2);
+  }
+  return value;
 }

--- a/scripts/lib/bundle-budgets.mjs
+++ b/scripts/lib/bundle-budgets.mjs
@@ -1,0 +1,216 @@
+// Shared, side-effect-free logic for `pnpm bundle-check` (scripts/check-bundle-size.mjs).
+// Kept separate from IO so the threshold/measurement/update rules stay unit-testable.
+
+/** Budgets are always multiples of this many bytes. */
+export const BUDGET_STEP = 512;
+
+/** Minimum guaranteed headroom between a measured size and its budget. */
+export const MIN_HEADROOM = 512;
+
+/** Default growth threshold for `tooling` budgets: 5% over budget still passes (with a warning). */
+export const DEFAULT_GROWTH_THRESHOLD = 0.05;
+
+/** Audience of a measured artifact. Unclassified artifacts default to `client` (hard gate). */
+export const DEFAULT_AUDIENCE = "client";
+
+export const AUDIENCES = ["client", "tooling"];
+
+export const EXPORT_BUDGET_FIELD = "vgpuExportBundleBudgetsGzipBytes";
+export const PACKAGE_BUDGET_FIELD = "vgpuBundleBudgetGzipBytes";
+export const EXPORT_AUDIENCE_FIELD = "vgpuExportBundleAudiences";
+export const PACKAGE_AUDIENCE_FIELD = "vgpuBundleAudience";
+export const THRESHOLD_FIELD = "vgpuBundleBudgetGrowthThreshold";
+export const EXPORT_NOTE_FIELD = "vgpuExportBundleBudgetNote";
+export const PACKAGE_NOTE_FIELD = "vgpuBundleBudgetNote";
+
+/**
+ * Convention: the smallest multiple of 512 that sits at least 512 B above the measured size, so
+ * headroom is never an accident of rounding (see issue #200).
+ */
+export function nextBudgetBytes(measuredBytes) {
+  if (!Number.isFinite(measuredBytes) || measuredBytes < 0) throw new Error(`cannot derive a budget from ${measuredBytes}`);
+  return Math.ceil((measuredBytes + MIN_HEADROOM) / BUDGET_STEP) * BUDGET_STEP;
+}
+
+/** Soft ceiling for `tooling` budgets: growth up to this size warns instead of failing. */
+export function softLimitBytes(budgetBytes, threshold = DEFAULT_GROWTH_THRESHOLD) {
+  return Math.floor(budgetBytes * (1 + threshold));
+}
+
+export function resolveThreshold(pkg, override) {
+  if (override !== undefined) return override;
+  const declared = pkg?.[THRESHOLD_FIELD];
+  if (declared === undefined) return DEFAULT_GROWTH_THRESHOLD;
+  if (typeof declared !== "number" || !Number.isFinite(declared) || declared < 0) {
+    throw new Error(`${pkg.name}: ${THRESHOLD_FIELD} must be a non-negative number, got ${JSON.stringify(declared)}`);
+  }
+  return declared;
+}
+
+/** Audience for an export subpath: per-export override, else package default, else `client`. */
+export function resolveExportAudience(pkg, subpath) {
+  const audience = pkg?.[EXPORT_AUDIENCE_FIELD]?.[subpath] ?? pkg?.[PACKAGE_AUDIENCE_FIELD] ?? DEFAULT_AUDIENCE;
+  return validateAudience(audience, exportLabel(pkg?.name, subpath));
+}
+
+export function resolvePackageAudience(pkg) {
+  return validateAudience(pkg?.[PACKAGE_AUDIENCE_FIELD] ?? DEFAULT_AUDIENCE, pkg?.name);
+}
+
+function validateAudience(audience, label) {
+  if (!AUDIENCES.includes(audience)) throw new Error(`${label}: unknown audience ${JSON.stringify(audience)} (expected ${AUDIENCES.join(" | ")})`);
+  return audience;
+}
+
+/**
+ * Verdict for one measured artifact.
+ * - `client`: hard gate, any byte over budget fails.
+ * - `tooling`: soft gate, over budget warns until the growth threshold is exceeded.
+ */
+export function evaluateBudget({ measuredBytes, budgetBytes, audience = DEFAULT_AUDIENCE, threshold = DEFAULT_GROWTH_THRESHOLD }) {
+  const soft = audience === "tooling";
+  const limitBytes = soft ? softLimitBytes(budgetBytes, threshold) : budgetBytes;
+  const status = measuredBytes <= budgetBytes ? "ok" : measuredBytes <= limitBytes ? "warn" : "fail";
+  return {
+    status,
+    audience,
+    soft,
+    threshold: soft ? threshold : 0,
+    measuredBytes,
+    budgetBytes,
+    limitBytes,
+    overBudgetBytes: measuredBytes - budgetBytes,
+    overLimitBytes: measuredBytes - limitBytes,
+    headroomBytes: budgetBytes - measuredBytes,
+    suggestedBudgetBytes: Number.isFinite(measuredBytes) ? nextBudgetBytes(measuredBytes) : budgetBytes,
+  };
+}
+
+export function formatBytes(bytes) {
+  return Number.isFinite(bytes) ? `${bytes} B` : "missing artifact";
+}
+
+function percent(numerator, denominator) {
+  return `${((numerator / denominator) * 100).toFixed(1)}%`;
+}
+
+/** One line per artifact, always printed. */
+export function formatVerdictLine(label, verdict) {
+  const prefix = verdict.status === "ok" ? "" : verdict.status === "warn" ? "WARN " : "FAIL ";
+  const head = `${prefix}${label} [${verdict.audience}]: ${formatBytes(verdict.measuredBytes)} gzip / ${verdict.budgetBytes} B budget`;
+  if (verdict.status === "ok") return `${head} (headroom ${verdict.headroomBytes} B)`;
+  const over = `+${verdict.overBudgetBytes} B over budget`;
+  if (verdict.status === "warn") {
+    return `${head} (${over}, ${percent(verdict.overBudgetBytes, verdict.budgetBytes)}; within the ${percent(verdict.threshold, 1)} tooling growth threshold, soft limit ${verdict.limitBytes} B)`;
+  }
+  return `${head} (${over}${verdict.soft ? `, ${verdict.overLimitBytes} B past the ${verdict.limitBytes} B soft limit` : ""})`;
+}
+
+/**
+ * Actionable failure block: names the budget field, the package/entry, measured vs budget and the
+ * `--update` escape hatch, so a red `test-fast` job explains itself (issue #200).
+ */
+export function formatFailure({ label, field, manifestPath, verdict }) {
+  const lines = [`${label}: ${formatBytes(verdict.measuredBytes)} gzip exceeds the ${verdict.soft ? `tooling soft limit of ${verdict.limitBytes}` : `hard client budget of ${verdict.budgetBytes}`} B`];
+  lines.push(`  budget field: ${manifestPath} -> ${field} (currently ${verdict.budgetBytes} B, measured ${formatBytes(verdict.measuredBytes)})`);
+  if (verdict.soft) {
+    lines.push(`  audience: tooling (soft gate) -> growth up to +${percent(verdict.threshold, 1)} (${verdict.limitBytes} B) only warns; this is ${verdict.overLimitBytes} B past that`);
+  } else {
+    lines.push(`  audience: client (hard gate) -> browser bytes, ${verdict.overBudgetBytes} B over budget; prefer shrinking the entry over raising the budget`);
+  }
+  lines.push(`  fix: if the growth is intentional run \`pnpm bundle-check --update\` to re-baseline (would write ${verdict.suggestedBudgetBytes} B: next ${BUDGET_STEP} B multiple at least ${MIN_HEADROOM} B above measured)`);
+  return lines.join("\n");
+}
+
+export function exportBudgetField(subpath) {
+  return `${EXPORT_BUDGET_FIELD}[${JSON.stringify(subpath)}]`;
+}
+
+export function exportLabel(pkgName, subpath) {
+  return `${pkgName}${subpath === "." ? "" : subpath.slice(1)}`;
+}
+
+export const BUDGET_NOTE = `Gzip ceilings use 512-byte granularity: each budget is the next 512-byte multiple at least 512 B above the measured size, so headroom is never a rounding accident. Regenerate with \`pnpm bundle-check --update\`. ${PACKAGE_AUDIENCE_FIELD}/${EXPORT_AUDIENCE_FIELD} select the gate: "client" entries ship to browsers and fail on any byte over budget; "tooling" entries (loaders, Node runtime, CLI, package tarballs) only warn until growth passes ${THRESHOLD_FIELD} (default 5%). Tarballs measure published dist bytes with sourcemap sourcesContent stripped and *.docs.md excluded.`;
+
+/**
+ * Tarball measurement (issue #200 C): count published dist bytes only. Co-located `*.docs.md`
+ * files are dropped and sourcemap `sourcesContent` is stripped, so documenting the API or emitting
+ * maps never competes with the size gate.
+ */
+export function isMeasuredTarballEntry(path) {
+  return !path.endsWith(".docs.md");
+}
+
+export function stripSourcesContent(path, contents) {
+  if (!path.endsWith(".map")) return contents;
+  let map;
+  try {
+    map = JSON.parse(contents.toString("utf8"));
+  } catch {
+    return contents;
+  }
+  if (!Array.isArray(map.sourcesContent)) return contents;
+  delete map.sourcesContent;
+  return Buffer.from(JSON.stringify(map), "utf8");
+}
+
+/**
+ * The budget metadata itself is published bytes, so leaving it in would make `--update` chase its
+ * own tail (writing a bigger budget grows the manifest, which grows the measurement). Dropping it
+ * keeps the measurement invariant under re-baselining, so `--update` converges in one pass.
+ */
+export function stripBudgetMetadata(path, contents) {
+  if (path !== "package/package.json") return contents;
+  let manifest;
+  try {
+    manifest = JSON.parse(contents.toString("utf8"));
+  } catch {
+    return contents;
+  }
+  const keys = Object.keys(manifest).filter((key) => /^vgpu(Export)?Bundle/.test(key));
+  if (!keys.length) return contents;
+  for (const key of keys) delete manifest[key];
+  return Buffer.from(`${JSON.stringify(manifest, null, 2)}\n`, "utf8");
+}
+
+/** Deterministic payload measured for a package tarball: filtered, stripped files sorted by path. */
+export function measuredTarballPayload(entries) {
+  return Buffer.concat(
+    entries
+      .filter((entry) => isMeasuredTarballEntry(entry.path))
+      .sort((a, b) => (a.path < b.path ? -1 : a.path > b.path ? 1 : 0))
+      .map((entry) => stripBudgetMetadata(entry.path, stripSourcesContent(entry.path, entry.contents))),
+  );
+}
+
+const TAR_BLOCK = 512;
+
+/** Minimal ustar reader: npm/pnpm tarballs only hold regular files, directories and GNU long names. */
+export function parseTarEntries(buffer) {
+  const entries = [];
+  let offset = 0;
+  let longName;
+  while (offset + TAR_BLOCK <= buffer.length) {
+    const header = buffer.subarray(offset, offset + TAR_BLOCK);
+    if (header.every((byte) => byte === 0)) break;
+    const name = readField(header, 0, 100);
+    const size = Number.parseInt(readField(header, 124, 12).trim() || "0", 8);
+    const type = String.fromCharCode(header[156] || 0x30);
+    const body = buffer.subarray(offset + TAR_BLOCK, offset + TAR_BLOCK + size);
+    if (type === "L") longName = body.toString("utf8").replace(/\0+$/, "");
+    else if (type === "0" || type === "\0") entries.push({ path: longName ?? joinTarPath(readField(header, 345, 155), name), contents: Buffer.from(body) });
+    if (type !== "L") longName = undefined;
+    offset += TAR_BLOCK + Math.ceil(size / TAR_BLOCK) * TAR_BLOCK;
+  }
+  return entries;
+}
+
+function joinTarPath(prefix, name) {
+  return prefix ? `${prefix}/${name}` : name;
+}
+
+function readField(header, start, length) {
+  const raw = header.subarray(start, start + length);
+  const end = raw.indexOf(0);
+  return raw.subarray(0, end === -1 ? raw.length : end).toString("utf8");
+}

--- a/scripts/lib/bundle-budgets.mjs
+++ b/scripts/lib/bundle-budgets.mjs
@@ -185,24 +185,110 @@ export function measuredTarballPayload(entries) {
 
 const TAR_BLOCK = 512;
 
-/** Minimal ustar reader: npm/pnpm tarballs only hold regular files, directories and GNU long names. */
+/** Entry types this reader understands. Anything else is an error rather than a silent skip. */
+const TAR_FILE_TYPES = new Set(["0", "\0", "7"]);
+const TAR_SKIPPED_TYPES = new Set(["5", "1", "2", "3", "4", "6"]);
+
+/**
+ * Minimal tar reader for npm/pnpm tarballs (ustar with optional GNU long names and PAX headers).
+ *
+ * This feeds a size gate, so it is deliberately fail-closed: anything it cannot interpret exactly
+ * -- an unknown entry type, a non-octal or out-of-range size, a truncated body, a missing
+ * end-of-archive marker, an empty archive -- throws instead of returning fewer bytes than the
+ * tarball really holds. A silently under-counted measurement would turn a budget into a false pass.
+ */
 export function parseTarEntries(buffer) {
   const entries = [];
   let offset = 0;
-  let longName;
+  let terminated = false;
+  let pathOverride;
+  let sizeOverride;
   while (offset + TAR_BLOCK <= buffer.length) {
     const header = buffer.subarray(offset, offset + TAR_BLOCK);
-    if (header.every((byte) => byte === 0)) break;
-    const name = readField(header, 0, 100);
-    const size = Number.parseInt(readField(header, 124, 12).trim() || "0", 8);
+    if (header.every((byte) => byte === 0)) {
+      requireEndOfArchive(buffer, offset);
+      terminated = true;
+      break;
+    }
     const type = String.fromCharCode(header[156] || 0x30);
-    const body = buffer.subarray(offset + TAR_BLOCK, offset + TAR_BLOCK + size);
-    if (type === "L") longName = body.toString("utf8").replace(/\0+$/, "");
-    else if (type === "0" || type === "\0") entries.push({ path: longName ?? joinTarPath(readField(header, 345, 155), name), contents: Buffer.from(body) });
-    if (type !== "L") longName = undefined;
-    offset += TAR_BLOCK + Math.ceil(size / TAR_BLOCK) * TAR_BLOCK;
+    const isFile = TAR_FILE_TYPES.has(type);
+    const dataSize = isFile && sizeOverride !== undefined ? sizeOverride : readTarSize(header, offset);
+    const paddedSize = Math.ceil(dataSize / TAR_BLOCK) * TAR_BLOCK;
+    if (offset + TAR_BLOCK + paddedSize > buffer.length) {
+      throw new Error(`tar entry at offset ${offset} claims ${dataSize} B but the archive ends after ${buffer.length - offset - TAR_BLOCK} B (truncated archive)`);
+    }
+    const body = buffer.subarray(offset + TAR_BLOCK, offset + TAR_BLOCK + dataSize);
+    if (type === "L") {
+      pathOverride = body.toString("utf8").replace(/\0+$/, "");
+    } else if (type === "x") {
+      const records = parsePaxRecords(body, offset);
+      if (records.path !== undefined) pathOverride = records.path;
+      if (records.size !== undefined) sizeOverride = readPaxSize(records.size, offset);
+    } else if (type === "g") {
+      const records = parsePaxRecords(body, offset);
+      for (const key of ["path", "size"]) {
+        if (records[key] !== undefined) throw new Error(`tar global PAX header at offset ${offset} overrides "${key}" for every entry, which this reader does not support`);
+      }
+    } else if (isFile) {
+      entries.push({ path: pathOverride ?? joinTarPath(readField(header, 345, 155), readField(header, 0, 100)), contents: Buffer.from(body) });
+      pathOverride = undefined;
+      sizeOverride = undefined;
+    } else if (TAR_SKIPPED_TYPES.has(type)) {
+      pathOverride = undefined;
+      sizeOverride = undefined;
+    } else {
+      throw new Error(`unsupported tar entry type ${JSON.stringify(type)} at offset ${offset} (${JSON.stringify(readField(header, 0, 100))})`);
+    }
+    offset += TAR_BLOCK + paddedSize;
   }
+  if (!terminated) throw new Error(`tar is missing its end-of-archive marker after ${offset} B (truncated archive)`);
+  if (!entries.length) throw new Error("tar contains no files, refusing to measure an empty archive");
   return entries;
+}
+
+/** The archive must end with two zero blocks and nothing but zero padding after them. */
+function requireEndOfArchive(buffer, offset) {
+  const tail = buffer.subarray(offset);
+  if (tail.length < 2 * TAR_BLOCK) throw new Error(`tar ends with ${tail.length} B of zero padding, expected at least two ${TAR_BLOCK} B zero blocks`);
+  const trailing = tail.findIndex((byte) => byte !== 0);
+  if (trailing !== -1) throw new Error(`tar has ${tail.length - trailing} B of data after its end-of-archive marker at offset ${offset + trailing}`);
+}
+
+function readTarSize(header, offset) {
+  if (header[124] & 0x80) throw new Error(`tar entry at offset ${offset} uses a base-256 size field, which this reader does not support`);
+  const raw = readField(header, 124, 12).trim();
+  if (!/^[0-7]+$/.test(raw)) throw new Error(`tar entry at offset ${offset} has a malformed octal size field ${JSON.stringify(raw)}`);
+  const size = Number.parseInt(raw, 8);
+  if (!Number.isSafeInteger(size) || size < 0) throw new Error(`tar entry at offset ${offset} has an out-of-range size ${JSON.stringify(raw)}`);
+  return size;
+}
+
+function readPaxSize(raw, offset) {
+  const size = Number(raw);
+  if (!/^\d+$/.test(raw) || !Number.isSafeInteger(size)) throw new Error(`tar PAX header at offset ${offset} has a malformed size record ${JSON.stringify(raw)}`);
+  return size;
+}
+
+/** PAX extended headers are `"<length> <key>=<value>\n"` records; a malformed one is fatal. */
+function parsePaxRecords(body, offset) {
+  const records = {};
+  let cursor = 0;
+  while (cursor < body.length) {
+    const space = body.indexOf(0x20, cursor);
+    if (space === -1) throw new Error(`tar PAX header at offset ${offset} has a record without a length separator`);
+    const rawLength = body.subarray(cursor, space).toString("utf8");
+    const length = Number(rawLength);
+    if (!/^\d+$/.test(rawLength) || !Number.isSafeInteger(length) || length <= space - cursor + 1 || cursor + length > body.length) {
+      throw new Error(`tar PAX header at offset ${offset} has a record with an invalid length ${JSON.stringify(rawLength)}`);
+    }
+    if (body[cursor + length - 1] !== 0x0a) throw new Error(`tar PAX header at offset ${offset} has a record that does not end with a newline`);
+    const record = body.subarray(space + 1, cursor + length - 1).toString("utf8");
+    const separator = record.indexOf("=");
+    if (separator === -1) throw new Error(`tar PAX header at offset ${offset} has a record without "=": ${JSON.stringify(record)}`);
+    records[record.slice(0, separator)] = record.slice(separator + 1);
+    cursor += length;
+  }
+  return records;
 }
 
 function joinTarPath(prefix, name) {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,7 +5,7 @@ import { wgslVitePlugin } from "./packages/wgsl/src/loader-vite/index.ts";
 export default defineConfig({
   plugins: [wgslVitePlugin()],
   test: {
-    include: ["packages/**/*.test.ts", "examples/**/*.test.ts", "apps/docs/**/*.test.ts"],
+    include: ["packages/**/*.test.ts", "examples/**/*.test.ts", "apps/docs/**/*.test.ts", "scripts/**/*.test.ts"],
     poolMatchGlobs: [["{packages/adapter-node/tests/**,packages/render/tests/**}", "forks"]],
     testTimeout: 30_000,
   },


### PR DESCRIPTION
Closes #200

`pnpm bundle-check` enforced a single hard gzip gate whose headroom was an accident of rounding (`@vgpu/core` sat 2 B under budget, `@vgpu/wgsl/runtime` 128 B), and tarball budgets counted sourcemap `sourcesContent` plus co-located `*.docs.md`, so documenting the API competed with the size gate. Failures surfaced as an opaque `test-fast fail`.

## (B) Budgets tiered by audience

Classification is explicit: `vgpuBundleAudience` (package-wide) or `vgpuExportBundleAudiences` (per export subpath).

| audience | gate | applies to |
| --- | --- | --- |
| `client` (**default when unclassified**, preserving today's behavior) | **hard** — one byte over budget fails | browser-facing entries |
| `tooling` | **soft** — over budget warns, fails only past `vgpuBundleBudgetGrowthThreshold` (default 5%, `--threshold=` overrides) | loaders, Node runtime, CLI, package tarballs |

## (C) Tarballs measure published dist bytes

`pnpm pack` still decides the file set; the tarball is then read entry by entry and, before gzipping, the measurement drops `*.docs.md`, strips `sourcesContent` from `*.map` files, and ignores the `vgpu*Bundle*` budget metadata itself (otherwise writing a bigger budget grows the manifest, which grows the measurement, and `--update` would never converge). Docs and inlined sources no longer fight the gate.

## (D) `pnpm bundle-check --update`

Rewrites every budget mechanically to the new convention: **budget = next 512 B multiple at least 512 B above measured**, so headroom is guaranteed (>= 512 B) instead of a rounding accident. Idempotent: a second run reports `nothing to update`.

## Inventory: classification and re-baseline

Measured values for the three tarballs change because of (C); export bundles are measured as before and only their budgets move.

| package / entry | audience | measured before | budget before | measured after | budget after | headroom after |
| --- | --- | --- | --- | --- | --- | --- |
| `@vgpu/adapter-mock` (tarball) | tooling | 13456 | 13824 | 12826 | 13824 | 998 |
| `@vgpu/adapter-node` (tarball) | tooling | 40731 | 40960 | 33543 | 34304 | 761 |
| `@vgpu/core` (tarball) | tooling | 43438 -> 48638 | 48640 (2 B headroom) | 31841 | 32768 | 927 |
| `@vgpu/render/inspect` | client | 2506 | 2560 | 2506 | 3072 | 566 |
| `@vgpu/render/utils` | client | 574 | 1024 | 574 | 1536 | 962 |
| `@vgpu/render/edit` | client | 12204 | 12288 | 12204 | 12800 | 596 |
| `@vgpu/render/perf` | client | 1178 | 1536 | 1178 | 2048 | 870 |
| `vgpu` `"."` | client | 43527 | 44032 (17 B) | 43527 | 44544 | 1017 |
| `vgpu/node` | tooling | 43680 | 44032 | 43680 | 44544 | 864 |
| `vgpu/mock` | tooling | 43615 | 44032 | 43615 | 44544 | 929 |
| `vgpu/scene` | client | 6091 | 6144 | 6091 | 6656 | 565 |
| `vgpu/client` | client | 86 | 512 | 86 | 1024 | 938 |
| `vgpu/core` | client | 3301 | 3584 | 3301 | 4096 | 795 |
| `@vgpu/wgsl` `"."` | client | 688 | 1024 | 688 | 1536 | 848 |
| `@vgpu/wgsl/runtime` | tooling | 21753 | 22016 (128 B) | 21753 | 22528 | 775 |
| `@vgpu/wgsl/loader-webpack` | tooling | 22193 | 22528 | 22193 | 23040 | 847 |
| `@vgpu/wgsl/loader-vite` | tooling | 22170 | 22528 | 22170 | 23040 | 870 |
| `@vgpu/wgsl/reflect-source` | tooling | 13528 | 13824 | 13528 | 14336 | 808 |

Rationale: browser-facing entries (`@vgpu/wgsl` `"."`, `vgpu` `"."`, `vgpu/client`, `vgpu/scene`, `vgpu/core`, all `@vgpu/render/*` runtime entries) keep the hard gate — those are client bytes. Build-time/Node artifacts (WGSL loaders, `@vgpu/wgsl/runtime`, `reflect-source`, `vgpu/node`, `vgpu/mock`) and package tarballs get the soft gate, per the issue's cost model.

## Behavior proof (simulated growth, not committed)

Real growth was appended to built `dist` files, then reverted.

**1. Tooling entry, +825 B (inside the 5% margin) -> warning, exit 0**

```
WARN @vgpu/wgsl/runtime [tooling]: 22578 B gzip / 22528 B budget (+50 B over budget, 0.2%; within the 5.0% tooling growth threshold, soft limit 23654 B)

1 tooling budget exceeded within the growth threshold (warning only):
  @vgpu/wgsl/runtime: 22578 B gzip vs 22528 B budget (+50 B) -> re-baseline with `pnpm bundle-check --update`
exit=0
```

**2. Same tooling entry, past the threshold -> failure, exit 1**

```
FAIL @vgpu/wgsl/runtime [tooling]: 23876 B gzip / 22528 B budget (+1348 B over budget, 222 B past the 23654 B soft limit)

1 bundle budget exceeded:

@vgpu/wgsl/runtime: 23876 B gzip exceeds the tooling soft limit of 23654 B
  budget field: packages/wgsl/package.json -> vgpuExportBundleBudgetsGzipBytes["./runtime"] (currently 22528 B, measured 23876 B)
  audience: tooling (soft gate) -> growth up to +5.0% (23654 B) only warns; this is 222 B past that
  fix: if the growth is intentional run `pnpm bundle-check --update` to re-baseline (would write 24576 B: next 512 B multiple at least 512 B above measured)

Run `pnpm bundle-check --update` to re-baseline every budget to the convention (next 512 B multiple at least 512 B above measured), then review the one-line diffs.
exit=1
```

**3. Client entry, +187 B over budget -> hard failure, exit 1**

```
FAIL @vgpu/wgsl [client]: 1723 B gzip / 1536 B budget (+187 B over budget)

1 bundle budget exceeded:

@vgpu/wgsl: 1723 B gzip exceeds the hard client budget of 1536 B
  budget field: packages/wgsl/package.json -> vgpuExportBundleBudgetsGzipBytes["."] (currently 1536 B, measured 1723 B)
  audience: client (hard gate) -> browser bytes, 187 B over budget; prefer shrinking the entry over raising the budget
  fix: if the growth is intentional run `pnpm bundle-check --update` to re-baseline (would write 2560 B: next 512 B multiple at least 512 B above measured)
exit=1
```

## Tests and gates

- New `scripts/bundle-budgets.test.ts` (14 tests): budget convention and the >= 512 B headroom invariant, hard vs soft verdicts at the boundaries, threshold resolution (default / package field / flag), audience resolution incl. the `client` default and invalid values, actionable failure content, tarball filtering + `sourcesContent`/metadata stripping through a real ustar round-trip, plus end-to-end runs of the script over a temp workspace fixture covering warn / soft fail / hard fail / `--update` idempotency / `--threshold` / bad flags.
- `scripts/**/*.test.ts` added to the vitest `include` and to `test:fast`, so the script is covered by CI's `vitest run`.
- `pnpm bundle-check` green on the new baselines, `pnpm test:fast` 531 passed / 63 skipped, `pnpm typecheck` clean.
- `CONTRIBUTING.md` documents the audiences, the threshold and `--update`. No changeset: package changes are CI-only budget metadata (no published behavior change), which `CONTRIBUTING.md` explicitly allows to skip.
