### PR TITLE
docs: redesign the vgpu README and drop version numbers from package READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,63 +1,103 @@
 # vgpu
 
-> 0.1.6 — early preview of the new public `vgpu` API
+[![npm version](https://img.shields.io/npm/v/vgpu.svg)](https://www.npmjs.com/package/vgpu)
+[![CI](https://github.com/vercel-labs/vgpu/actions/workflows/ci.yml/badge.svg)](https://github.com/vercel-labs/vgpu/actions/workflows/ci.yml)
+[![license](https://img.shields.io/npm/l/vgpu.svg)](./LICENSE)
 
-vgpu is an agentic-first WebGPU library for browsers, Node/Dawn, and deterministic mock tests. The public package is `vgpu`: one `Gpu` context with explicit WGSL reflection and performance-oriented defaults.
+vgpu is a TypeScript library for WebGPU: typed shader imports, a tiny gpu-first API, and the same code running in the browser, headless Node, and your test suite. Ship a 25 KB effect, not a 500 KB engine.
 
-## Packages
-
-| Package | What it is |
-| --- | --- |
-| [`vgpu`](./packages/vgpu-api/README.md) | Public main API (`vgpu`): `init`, `pass`, `draw`, `compute`, `frame`, `bundle`, `target`, `uniforms`, scene and core subpaths. |
-| [`@vgpu/core`](./packages/core/README.md) | core layer (`vgpu/core`) resource wrappers and native WebGPU escape hatches. |
-| [`@vgpu/render`](./packages/render/README.md) | Slim edit/inspect/utils/perf package for helpers outside the new rendering surface. |
-| [`@vgpu/wgsl`](./packages/wgsl/README.md) | WGSL modules, reflection, runtime resolution, and loaders. |
-| [`@vgpu/wgsl-std`](./packages/wgsl-std/README.md) | Standard WGSL utility modules. |
-| [`@vgpu/adapter-node`](./packages/adapter-node/README.md) | Dawn-backed adapter used by `vgpu/node`. |
-| [`@vgpu/adapter-mock`](./packages/adapter-mock/README.md) | Mock adapter used by `vgpu/mock`. |
-
-## Install
+## Quick Start
 
 ```bash
 pnpm add vgpu
 pnpm add -D @webgpu/types
 ```
 
-## Browser quick start
-
 ```ts
 import { clock, init, effect, frameLoop, surface } from "vgpu";
+import waveShader from "./wave.wgsl";
 
 const gpu = await init();
 const canvasSurface = surface(gpu, canvas, { dpr: [1, 2] });
-const wave = effect(gpu, WAVE_WGSL, { set: { speed: 2 } });
+const wave = effect(gpu, waveShader, { set: { speed: 2 } });
+
 const time = clock(gpu);
-frameLoop(gpu, () => {
+frameLoop(gpu, (frame) => {
   wave.set({ time: time.time });
-  wave.draw();
+  frame.pass(canvasSurface, wave);
 });
 ```
 
-## Node quick start
+### Node quick start
+
+The same API runs headless, against a Dawn-backed device:
 
 ```ts
-import { init, draw, frame, target } from "vgpu/node";
+import { draw, frame, init, target } from "vgpu/node";
+import triangleShader from "./triangle.wgsl";
 
 const gpu = await init();
 const colorTarget = target(gpu, { size: [256, 256], format: "rgba8unorm" });
-const drawable = draw(gpu, { shader: TRIANGLE_WGSL, targets: [colorTarget] });
-frame(gpu, (f) => f.pass({ target: colorTarget, clear: [0, 0, 0, 1] }, (p) => p.draw(drawable)));
+const triangle = draw(gpu, { shader: triangleShader });
+
+frame(gpu, (f) => f.pass(colorTarget, triangle));
 const pixels = await colorTarget.read();
 gpu.dispose();
 ```
 
-## Performance playbook
+`vgpu/mock` swaps in a deterministic software adapter for the same code, so tests never need a GPU.
 
-Start with `docs/topics/performance-playbook.docs.md`. It makes bundles, target pre-warm, dynamic offsets, in-place `set()`, bake, instancing, shared uniforms, ping-pong, and MSAA/depth the default implementation style for shader authors.
+## WGSL modules with typed imports
 
-## Releasing
+`.wgsl` files import and export like TypeScript modules. `@vgpu/wgsl-std` ships reusable declarations (hash, noise, color, sampling, ...) as named exports, and any `.wgsl` file can export its own `fn`, `struct`, or `const` for other shaders to import:
 
-Releases are triggered by GitHub Releases. Bump package versions, commit the bumps, create a release tag, and let the release workflow publish packages with provenance.
+```wgsl
+// grain.wgsl
+import { hash2 } from "@vgpu/wgsl-std/hash";
+
+export fn grain(uv: vec2f, time: f32) -> f32 {
+  return hash2(uv * time).x;
+}
+```
+
+Imports resolve at build time through typed WGSL reflection — no codegen step and no manual binding declarations to keep in sync.
+
+## Why vgpu
+
+- **One `Gpu` context.** `init()` returns a single handle; every entry point (`draw`, `effect`, `frame`, `surface`, `target`, ...) takes it as its first argument. No facade, no hidden global state.
+- **Typed WGSL imports.** Shaders import from `@vgpu/wgsl-std` or from each other, and reflection keeps binding names, types, and layouts correct without hand-written declarations.
+- **Real tree-shaking.** Unused declarations are pruned before minification, so a single fullscreen effect ships in a 25 KB gzip budget instead of a 500 KB engine.
+- **Multi-runtime by default.** One public API surface across the browser, headless Node (`vgpu/node`, Dawn-backed), and a deterministic mock (`vgpu/mock`) built for tests and CI.
+
+## Documentation
+
+Guides and API reference ship inside the package and run fully offline through the CLI:
+
+```bash
+npx vgpu docs cat getting-started.md
+npx vgpu docs find effect
+```
+
+Start with [`docs/topics/getting-started.docs.md`](./docs/topics/getting-started.docs.md), then [`docs/topics/performance-playbook.docs.md`](./docs/topics/performance-playbook.docs.md) for the defaults (bundles, target pre-warm, in-place `set()`, instancing, ping-pong, MSAA/depth) that shader authors should reach for from day one.
+
+## Packages
+
+This is a monorepo. The public entry point is `vgpu`; everything else backs it or ships independently.
+
+| Package | What it is |
+| --- | --- |
+| [`vgpu`](./packages/vgpu-api/README.md) | Public main API: `init`, `draw`, `compute`, `effect`, `frame`, `bundle`, `target`, `uniforms`, plus `scene` and `core` subpaths. |
+| [`@vgpu/cli`](./packages/vgpu/README.md) | The `vgpu` command-line binary: docs, shader `check`, `doctor`, and Dawn/software-renderer setup. |
+| [`@vgpu/core`](./packages/core/README.md) | Low-level WebGPU wrappers (`Device`, `Buffer`, `Texture`, bind groups) behind `vgpu/core`. |
+| [`@vgpu/wgsl`](./packages/wgsl/README.md) | Turns `.wgsl` files into JS modules and resolves WGSL-to-WGSL imports before bundling. |
+| [`@vgpu/wgsl-std`](./packages/wgsl-std/README.md) | Standard WGSL utility modules (math, color, sampling, noise, hash, ...). |
+| [`@vgpu/adapter-node`](./packages/adapter-node/README.md) | Dawn-backed adapter used by `vgpu/node`. |
+| [`@vgpu/adapter-mock`](./packages/adapter-mock/README.md) | Deterministic mock adapter used by `vgpu/mock`. |
+| [`@vgpu/render`](./packages/render/README.md) | Slim edit/inspect/utils/perf helpers outside the main rendering surface. |
+
+## Contributing
+
+See [CONTRIBUTING.md](./CONTRIBUTING.md) for the development setup, bundle budgets, and release flow.
 
 ## License
 

--- a/packages/adapter-mock/README.md
+++ b/packages/adapter-mock/README.md
@@ -1,6 +1,6 @@
 # @vgpu/adapter-mock
 
-> 0.1.6 — deterministic adapter for `vgpu/mock`
+Deterministic adapter for `vgpu/mock`.
 
 `@vgpu/adapter-mock` backs the `vgpu/mock` entrypoint for tests that need the public `Gpu` API without real GPU hardware.
 

--- a/packages/adapter-node/README.md
+++ b/packages/adapter-node/README.md
@@ -1,6 +1,6 @@
 # @vgpu/adapter-node
 
-> 0.1.6 — Dawn adapter for `vgpu/node`
+Dawn adapter for `vgpu/node`.
 
 `@vgpu/adapter-node` connects vgpu to Node.js through the `webgpu` Dawn native prebuild. Most callers should import `init` from `vgpu/node`; direct adapter/device helpers remain for core layer (`vgpu/core`) tooling.
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,6 +1,6 @@
 # @vgpu/core
 
-> 0.1.6 — core layer (`vgpu/core`) runtime primitives
+Core layer (`vgpu/core`) runtime primitives.
 
 `@vgpu/core` contains the low-level WebGPU wrappers used by `vgpu/core`: `Device`, `Buffer`, `Texture`, `Queue`, shader modules, bind-group helpers, resource identities, and validation errors. Most applications should start from `init()` in `vgpu`, `vgpu/node`, or `vgpu/mock` and drop to these primitives only for explicit native control.
 

--- a/packages/render/README.md
+++ b/packages/render/README.md
@@ -1,6 +1,6 @@
 # @vgpu/render
 
-> 0.1.6 — slim legacy/utility render package
+Slim legacy/utility render package, kept for compatibility while the old thick render surface is removed from the public path.
 
 New applications should use the public `vgpu` package. `@vgpu/render` remains as a slim package for edit/inspect/utils/perf helpers and compatibility while the old thick render surface is removed from the public path.
 

--- a/packages/vgpu-api/README.md
+++ b/packages/vgpu-api/README.md
@@ -1,8 +1,10 @@
 # vgpu
 
-> 0.1.6 — public main API (`vgpu`) preview
+[![npm version](https://img.shields.io/npm/v/vgpu.svg)](https://www.npmjs.com/package/vgpu)
+[![CI](https://github.com/vercel-labs/vgpu/actions/workflows/ci.yml/badge.svg)](https://github.com/vercel-labs/vgpu/actions/workflows/ci.yml)
+[![license](https://img.shields.io/npm/l/vgpu.svg)](../../LICENSE)
 
-`vgpu` is the public package for the new API. It is built around one `Gpu` context, explicit WGSL reflection, and `set()` ownership rules that make the fast path the default.
+vgpu is a TypeScript library for WebGPU: typed shader imports, a tiny gpu-first API, and the same code running in the browser, headless Node, and your test suite. Ship a 25 KB effect, not a 500 KB engine.
 
 ## Install
 
@@ -11,57 +13,63 @@ pnpm add vgpu
 pnpm add -D @webgpu/types
 ```
 
-## Entry points and layers
-
-- **main API (`vgpu`)**: `init`, `Gpu`, `pass`, `draw`, `compute`, `frame`, `bundle`, `target`, `pingPong`, `uniforms`.
-- **core layer (`vgpu/core`)**: device/resource escape hatches, native handles, bind groups, `Uniform`, `UniformPool`, storage buffers.
-- **scene helpers (`vgpu/scene`)**: pure geometry and camera helpers. No scene graph and no material layer.
-
-## Browser quick start
+## Quick Start
 
 ```ts
 import { clock, init, effect, frameLoop, surface } from "vgpu";
+import waveShader from "./wave.wgsl";
 
 const gpu = await init();
 const canvasSurface = surface(gpu, canvas, { dpr: [1, 2] });
-const wave = effect(gpu, /* wgsl */ `
-struct Params { time: f32, speed: f32 }
-@group(0) @binding(0) var<uniform> params: Params;
-@fragment fn fs_main(@location(0) uv: vec2f) -> @location(0) vec4f {
-  return vec4f(uv, sin(params.time * params.speed) * .5 + .5, 1);
-}
-`, { set: { speed: 2 } });
+const wave = effect(gpu, waveShader, { set: { speed: 2 } });
 
 const time = clock(gpu);
-frameLoop(gpu, () => {
+frameLoop(gpu, (frame) => {
   wave.set({ time: time.time });
-  wave.draw();
+  frame.pass(canvasSurface, wave);
 });
 ```
 
-## Node quick start
+The same `init`, `effect`, and `frame` calls run unchanged against `vgpu/node` (Dawn-backed, headless) and `vgpu/mock` (deterministic, no GPU hardware) — see the [Node quick start](../../README.md#node-quick-start) in the repo root.
 
-```ts
-import { init, draw, frame, target } from "vgpu/node";
+## WGSL modules with typed imports
 
-const gpu = await init();
-const colorTarget = target(gpu, { size: [256, 256], format: "rgba8unorm" });
-const tri = draw(gpu, { shader: TRIANGLE_WGSL });
-frame(gpu, (f) => f.pass({ target: colorTarget, clear: [0, 0, 0, 1] }, (p) => p.draw(tri)));
-const pixels = await colorTarget.read();
-gpu.dispose();
+`.wgsl` files import and export like TypeScript modules. `@vgpu/wgsl-std` ships reusable declarations (hash, noise, color, sampling, ...) as named exports, and any `.wgsl` file can export its own `fn`, `struct`, or `const` for other shaders to import:
+
+```wgsl
+// grain.wgsl
+import { hash2 } from "@vgpu/wgsl-std/hash";
+
+export fn grain(uv: vec2f, time: f32) -> f32 {
+  return hash2(uv * time).x;
+}
 ```
 
-## Performance defaults
+Imports resolve at build time through typed WGSL reflection — no codegen step and no manual binding declarations to keep in sync.
 
-Read `docs/topics/performance-playbook.docs.md` before writing shader code. It documents bundles, target pre-warm, manual bind-group dynamic offsets, in-place `set()`, bake, instancing, shared uniforms, ping-pong, and MSAA/depth as defaults rather than late optimizations.
+## Why vgpu
 
-## WGSL imports
+- **One `Gpu` context.** `init()` returns a single handle; `draw`, `effect`, `frame`, `surface`, `target`, and every other entry point take it as their first argument. No facade, no hidden global state.
+- **Typed WGSL imports.** Shaders import from `@vgpu/wgsl-std` or from each other, and reflection keeps binding names, types, and layouts correct without hand-written declarations.
+- **Real tree-shaking.** Unused declarations are pruned before minification, so a single fullscreen effect ships in a 25 KB gzip budget instead of a 500 KB engine.
+- **Multi-runtime by default.** The public API is one surface across the browser, headless Node (`vgpu/node`, Dawn-backed), and a deterministic mock (`vgpu/mock`) built for tests and CI.
+- **Explicit frames.** `frame(gpu, (f) => f.pass(target, effect))` — passes, clears, and draws are all explicit calls, never implicit scene-graph state.
 
-For app projects that import `.wgsl` files, add:
+## Documentation
 
-```ts
-/// <reference types="vgpu/client" />
+Guides and API reference ship inside the package and run fully offline through the CLI:
+
+```bash
+npx vgpu docs cat getting-started.md
+npx vgpu docs find effect
 ```
 
-Runtime reflection remains the source of truth for binding names, types, and layouts.
+Start with [`docs/topics/getting-started.docs.md`](../../docs/topics/getting-started.docs.md), then [`docs/topics/performance-playbook.docs.md`](../../docs/topics/performance-playbook.docs.md) for the defaults (bundles, target pre-warm, in-place `set()`, instancing, ping-pong, MSAA/depth) that shader authors should reach for from day one.
+
+## Contributing
+
+See [CONTRIBUTING.md](../../CONTRIBUTING.md) for the development setup, bundle budgets, and release flow.
+
+## License
+
+MIT — see [LICENSE](../../LICENSE).


### PR DESCRIPTION
## What

Redesigns the `vgpu` (root) and `vgpu` package (`packages/vgpu-api`) READMEs to follow Vercel's OSS README pattern, and sweeps every other package README to drop hardcoded version numbers.

**Pattern applied** (badges → tagline → quick start → features → docs → packages → contributing → license), based on research of `vercel/swr`, `vercel/ai`, `vercel/turborepo`, `vercel/next.js`, `vercel/satori`, `vercel/ms`, `vercel/edge-runtime`, `vercel/style-guide`, and `vercel/flags`.

**New**: a WGSL module import/export showcase under Quick Start, verified against `@vgpu/wgsl-std/hash` (`import { hash2 } from "@vgpu/wgsl-std/hash"` + `export fn`) — the library's tree-shaking/typed-reflection differential.

Every quick-start snippet is verified against `packages/vgpu-api/src` (`init`, `surface`, `effect`, `frame`, `draw`, `target` as gpu-first free functions) and against `docs/topics/getting-started.docs.md`.

## Rules followed

- **No version numbers in any README body.** The npm badge is the single source of truth for the published version; it updates itself. The only two `0.1.x` mentions left in the repo (`infra/lavapipe-build/README.md`, `experiments/ort-init-device/README.md`) document a specific pinned test run/dependency matrix, not the package's current version — left untouched as legitimate historical references.
- **English throughout**, including code comments inside snippets.
- Badges capped at 3: npm version (dynamic) · CI · license.
