### PR TITLE
fix: resolve bare package specifiers used as binding and struct-member types in the WGSL reflector

### DIFF
--- a/packages/wgsl-std/tests/package-resolution.test.ts
+++ b/packages/wgsl-std/tests/package-resolution.test.ts
@@ -46,6 +46,40 @@ fn main() -> f32 {
   expect(result.wgsl).toMatch(/fn _vgsl_[0-9a-f]{8}__fullscreenTriangleClip\(index: u32\) -> vec4f/);
 });
 
+test("structs imported from a package subpath can type bindings and struct members (#212)", async () => {
+  const dir = await workspaceFixture();
+  const entry = join(dir, "app", "main.wgsl");
+  await writeFile(entry, `import { VoronoiSample2, VoronoiSample3, voronoi2d, voronoi3d } from "@vgpu/wgsl-std/noise";
+
+struct Report {
+  flat: VoronoiSample2,
+  volume: VoronoiSample3,
+}
+
+@group(0) @binding(0) var<storage, read_write> report: Report;
+@group(0) @binding(1) var<storage, read_write> latest: VoronoiSample2;
+
+@compute @workgroup_size(1) fn main() {
+  report.flat = voronoi2d(vec2f(0.5, 0.25));
+  report.volume = voronoi3d(vec3f(0.5, 0.25, 0.125));
+  latest = report.flat;
+}`);
+
+  const { reflection } = await resolveShader({ entry, validate: false });
+  const [report, latest] = reflection.bindings;
+
+  expect(report?.layout?.members?.map((member) => [member.name, member.offset, member.size])).toEqual([
+    ["flat", 0, 16],
+    ["volume", 16, 32],
+  ]);
+  expect(latest?.struct?.name).toBe("VoronoiSample2");
+  expect(latest?.layout?.members?.map((member) => [member.name, member.offset])).toEqual([
+    ["f1", 0],
+    ["f2", 4],
+    ["cell", 8],
+  ]);
+});
+
 test("wgsl-std has no root WGSL export", async () => {
   const dir = await workspaceFixture();
   const entry = join(dir, "app", "main.wgsl");

--- a/packages/wgsl/src/runtime/reflect-symbols.ts
+++ b/packages/wgsl/src/runtime/reflect-symbols.ts
@@ -3,7 +3,15 @@ import type { MangleModule } from "./mangler.ts";
 import type { AliasInfo, ModuleSymbols, ParsedDecls, Registry, StructInfo, SymbolTarget, WGSLType } from "./reflect-types.ts";
 import { namespaceTypeError, unknownTypeError } from "./diagnostics.ts";
 
-export function buildModuleSymbols(modules: readonly MangleModule[], parsed: readonly ParsedDecls[]): ReadonlyMap<string, ModuleSymbols> {
+/**
+ * Resolves an import declaration to the canonical path of the imported module, using the same
+ * module resolution that loaded the graph (relative/root-alias/`packageMap`/`package.json`
+ * `exports`). `resolveShader()` passes its resolver so bare package specifiers resolve for
+ * nominal type positions exactly like they do for value positions in the mangler.
+ */
+export type ImportPathResolver = (from: string, imp: ImportDecl) => string;
+
+export function buildModuleSymbols(modules: readonly MangleModule[], parsed: readonly ParsedDecls[], resolveImport?: ImportPathResolver): ReadonlyMap<string, ModuleSymbols> {
   const own = new Map<string, Map<string, SymbolTarget>>();
   for (const decls of parsed) {
     const map = new Map<string, SymbolTarget>();
@@ -16,14 +24,14 @@ export function buildModuleSymbols(modules: readonly MangleModule[], parsed: rea
   const result = new Map<string, ModuleSymbols>();
   for (const module of modules) {
     const map = new Map(byPath.get(module.path));
-    for (const imp of module.parsed.imports) addImportedSymbols(module, imp, map, modules, byPath);
+    for (const imp of module.parsed.imports) addImportedSymbols(module, imp, map, modules, byPath, resolveImport);
     result.set(module.path, map);
   }
   return result;
 }
 
-function addImportedSymbols(module: MangleModule, imp: ImportDecl, map: Map<string, SymbolTarget>, modules: readonly MangleModule[], byPath: ReadonlyMap<string, ReadonlyMap<string, SymbolTarget>>): void {
-  const targetPath = resolveImportPath(imp.from, module.path, modules);
+function addImportedSymbols(module: MangleModule, imp: ImportDecl, map: Map<string, SymbolTarget>, modules: readonly MangleModule[], byPath: ReadonlyMap<string, ReadonlyMap<string, SymbolTarget>>, resolveImport?: ImportPathResolver): void {
+  const targetPath = resolveImportPath(imp, module.path, modules, resolveImport);
   const exports = byPath.get(targetPath);
   for (const binding of imp.bindings) {
     if (binding.namespace) {
@@ -108,11 +116,27 @@ export function resolveAliasesDeep(type: WGSLType, registry: Registry): WGSLType
   }
 }
 
-function resolveImportPath(from: string, owner: string, modules: readonly MangleModule[]): string {
+function resolveImportPath(imp: ImportDecl, owner: string, modules: readonly MangleModule[], resolveImport?: ImportPathResolver): string {
+  const resolved = tryResolveImport(imp, owner, resolveImport);
+  if (resolved !== undefined && modules.some((module) => module.path === resolved)) return resolved;
+  const from = imp.from;
   const base = owner.slice(0, owner.lastIndexOf("/") + 1);
   const joined = from.startsWith("/") ? from : normalizeVirtualPath(`${base}${from}`);
   const candidates = [from, joined];
-  return candidates.find((candidate) => modules.some((module) => module.path === candidate)) ?? joined;
+  return candidates.find((candidate) => modules.some((module) => module.path === candidate)) ?? resolved ?? joined;
+}
+
+/**
+ * Bare specifiers (`@vgpu/wgsl-std/scene`) only resolve through the graph resolver, so failures
+ * fall back to the relative/absolute heuristic below instead of aborting reflection.
+ */
+function tryResolveImport(imp: ImportDecl, owner: string, resolveImport?: ImportPathResolver): string | undefined {
+  if (!resolveImport) return undefined;
+  try {
+    return resolveImport(owner, imp);
+  } catch {
+    return undefined;
+  }
 }
 
 function normalizeVirtualPath(path: string): string {

--- a/packages/wgsl/src/runtime/reflect.ts
+++ b/packages/wgsl/src/runtime/reflect.ts
@@ -3,7 +3,7 @@ import { bindingKind, reflectedBindingLayout } from "./reflect-bind-layout.ts";
 import { parseDeclarations } from "./reflect-declarations.ts";
 import { layoutOf } from "./reflect-layout.ts";
 import { entrySamplingPairs } from "./reflect-sampling.ts";
-import { buildModuleSymbols, buildRegistry, resolveType, unwrapAlias } from "./reflect-symbols.ts";
+import { buildModuleSymbols, buildRegistry, resolveType, unwrapAlias, type ImportPathResolver } from "./reflect-symbols.ts";
 import type { Attr, BindingInfo, BindingRef, EntryPointInfo, EntryPointInputInfo, HostShareableLayout, ModuleSymbols, ParsedDecls, ParsedEntryPoint, ParsedStructMember, Reflection, Registry } from "./reflect-types.ts";
 import { numericAttr } from "./reflect-utils.ts";
 import { analyzeWgslTokens } from "./scope-walker.ts";
@@ -40,10 +40,13 @@ export type {
 /**
  * Reflects mangled WGSL modules into the frozen ReflectionFacade contract.
  * The returned names preserve source-facing identifiers while `mangledName` points at emitted WGSL.
+ * `resolveImport` is the graph resolver that loaded the modules; passing it lets imported nominal
+ * types (binding/struct-member types) resolve through bare package specifiers, `packageMap`
+ * entries and root aliases instead of relative/absolute paths only.
  */
-export function reflect(modules: readonly MangleModule[]): Reflection {
+export function reflect(modules: readonly MangleModule[], resolveImport?: ImportPathResolver): Reflection {
   const raw = modules.map(parseDeclarations);
-  const moduleSymbols = buildModuleSymbols(modules, raw);
+  const moduleSymbols = buildModuleSymbols(modules, raw, resolveImport);
   const registry = buildRegistry(raw, moduleSymbols);
   const bindings: BindingInfo[] = [];
   const hostShareableLayouts: HostShareableLayout[] = [];

--- a/packages/wgsl/src/runtime/resolve-shader.ts
+++ b/packages/wgsl/src/runtime/resolve-shader.ts
@@ -54,7 +54,7 @@ export async function resolveShader(opts: ResolveOptions): Promise<ResolvedShade
   const exportsByPath = buildExports(modules);
   const pathOf = (from: string, imp: ImportDecl) => resolvePath(imp.from, from, opts, diagnostics);
   const emittedWgsl = eliminateDeadDeclarations(modules.map((module) => `// vgsl-module: ${module.path}\n${emitModule(module, exportsByPath, pathOf).trim()}\n`).join("\n"));
-  const reflection = reflect(modules);
+  const reflection = reflect(modules, pathOf);
   const emittedReflection = reflectSource(emittedWgsl, entry);
   for (const reflectedEntry of reflection.entryPoints) {
     const emittedEntry = emittedReflection.entryPoints.find((item) => item.name === reflectedEntry.mangledName);

--- a/packages/wgsl/tests/reflect-import-types.test.ts
+++ b/packages/wgsl/tests/reflect-import-types.test.ts
@@ -1,0 +1,250 @@
+import { mkdtemp, mkdir, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { expect, test } from "vitest";
+import { resolveShader } from "@vgpu/wgsl/runtime";
+
+/**
+ * Regression suite for #212: bare package specifiers must resolve for *nominal type*
+ * positions (binding types, struct members, aliases, function signatures), not only for
+ * the value/function positions that the mangler already handled.
+ */
+
+const SCENE_ABI = `export struct SceneCamera {
+  viewProjection: mat4x4f,
+}
+
+export struct SceneLight {
+  direction: vec4f,
+  color: vec4f,
+  intensity: f32,
+  kind: u32,
+}
+
+export struct SceneLights {
+  count: u32,
+  lights: array<SceneLight, 8>,
+}
+
+export struct SceneModel {
+  matrix: mat4x4f,
+}
+
+export struct SceneVarying {
+  @builtin(position) clip: vec4f,
+  @location(0) normal: vec3f,
+}
+
+export fn vgpuSceneLighting(lights: SceneLights, normal: vec3f) -> vec3f {
+  var total = vec3f(0.0);
+  for (var i = 0u; i < lights.count; i = i + 1u) {
+    let light = lights.lights[i];
+    total = total + light.color.rgb * light.intensity * max(dot(normal, -light.direction.xyz), 0.0);
+  }
+  return total;
+}
+`;
+
+test("bare package specifier resolves for a uniform binding type", async () => {
+  const dir = await sceneFixture();
+  const entry = join(dir, "app", "main.wgsl");
+  await writeFile(entry, `import { SceneCamera } from "@scene/abi/scene";
+
+@group(0) @binding(0) var<uniform> camera: SceneCamera;
+
+@vertex fn vs() -> @builtin(position) vec4f {
+  return camera.viewProjection * vec4f(0.0, 0.0, 0.0, 1.0);
+}
+`);
+
+  const { reflection } = await resolveShader({ entry, validate: false });
+  const binding = reflection.bindings[0]!;
+
+  expect(binding).toMatchObject({ group: 0, binding: 0, name: "camera", kind: "buffer", addressSpace: "uniform" });
+  expect(binding.type).toMatchObject({ kind: "identifier", name: "SceneCamera" });
+  expect(binding.struct?.name).toBe("SceneCamera");
+  expect(binding.layout).toMatchObject({ size: 64, align: 16 });
+  expect(binding.layout?.members?.map((member) => [member.name, member.offset, member.size])).toEqual([["viewProjection", 0, 64]]);
+});
+
+test("bare package specifier resolves for struct member types", async () => {
+  const dir = await sceneFixture();
+  const entry = join(dir, "app", "main.wgsl");
+  await writeFile(entry, `import { SceneCamera, SceneModel } from "@scene/abi/scene";
+
+struct Frame {
+  camera: SceneCamera,
+  model: SceneModel,
+}
+
+@group(0) @binding(0) var<uniform> frame: Frame;
+
+@vertex fn vs() -> @builtin(position) vec4f {
+  return frame.camera.viewProjection * frame.model.matrix[0];
+}
+`);
+
+  const { reflection } = await resolveShader({ entry, validate: false });
+  const layout = reflection.bindings[0]!.layout!;
+
+  expect(layout).toMatchObject({ size: 128, align: 16 });
+  expect(layout.members?.map((member) => [member.name, member.offset, member.size])).toEqual([
+    ["camera", 0, 64],
+    ["model", 64, 64],
+  ]);
+  expect(layout.members?.[0]?.layout.members?.map((member) => member.name)).toEqual(["viewProjection"]);
+});
+
+test("bare package specifier resolves through aliases, storage bindings and function signatures", async () => {
+  const dir = await sceneFixture();
+  const entry = join(dir, "app", "main.wgsl");
+  await writeFile(entry, `import { SceneCamera, SceneLights, SceneModel, SceneVarying, vgpuSceneLighting } from "@scene/abi/scene";
+
+alias Camera = SceneCamera;
+
+@group(0) @binding(0) var<uniform> camera: Camera;
+@group(0) @binding(1) var<storage, read> lights: SceneLights;
+@group(0) @binding(2) var<uniform> model: SceneModel;
+
+fn shade(varying: SceneVarying) -> vec3f {
+  return vgpuSceneLighting(lights, varying.normal);
+}
+
+@fragment fn fs(varying: SceneVarying) -> @location(0) vec4f {
+  let world = model.matrix * camera.viewProjection * varying.clip;
+  return vec4f(shade(varying) + world.xyz, 1.0);
+}
+`);
+
+  const { reflection, wgsl } = await resolveShader({ entry, validate: false });
+
+  expect(reflection.bindings.map((binding) => [binding.name, binding.layout?.size, binding.layout?.align])).toEqual([
+    ["camera", 64, 16],
+    ["lights", 400, 16],
+    ["model", 64, 16],
+  ]);
+  expect(reflection.bindings[0]!.type).toMatchObject({ kind: "identifier", name: "Camera" });
+  expect(reflection.bindings[0]!.layout?.members?.map((member) => member.name)).toEqual(["viewProjection"]);
+  expect(reflection.bindings[1]!.struct?.name).toBe("SceneLights");
+  expect(reflection.bindings[2]!.type).toMatchObject({ kind: "identifier", name: "SceneModel" });
+  expect(wgsl).toMatch(/fn _vgsl_[0-9a-f]{8}__vgpuSceneLighting\(/u);
+});
+
+test("bare package specifier resolves for binding types through packageMap and virtual modules", async () => {
+  const shader = await resolveShader({
+    entry: "/app/main.wgsl",
+    validate: false,
+    packageMap: { "@scene/abi": "/vendor/scene-abi" },
+    modules: {
+      "/vendor/scene-abi/scene.wgsl": SCENE_ABI,
+      "/app/main.wgsl": `import { SceneCamera, SceneLights, vgpuSceneLighting } from "@scene/abi/scene";
+
+@group(0) @binding(0) var<uniform> camera: SceneCamera;
+@group(0) @binding(1) var<storage, read> lights: SceneLights;
+
+@fragment fn fs() -> @location(0) vec4f {
+  return vec4f(vgpuSceneLighting(lights, camera.viewProjection[0].xyz), 1.0);
+}
+`,
+    },
+  });
+
+  expect(shader.reflection.bindings.map((binding) => [binding.name, binding.type.kind === "identifier" ? binding.type.name : undefined, binding.layout?.size])).toEqual([
+    ["camera", "SceneCamera", 64],
+    ["lights", "SceneLights", 400],
+  ]);
+});
+
+test("bare package specifier reflection matches the relative virtual-module workaround", async () => {
+  const source = (from: string) => `import { SceneCamera, SceneLights, SceneModel, vgpuSceneLighting } from "${from}";
+
+struct Frame {
+  camera: SceneCamera,
+  model: SceneModel,
+}
+
+@group(0) @binding(0) var<uniform> frame: Frame;
+@group(0) @binding(1) var<storage, read> lights: SceneLights;
+
+@fragment fn fs() -> @location(0) vec4f {
+  return vec4f(vgpuSceneLighting(lights, frame.camera.viewProjection[0].xyz) + frame.model.matrix[0].xyz, 1.0);
+}
+`;
+
+  const bare = await resolveShader({
+    entry: "/app/main.wgsl",
+    validate: false,
+    packageMap: { "@scene/abi": "/vendor/scene-abi" },
+    modules: { "/vendor/scene-abi/scene.wgsl": SCENE_ABI, "/app/main.wgsl": source("@scene/abi/scene") },
+  });
+  const relative = await resolveShader({
+    entry: "/app/main.wgsl",
+    validate: false,
+    modules: { "/app/scene-abi.wgsl": SCENE_ABI, "/app/main.wgsl": source("./scene-abi.wgsl") },
+  });
+
+  expect(normalizeMangling(bare.wgsl)).toBe(normalizeMangling(relative.wgsl));
+  expect(normalizeMangling(JSON.stringify(bare.reflection.bindings))).toBe(normalizeMangling(JSON.stringify(relative.reflection.bindings)));
+  expect(normalizeMangling(JSON.stringify(bare.reflection.hostShareableLayouts))).toBe(normalizeMangling(JSON.stringify(relative.reflection.hostShareableLayouts)));
+});
+
+test("real @vgpu/wgsl-std package export types a binding through the bare specifier", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "vgsl-std-types-"));
+  await mkdir(join(dir, "app"), { recursive: true });
+  await mkdir(join(dir, "node_modules", "@vgpu"), { recursive: true });
+  const { symlink } = await import("node:fs/promises");
+  const { resolve } = await import("node:path");
+  await symlink(resolve(import.meta.dirname, "..", "..", "wgsl-std"), join(dir, "node_modules", "@vgpu", "wgsl-std"), "dir");
+  const entry = join(dir, "app", "main.wgsl");
+  await writeFile(entry, `import { VoronoiSample2, voronoi2d } from "@vgpu/wgsl-std/noise";
+
+struct Samples {
+  first: VoronoiSample2,
+}
+
+@group(0) @binding(0) var<storage, read_write> samples: Samples;
+
+@compute @workgroup_size(1) fn main() {
+  samples.first = voronoi2d(vec2f(0.5, 0.25));
+}
+`);
+
+  const { reflection } = await resolveShader({ entry, validate: false });
+  const layout = reflection.bindings[0]!.layout!;
+
+  expect(layout.members?.map((member) => member.name)).toEqual(["first"]);
+  expect(layout.members?.[0]?.layout.members?.map((member) => [member.name, member.offset])).toEqual([
+    ["f1", 0],
+    ["f2", 4],
+    ["cell", 8],
+  ]);
+});
+
+test("unknown types in a package module still report VGPU-WGSL-REFLECT-UNKNOWN-TYPE", async () => {
+  await expect(
+    resolveShader({
+      entry: "/app/main.wgsl",
+      validate: false,
+      packageMap: { "@scene/abi": "/vendor/scene-abi" },
+      modules: {
+        "/vendor/scene-abi/scene.wgsl": SCENE_ABI,
+        "/app/main.wgsl": `import { SceneCamera } from "@scene/abi/scene";
+@group(0) @binding(0) var<uniform> camera: SceneMissing;
+`,
+      },
+    }),
+  ).rejects.toMatchObject({ code: "VGPU-WGSL-REFLECT-UNKNOWN-TYPE" });
+});
+
+function normalizeMangling(text: string): string {
+  return text.replace(/_vgsl_[0-9a-f]{8}__/gu, "_vgsl_HASH__").replace(/\/\/ vgsl-module: .*/gu, "// vgsl-module: <path>");
+}
+
+async function sceneFixture(): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), "vgsl-scene-abi-"));
+  await mkdir(join(dir, "app"), { recursive: true });
+  await mkdir(join(dir, "node_modules", "@scene", "abi", "src"), { recursive: true });
+  await writeFile(join(dir, "node_modules", "@scene", "abi", "package.json"), JSON.stringify({ name: "@scene/abi", exports: { "./scene": "./src/scene.wgsl" } }));
+  await writeFile(join(dir, "node_modules", "@scene", "abi", "src", "scene.wgsl"), SCENE_ABI);
+  return dir;
+}


### PR DESCRIPTION
Closes #212

## Root cause

The WGSL reflector resolved imports through two independent code paths that disagreed on bare package specifiers (e.g. `@vgpu/wgsl-std/scene`):

- **Value/function positions** (the mangler, `resolve-shader.ts` → `mangler.ts`) resolved imports via the real graph resolver (`resolveImport` / `pathOf` in `package-resolution.ts`), which understands relative paths, root aliases (`@/`), `packageMap` entries, and `package.json` `exports` (including conditional/glob exports and virtual `modules` maps).
- **Nominal type positions** (binding types, struct-member types, aliases, function signatures) went through `reflect-symbols.ts`, which reimplemented import resolution by hand and only understood relative/absolute paths.

As a result, a bare specifier used to import a *value* (e.g. a function) worked fine, but the exact same specifier used to type a `@group/@binding` var or a struct member failed reflection with `VGPU-WGSL-REFLECT-UNKNOWN-TYPE`, because `reflect-symbols.ts` could never map the bare specifier back to the already-loaded module.

## Fix

- `buildModuleSymbols()` / `reflect()` now accept an optional `resolveImport` closure (`ImportPathResolver = (from, imp) => string`) with the same shape as the mangler's `pathOf`.
- `resolve-shader.ts` passes its own `pathOf` into `reflect(modules, pathOf)`, so type-position imports resolve through the identical resolver used for value-position imports — no more divergent logic.
- `resolveImportPath()` tries the injected resolver first (via `tryResolveImport`, which catches resolver errors and falls back rather than throwing) and only uses it if the resolved path matches an already-loaded module; otherwise it falls back to the original relative/absolute heuristic. This keeps `reflect()` fully backwards compatible for any caller that doesn't pass a resolver (e.g. `reflect-source.ts`, which reflects a single already-emitted module with no imports).
- The `try/catch` around the injected resolver is intentionally narrow: by the time `reflect()` runs inside `resolveShader()`, every import has already been resolved once during `loadGraph()`, so a real "package not found" style error would have already surfaced earlier in the pipeline. The catch exists so `reflect()` stays usable with partial/synthetic module graphs (as in tests) without forcing every caller to supply a resolver that never throws.
- Diagnostics dedup (`warnOnce` in `package-resolution.ts`, e.g. for conditional package exports) is unaffected: the injected resolver closes over the same `diagnostics` array used elsewhere in `resolveShader()`, so calling it again from `reflect()` doesn't produce duplicate warnings.

## Tests

- `packages/wgsl/tests/reflect-import-types.test.ts` (new, 7 cases): bare specifier resolving a uniform binding type, struct-member types, aliases/storage bindings/function signatures, `packageMap` + virtual modules, byte-exact parity between the bare-specifier form and the pre-fix relative virtual-module workaround, a real `@vgpu/wgsl-std/noise` import typing a binding, and confirmation that genuinely unknown types still report `VGPU-WGSL-REFLECT-UNKNOWN-TYPE`.
- `packages/wgsl-std/tests/package-resolution.test.ts` (extended): a real `@vgpu/wgsl-std/noise` subpath import typing both a struct member and a top-level binding.

Verified red→green: reverting only the `src` changes (keeping the new/extended tests) makes the 7 new/updated assertions fail with `VGPU-WGSL-REFLECT-UNKNOWN-TYPE`; restoring the fix makes the full suite green again with an identical diff.

Full local verification: `packages/wgsl`, `packages/wgsl-std`, `packages/vgpu-api` suites (115 test files / 860 tests passing, 84 GPU-only tests skipped as expected) plus `pnpm typecheck`, all green.

## Note on `@vgpu/wgsl-std/scene`

The issue's literal repro import (`@vgpu/wgsl-std/scene`) can't be exercised yet because the `scene` module doesn't exist on `main` — it lives on `feat/scene-view`. This PR covers the general bare-specifier-as-type case with `@vgpu/wgsl-std/noise` (which does exist) plus synthetic `@scene/abi/scene`-style fixtures that reproduce the same shape of bug. Once `feat/scene-view` merges, the literal `@vgpu/wgsl-std/scene` case will exercise the same code path and should pass without further changes; at that point the T205 workaround (importing scene types through a relative/virtual-module path instead of the bare specifier) can be retired.
