### PR TITLE
fix(docs): log the cause behind VGPU-EXAMPLES-STORAGE responses

### DIFF
--- a/apps/docs/lib/examples-api/http-response.test.ts
+++ b/apps/docs/lib/examples-api/http-response.test.ts
@@ -1,0 +1,82 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { artifactResponse } from './http-response';
+import type { StoredArtifact } from './artifact-store';
+
+const request = (path: string, headers?: HeadersInit) => new Request(`https://vgpu.sh${path}`, { headers });
+const cacheControl = 'public, max-age=60, must-revalidate';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('artifactResponse storage failures', () => {
+  it('records the underlying cause server-side while keeping the opaque 500 contract', async () => {
+    const errors = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const load = () => Promise.reject(new Error('Missing VGPU_EXAMPLES_VERCEL_BLOB_READ_WRITE_TOKEN'));
+
+    const response = await artifactResponse(request('/api/examples/v1/latest.json'), 'GET', load, cacheControl);
+
+    expect(response.status).toBe(500);
+    expect(response.headers.get('cache-control')).toBe('no-store');
+    expect(response.headers.get('content-type')).toBe('application/json; charset=utf-8');
+    expect(await response.json()).toEqual({
+      error: { code: 'VGPU-EXAMPLES-STORAGE', message: 'Artifact storage verification failed' },
+    });
+
+    expect(errors).toHaveBeenCalledTimes(1);
+    const [logged] = errors.mock.calls[0] as [string];
+    expect(logged).toContain('VGPU-EXAMPLES-STORAGE');
+    expect(logged).toContain('GET /api/examples/v1/latest.json');
+    expect(logged).toContain('Error: Missing VGPU_EXAMPLES_VERCEL_BLOB_READ_WRITE_TOKEN');
+  });
+
+  it('distinguishes the other storage conditions in the log line', async () => {
+    const errors = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const causes = [
+      new Error('Unsupported VGPU_EXAMPLES_ARTIFACT_STORE: vercel-blob'),
+      new Error('Stored artifact integrity mismatch: examples/v1/revisions/abc/index.json'),
+      new Error('Stored revision manifest is invalid JSON'),
+      'plain string rejection',
+    ];
+
+    for (const cause of causes) {
+      const response = await artifactResponse(request('/.well-known/vgpu-examples.json'), 'HEAD', () => Promise.reject(cause), cacheControl);
+      expect(response.status).toBe(500);
+    }
+
+    const logged = errors.mock.calls.map(([line]) => line as string);
+    expect(logged).toHaveLength(causes.length);
+    expect(logged[0]).toContain('Unsupported VGPU_EXAMPLES_ARTIFACT_STORE: vercel-blob');
+    expect(logged[1]).toContain('Stored artifact integrity mismatch');
+    expect(logged[2]).toContain('Stored revision manifest is invalid JSON');
+    expect(logged[3]).toContain('plain string rejection');
+    expect(logged.every((line) => line.startsWith('VGPU-EXAMPLES-STORAGE HEAD /.well-known/vgpu-examples.json'))).toBe(true);
+  });
+
+  it('does not log for a missing artifact, which stays a 404', async () => {
+    const errors = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    const response = await artifactResponse(request('/api/examples/v1/latest.json'), 'GET', () => Promise.resolve(undefined), cacheControl);
+
+    expect(response.status).toBe(404);
+    expect(await response.json()).toEqual({
+      error: { code: 'VGPU-EXAMPLES-NOT-FOUND', message: 'Artifact not found' },
+    });
+    expect(errors).not.toHaveBeenCalled();
+  });
+
+  it('does not log on the success and 304 paths', async () => {
+    const errors = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const bytes = new TextEncoder().encode('{"ok":true}\n');
+    const artifact: StoredArtifact = { bytes, contentType: 'application/json; charset=utf-8', sha256: 'a'.repeat(64) };
+
+    const ok = await artifactResponse(request('/api/examples/v1/latest.json'), 'GET', () => Promise.resolve(artifact), cacheControl);
+    expect(ok.status).toBe(200);
+    expect(new Uint8Array(await ok.arrayBuffer())).toEqual(bytes);
+
+    const etag = `"${artifact.sha256}"`;
+    const notModified = await artifactResponse(request('/api/examples/v1/latest.json', { 'if-none-match': etag }), 'GET', () => Promise.resolve(artifact), cacheControl);
+    expect(notModified.status).toBe(304);
+    expect(errors).not.toHaveBeenCalled();
+  });
+});

--- a/apps/docs/lib/examples-api/http-response.ts
+++ b/apps/docs/lib/examples-api/http-response.ts
@@ -20,7 +20,8 @@ export async function artifactResponse(
   let artifact: StoredArtifact | undefined;
   try {
     artifact = await load();
-  } catch {
+  } catch (error) {
+    reportStorageFailure(request, method, error);
     return errorResponse(500, 'VGPU-EXAMPLES-STORAGE', 'Artifact storage verification failed');
   }
   if (!artifact) return errorResponse(404, 'VGPU-EXAMPLES-NOT-FOUND', 'Artifact not found');
@@ -48,6 +49,21 @@ export function methodNotAllowedResponse(): Response {
   const response = errorResponse(405, 'VGPU-EXAMPLES-METHOD-NOT-ALLOWED', 'Only GET, HEAD, and OPTIONS are allowed');
   response.headers.set('Allow', 'GET, HEAD, OPTIONS');
   return response;
+}
+
+/**
+ * Storage failures are fail-closed by design (a missing credential or an
+ * integrity mismatch must never degrade into a 404 or into deployment files),
+ * so the response body stays deliberately opaque. Without a server-side record
+ * of the cause, though, every distinct condition — absent
+ * `VGPU_EXAMPLES_VERCEL_BLOB_READ_WRITE_TOKEN`, an unsupported
+ * `VGPU_EXAMPLES_ARTIFACT_STORE`, a rejected Blob read, a corrupt revision
+ * manifest — is indistinguishable in production. Log the cause only; the
+ * public response is unchanged.
+ */
+function reportStorageFailure(request: Request, method: ReadMethod, error: unknown): void {
+  const cause = error instanceof Error ? `${error.name}: ${error.message}` : String(error);
+  console.error(`VGPU-EXAMPLES-STORAGE ${method} ${new URL(request.url).pathname} — ${cause}`);
 }
 
 function errorResponse(status: number, code: string, message: string): Response {


### PR DESCRIPTION
## Why

Production returned `500 {"error":{"code":"VGPU-EXAMPLES-STORAGE","message":"Artifact storage verification failed"}}` on `/.well-known/vgpu-examples.json`, `/api/examples/v1/latest.json` and every revision artifact, on every host.

Failing closed there is correct and deliberate — a missing credential or an integrity mismatch must never degrade into a 404 or into deployment files (`apps/docs/examples-api.md`) — so the response body is intentionally opaque. But `artifactResponse` also discarded the cause with a bare `catch {}`, so **nothing** was recorded anywhere, and these five very different conditions were indistinguishable in production:

- absent `VGPU_EXAMPLES_VERCEL_BLOB_READ_WRITE_TOKEN` (`artifact-store.ts:94`)
- unsupported `VGPU_EXAMPLES_ARTIFACT_STORE` value (`artifact-store.ts:83`)
- a Blob read rejected by the store (rotated/revoked token, service error)
- a corrupt or mismatched `revision.json` / integrity mismatch (`artifact-store.ts:53`)
- an object beyond its response cap, or an unsafe local symlink (`safe-local-path.ts`)

With empty function logs, diagnosing the outage required inferring the answer from **outside** the deployment: comparing the latency of a response that never touches storage (`/api/examples/v1/revisions/not-a-sha/index.json`, rejected by `revisionArtifactKey`) against the two storage-touching endpoints. A healthy Blob read costs a round trip to `*.blob.vercel-storage.com`, and a revision index costs two; the failing 500s cost the same as the no-storage baseline (min 253.0ms / 251.8ms vs 254.5ms, delta ≈ −3ms), which is what identified the throw as preceding any I/O — i.e. the missing project env var rather than a rejected token. That work should have been one log line.

## What

`reportStorageFailure` logs `VGPU-EXAMPLES-STORAGE <METHOD> <pathname> — <name>: <message>` server-side before returning the error.

- The **public response is byte-identical**: same 500, same `VGPU-EXAMPLES-STORAGE` code and message, same `no-store`, same content type. No cause is ever exposed to clients.
- Only the throw path logs. Success, `304`, and the `404` missing-artifact path stay silent.
- Only `error.name` and `error.message` are recorded, never the credential.

## Tests

New `apps/docs/lib/examples-api/http-response.test.ts` (4 tests): the cause is logged while the 500 contract holds; all five storage conditions are distinguishable in the log line (including a non-`Error` rejection); a missing artifact stays a silent 404; success and 304 do not log. The pre-existing symlink and response-cap route tests now also print their exact cause, which shows the logging working through the real handlers.

`pnpm vitest run apps/docs` → 11 files, 39 tests passing. `tsc --noEmit` in `apps/docs` reports 212 errors both with and without this change (pre-existing, from an unbuilt workspace `dist`), none in the touched files.

## Not the outage fix

The outage itself is operational: the Vercel docs project is missing `VGPU_EXAMPLES_ARTIFACT_STORE=blob` / `VGPU_EXAMPLES_VERCEL_BLOB_READ_WRITE_TOKEN` in Production, and the `Publish examples API` workflow has never run, so nothing was ever published to the Blob store. This PR only makes that class of failure diagnosable from the logs instead of from latency measurements.
