### PR TITLE
fix(wgsl): scope the package resolver fallback to @vgpu packages

### DIFF
--- a/.changeset/scope-wgsl-fallback.md
+++ b/.changeset/scope-wgsl-fallback.md
@@ -1,0 +1,5 @@
+---
+"@vgpu/wgsl": patch
+---
+
+The transitive-resolution fallback in `resolveImport` is now scoped to `@vgpu/*` specifiers. That fallback (`resolveAlongsideResolver`) exists only to rescue `@vgpu/wgsl`'s own transitive dependencies (like `@vgpu/wgsl-std`) in isolated pnpm/PnP layouts, but it previously ran for any bare specifier that failed the project-local `node_modules` walk. That meant a mistyped or unrelated WGSL import (e.g. `webpack`, a devDependency of `@vgpu/wgsl` itself) could resolve to the real installed JS file and fail later with a confusing `VGPU-WGSL-REFLECT-PARSE Expected identifier`, instead of the clear `VGPU-WGSL-PKG-NOTFOUND` (with its install fix-it) that non-`@vgpu` specifiers should get.

--- a/packages/wgsl/src/runtime/package-resolution.ts
+++ b/packages/wgsl/src/runtime/package-resolution.ts
@@ -54,8 +54,10 @@ function packageImport(spec: string, from: string, diagnostics: Diagnostic[]): s
     if (isWorkspaceRoot(dir)) break;
     const next = dirname(dir); if (next === dir) break; dir = next;
   }
-  const transitive = resolveAlongsideResolver(spec);
-  if (transitive) return transitive;
+  if (pkg.startsWith("@vgpu/")) {
+    const transitive = resolveAlongsideResolver(spec);
+    if (transitive) return transitive;
+  }
   throw packageNotFound(pkg, PKG_NOTFOUND_FIXIT);
 }
 
@@ -69,7 +71,12 @@ function packageImport(spec: string, from: string, diagnostics: Diagnostic[]): s
  * resolver is used rather than another node_modules walk because it honors `exports` maps and is the
  * only thing that works under Yarn PnP.
  *
- * This runs after the loop above, so it never shadows a project-local copy.
+ * This runs after the loop above, so it never shadows a project-local copy. Scoped to `@vgpu/*`
+ * specifiers only: it exists solely to rescue vgpu's own transitives in isolated pnpm/PnP layouts.
+ * Any other bare specifier that happens to be reachable from `@vgpu/wgsl`'s own install location
+ * (e.g. a devDependency like `webpack`) must NOT resolve here — it should fail with
+ * VGPU-WGSL-PKG-NOTFOUND instead of silently picking up an unrelated JS file that then fails much
+ * later with a confusing parse error.
  */
 function resolveAlongsideResolver(spec: string): string | undefined {
   try {

--- a/packages/wgsl/tests/loader-integration.test.ts
+++ b/packages/wgsl/tests/loader-integration.test.ts
@@ -37,6 +37,22 @@ test("a transitively installed WGSL package resolves from an isolated layout", a
   expect(result.deps.some((dep) => dep.replace(/\\/gu, "/").endsWith("wgsl-std/src/noise/index.wgsl"))).toBe(true);
 });
 
+// The fallback that resolves alongside the resolver exists only to rescue `@vgpu/*` transitives in
+// isolated layouts (see above). A non-`@vgpu` bare specifier must never ride that fallback, even when
+// it happens to be reachable from `@vgpu/wgsl`'s own install location (e.g. one of its
+// devDependencies, like `webpack`) — otherwise a typo'd import can silently resolve to an unrelated
+// JS file instead of failing with a clear PKG-NOTFOUND.
+test("a non-@vgpu specifier reachable only from the resolver's own install location is not resolved", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "vgsl-isolated-"));
+  const entry = join(dir, "main.wgsl");
+  await writeFile(entry, "import { thing } from 'webpack'; fn main(){}");
+
+  await expect(resolveShader({ entry, validate: false })).rejects.toMatchObject({
+    code: "VGPU-WGSL-PKG-NOTFOUND",
+    message: "Package webpack was not found. Install the package (npm install webpack) or check the specifier",
+  });
+});
+
 test("a project-local copy of a WGSL package wins over the transitive one", async () => {
   const dir = await mkdtemp(join(tmpdir(), "vgsl-local-wins-"));
   const pkgDir = join(dir, "node_modules", "@vgpu", "wgsl-std");


### PR DESCRIPTION
## What

`resolveAlongsideResolver` in `packages/wgsl/src/runtime/package-resolution.ts` used `createRequire(import.meta.url).resolve(spec)` without scoping the specifier. That fallback exists solely to rescue `@vgpu/wgsl`'s own transitive dependencies (e.g. `@vgpu/wgsl-std`) in isolated pnpm/PnP layouts, but it ran for **any** bare specifier once the project-local `node_modules` walk failed.

## The bug (Medium finding from #229's review)

A mistyped or unrelated WGSL import specifier that happened to match any package reachable from `@vgpu/wgsl`'s own install location (e.g. `webpack`, almost always present as a devDependency somewhere in the tree) would resolve to that real JS file instead of failing fast. It then blew up later with a confusing `VGPU-WGSL-REFLECT-PARSE Expected identifier`, instead of the `VGPU-WGSL-PKG-NOTFOUND` (with install fix-it) that #229 specifically improved.

## The fix

Scope the fallback to specifiers whose package name starts with `@vgpu/`. Everything else must resolve via the project-local `node_modules` walk or fail with `VGPU-WGSL-PKG-NOTFOUND`.

## Tests

- New regression test: a non-`@vgpu` specifier that *does* exist alongside the resolver (`webpack`, a real devDependency of `@vgpu/wgsl`) now correctly throws `VGPU-WGSL-PKG-NOTFOUND` from an isolated dir instead of resolving.
- Confirmed the two #229 layout tests still pass:
  - "a transitively installed WGSL package resolves from an isolated layout"
  - "a project-local copy of a WGSL package wins over the transitive one"
- Full `packages/wgsl` + `packages/wgsl-std` suite: 288 passed, 39 skipped.
- `pnpm typecheck`: clean.
- `pnpm bundle-check --experiences`: clean. `@vgpu/wgsl/runtime` [tooling]: 22002 B gzip / 22016 B budget (headroom 14 B, down from 24 B before this change) — still under budget, so no re-baseline needed.

## Changeset

Added a `patch` changeset for `@vgpu/wgsl`.