### PR TITLE
feat(cli): make the bare vgpu command a guide to the docs workflow

### DIFF
--- a/.changeset/cli-bare-router.md
+++ b/.changeset/cli-bare-router.md
@@ -1,0 +1,5 @@
+---
+"vgpu": patch
+---
+
+the bare vgpu command now routes agents and humans to the docs workflow

--- a/packages/vgpu/bin/vgpu.js
+++ b/packages/vgpu/bin/vgpu.js
@@ -16,42 +16,23 @@ const VERSION = packageJson.version;
 
 const help = `vgpu ${VERSION}
 
-Official VGPU CLI.
+TypeScript library for WebGPU: typed shader imports, a tiny gpu-first API, and
+the same code running in the browser, headless Node, and your test suite.
 
-New here? Read the guide first:
-  vgpu docs cat getting-started.md
-Rendering in Node? Check the environment first:
-  vgpu doctor
+## Read the docs
+  npx vgpu docs cat getting-started.md    The guide for using the current API correctly
+  npx vgpu docs find "<topic | symbol | VGPU-error-code>"
+  npx vgpu docs cat <path>
 
-Commands:
-  check      Validate and reflect a WGSL file as JSON
-  docs       Explore bundled VGPU documentation
-  examples   Inspect canonical gallery source (never executes code)
-  snapshot   Compare the representative GPU pixel snapshot
-  install-dawn  Download and verify the portable Node Dawn prebuild
-  install-software-renderer  Download and verify the portable CPU renderer
-  doctor     Verify this machine can render headless (JSON verdict + fixes)
-  wgsl       Coming soon
+## Validate shader code
+  npx vgpu check <file.wgsl>              Validate and reflect a WGSL file as JSON
 
-Primary runtime entrypoints:
-  - vgpu
-  - vgpu/node
-  - vgpu/mock
-  - vgpu/scene
-  - vgpu/client
+## Working examples
+  npx vgpu examples search "<topic>"
+  npx vgpu examples pull <slug> --out <dir>
 
-WGSL and adapter packages:
-  - @vgpu/wgsl
-  - @vgpu/adapter-mock
-  - @vgpu/adapter-node
-
-Slim tooling subpaths:
-  - @vgpu/render/inspect
-  - @vgpu/render/utils
-  - @vgpu/render/edit
-  - @vgpu/render/perf
-
-Run \`vgpu docs --help\` for docs commands.
+## Node rendering environment
+  npx vgpu doctor
 `;
 
 const comingSoon = (command) => `vgpu ${command} is coming soon.
@@ -72,7 +53,7 @@ export function runCli(args) {
   if (command === "install-software-renderer") return runInstallSoftwareRenderer(rest);
   if (command === "doctor") return runDoctor(rest);
   if (command === "wgsl") return { code: 1, stderr: comingSoon(command) };
-  return { code: 1, stderr: `Unknown vgpu command: ${command}\n\n${help}` };
+  return { code: 2, stderr: `Unknown command: ${command}\n\n${help}` };
 }
 
 if (isMain()) {

--- a/packages/vgpu/tests/cli.test.ts
+++ b/packages/vgpu/tests/cli.test.ts
@@ -11,14 +11,47 @@ function success(args) {
   return result.stdout ?? "";
 }
 
-test("preserves root help, version, and remaining placeholder", () => {
-  expect(success(["--help"])).toContain("snapshot");
-  expect(success(["--help"])).toContain("install-dawn");
-  expect(success(["--help"])).toContain("install-software-renderer");
-  expect(success(["--help"])).toContain("doctor     Verify this machine can render headless (JSON verdict + fixes)");
-  expect(success(["--help"])).toContain("vgpu docs --help");
+const routerHelp = `vgpu ${packageVersion}
+
+TypeScript library for WebGPU: typed shader imports, a tiny gpu-first API, and
+the same code running in the browser, headless Node, and your test suite.
+
+## Read the docs
+  npx vgpu docs cat getting-started.md    The guide for using the current API correctly
+  npx vgpu docs find "<topic | symbol | VGPU-error-code>"
+  npx vgpu docs cat <path>
+
+## Validate shader code
+  npx vgpu check <file.wgsl>              Validate and reflect a WGSL file as JSON
+
+## Working examples
+  npx vgpu examples search "<topic>"
+  npx vgpu examples pull <slug> --out <dir>
+
+## Node rendering environment
+  npx vgpu doctor
+`;
+
+test("routes the bare command and --help/-h to the docs-first guide, exit 0", () => {
+  expect(runCli([])).toMatchObject({ code: 0, stdout: routerHelp });
+  expect(runCli(["--help"])).toMatchObject({ code: 0, stdout: routerHelp });
+  expect(runCli(["-h"])).toMatchObject({ code: 0, stdout: routerHelp });
   expect(success(["--version"])).toBe(`${packageVersion}\n`);
-  expect(runCli(["wgsl"])).toMatchObject({ code: 1, stderr: expect.stringContaining("coming soon") });
+});
+
+test("does not list snapshot/install-dawn/install-software-renderer in the router (still runnable)", async () => {
+  const help = success(["--help"]);
+  expect(help).not.toContain("snapshot");
+  expect(help).not.toContain("install-dawn");
+  expect(help).not.toContain("install-software-renderer");
+  await expect(Promise.resolve(runCli(["install-dawn", "--help"]))).resolves.toMatchObject({ code: 0 });
+  await expect(Promise.resolve(runCli(["install-software-renderer", "--help"]))).resolves.toMatchObject({ code: 0 });
+});
+
+test("routes an unknown command to the same guide with exit code 2", () => {
+  const result = runCli(["nope"]);
+  expect(result.code).toBe(2);
+  expect(result.stderr).toBe(`Unknown command: nope\n\n${routerHelp}`);
 });
 
 test("exposes doctor JSON without rendering", async () => {
@@ -40,9 +73,7 @@ test("exposes the manual native installers", async () => {
 
 test("puts the getting-started guide first in CLI help", () => {
   const rootHelp = success(["--help"]);
-  expect(rootHelp).toContain("New here? Read the guide first:\n  vgpu docs cat getting-started.md\nRendering in Node? Check the environment first:\n  vgpu doctor");
-  expect(rootHelp.indexOf("vgpu docs cat getting-started.md")).toBeLessThan(rootHelp.indexOf("Commands:"));
-  expect(rootHelp.indexOf("WGSL and adapter packages:")).toBeLessThan(rootHelp.indexOf("Slim tooling subpaths:"));
+  expect(rootHelp.indexOf("npx vgpu docs cat getting-started.md")).toBeLessThan(rootHelp.indexOf("## Validate shader code"));
 
   const help = success(["docs", "help"]);
   expect(help).toContain("Usage: vgpu docs <command>");
@@ -121,7 +152,7 @@ test("keeps existing guide and API docs forms working", () => {
 test("returns nonzero for missing and unknown docs commands", () => {
   expect(runCli(["docs", "cat", "MissingSymbol"])).toMatchObject({ code: 1, stderr: expect.stringContaining("Symbol not found") });
   expect(runCli(["docs", "nope"])).toMatchObject({ code: 1, stderr: expect.stringContaining("Unknown docs command") });
-  expect(runCli(["nope"])).toMatchObject({ code: 1, stderr: expect.stringContaining("Unknown vgpu command") });
+  expect(runCli(["nope"])).toMatchObject({ code: 2, stderr: expect.stringContaining("Unknown command: nope") });
 });
 
 


### PR DESCRIPTION
## What

The bare `vgpu` command (and `--help`/`-h`) now prints a short, docs-first
guide instead of a full command inventory:

```
vgpu <version>

TypeScript library for WebGPU: typed shader imports, a tiny gpu-first API, and
the same code running in the browser, headless Node, and your test suite.

## Read the docs
  npx vgpu docs cat getting-started.md    The guide for using the current API correctly
  npx vgpu docs find "<topic | symbol | VGPU-error-code>"
  npx vgpu docs cat <path>

## Validate shader code
  npx vgpu check <file.wgsl>              Validate and reflect a WGSL file as JSON

## Working examples
  npx vgpu examples search "<topic>"
  npx vgpu examples pull <slug> --out <dir>

## Node rendering environment
  npx vgpu doctor
```

The description is the README tagline verbatim (`packages/vgpu-api/README.md`).

## Human → agent flow

Both a human running `npx vgpu` cold and an agent that just did `--help`
land on the same four steps: read the docs, validate a shader, look at a
working example, check the Node rendering environment. No inventory to
parse, no guessing which command to reach for first.

## Exit codes

- Bare command, `--help`, `-h` → this router, **exit 0**.
- Unknown command → the same router, prefixed with `Unknown command: <x>`,
  **exit 2** (previously exit 1).

## What got delisted, and why

`snapshot`, `install-dawn`, and `install-software-renderer` still work
exactly as before — they're just no longer named in the router text. The
router is a guide for "what do I do first," not a full command inventory;
those three are internal/setup commands most users never need to reach for
directly (`doctor` already tells you when to run the installers).

## Also in this PR

- Updated `packages/vgpu/tests/cli.test.ts` to pin the new router text and
  the exit-code behavior (0 for bare/help, 2 for unknown).
- Ran `pnpm -F @vgpu/cli generate:docs` — no diff, since `docs/topics/cli.docs.md`
  documents each subcommand individually and never reproduced the old
  top-level help text verbatim.
- Added a changeset (`vgpu: patch`).

## Verification

```
node packages/vgpu/bin/vgpu.js               # exit 0, new router
node packages/vgpu/bin/vgpu.js --help         # exit 0, same router
node packages/vgpu/bin/vgpu.js bogus          # exit 2, "Unknown command: bogus" + router
pnpm -F @vgpu/cli test                        # 703 passed
pnpm typecheck                                # clean
```
