### PR TITLE
chore(release): version packages for 0.2.0-rc.1

### DIFF
--- a/packages/adapter-mock/package.json
+++ b/packages/adapter-mock/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vgpu/adapter-mock",
-  "version": "0.2.0-rc.0",
+  "version": "0.2.0-rc.1",
   "description": "Mock GPU adapter for testing vgpu code without real WebGPU hardware.",
   "keywords": [
     "webgpu",

--- a/packages/adapter-node/package.json
+++ b/packages/adapter-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vgpu/adapter-node",
-  "version": "0.1.7-rc.0",
+  "version": "0.1.7-rc.1",
   "description": "Node.js GPU adapter for vgpu, using Dawn-based WebGPU bindings.",
   "keywords": [
     "webgpu",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vgpu/core",
-  "version": "0.2.0-rc.0",
+  "version": "0.2.0-rc.1",
   "description": "Core WebGPU runtime primitives (device, buffer, texture, shader, queue) for vgpu.",
   "keywords": [
     "webgpu",

--- a/packages/render/package.json
+++ b/packages/render/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vgpu/render",
-  "version": "0.1.7-rc.0",
+  "version": "0.1.7-rc.1",
   "description": "Render pipeline + render pass abstractions for vgpu.",
   "keywords": [
     "webgpu",

--- a/packages/vgpu-api/package.json
+++ b/packages/vgpu-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vgpu",
-  "version": "0.2.0-rc.0",
+  "version": "0.2.0-rc.1",
   "description": "Public VGPU API entrypoint scaffold for browser, Node, mock, scene, and client typing surfaces.",
   "keywords": [
     "webgpu",

--- a/packages/wgsl/package.json
+++ b/packages/wgsl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vgpu/wgsl",
-  "version": "0.2.0-rc.0",
+  "version": "0.2.0-rc.1",
   "description": "WGSL shader compilation, runtime resolution, and webpack/vite loaders for vgpu.",
   "keywords": [
     "webgpu",


### PR DESCRIPTION
## What

Mechanical suffix bump `-rc.0` → `-rc.1` on the `version` field of the six publishable packages, per [CONTRIBUTING.md § Release candidates](../blob/main/CONTRIBUTING.md#release-candidates). No `pnpm changeset version` was run — the pending changesets in `.changeset/` stay queued and will land in the `0.2.0` final CHANGELOG.

| Package | rc.0 | rc.1 |
| --- | --- | --- |
| `vgpu` (`packages/vgpu-api`) | 0.2.0-rc.0 | 0.2.0-rc.1 |
| `@vgpu/core` | 0.2.0-rc.0 | 0.2.0-rc.1 |
| `@vgpu/wgsl` | 0.2.0-rc.0 | 0.2.0-rc.1 |
| `@vgpu/adapter-mock` | 0.2.0-rc.0 | 0.2.0-rc.1 |
| `@vgpu/adapter-node` | 0.1.7-rc.0 | 0.1.7-rc.1 |
| `@vgpu/render` | 0.1.7-rc.0 | 0.1.7-rc.1 |

`@vgpu/cli` (`packages/vgpu`) and `apps/docs` are `private` and untouched. Internal cross-deps (`workspace:*`) are unchanged — pnpm pins them to exact versions at publish time (verified in the tarball below).

## Why rc.1

rc.0 can't consume the examples API surface merged into `main` since it was cut (#223–#226):

- **Single-host allowlist + dual-store gate** for the examples proxy — the discovery/artifact endpoints now validate the store origin against an allowlist instead of accepting any host.
- **`npx vgpu` docs router** — new routing so `npx vgpu` resolves against the `vgpu.sh` domain surface.
- **Honest `minimumCliVersion` gate** — the discovery contract now advertises `minimumCliVersion: "0.2.0-rc.1"`, so a CLI still pinned to `0.2.0-rc.0` fails the gate instead of silently working against a contract it doesn't actually support. Since the gate value itself is `0.2.0-rc.1`, the published packages have to carry that exact suffix for the check to be meaningful.

Net: this is a mechanical version stamp, not a new feature — the features already landed on `main` via #223–#226; this just brings the publishable versions in line with the gate they already declare.

## Verification

- `pnpm install` — lockfile unchanged (no diff).
- `pnpm build` — clean.
- `pnpm -w typecheck` — clean.
- `pnpm exec vitest run packages/vgpu` — 703 passed, 45 skipped (GPU-only suites skipped as usual in this sandbox).
- `pnpm bundle-check` — all budgets green.
- `cd packages/vgpu-api && pnpm pack --pack-destination /tmp/rc1-check` — inspected the tarball manifest and confirmed:
  - `"version": "0.2.0-rc.1"`
  - `"@vgpu/adapter-mock": "0.2.0-rc.1"`, `"@vgpu/adapter-node": "0.1.7-rc.1"`, `"@vgpu/core": "0.2.0-rc.1"`, `"@vgpu/wgsl": "0.2.0-rc.1"` all pinned exactly (not `workspace:*`).
  - Tarball deleted after inspection.

## Not in this PR

- Consuming the pending changesets in `.changeset/` — those describe the `0.2.0` final release notes and are intentionally left untouched until that release.
- Any code changes — this is version metadata only.
