### PR TITLE
feat(docs): photon-ring antialiasing for the black-hole hero

### DIFF
--- a/apps/docs/components/hero/bake.wgsl
+++ b/apps/docs/components/hero/bake.wgsl
@@ -14,6 +14,14 @@
 // light away. After the second hit the ray still continues to the horizon or to
 // infinity, so the G-buffer also keeps the background (stars / black) both
 // layers are composited against.
+//
+// THE INTEGRATOR ITSELF LIVES IN `geodesic.wgsl`. This file is camera setup, one
+// `traceRay` call and the flag folding: the antialiasing refine pass has to trace
+// sub-pixel rays with exactly this integrator, and two copies of a Verlet loop
+// would drift apart. The extraction was verbatim and gated on byte-identical
+// debug renders.
+
+import { TraceResult, cameraRay, escapeRadiusFor, traceRay } from "./geodesic.wgsl";
 
 struct Bake {
   resolution: vec2f,
@@ -26,10 +34,6 @@ struct Bake {
 }
 
 @group(0) @binding(0) var<uniform> bake: Bake;
-
-const HORIZON: f32 = 1.0;
-const ISCO: f32 = 3.0;
-const MAX_STEPS: i32 = 768;
 
 /**
  * sky.w bit 0 — the ray is SHADOW: it ended inside the event horizon, or it was
@@ -63,6 +67,10 @@ const FLAG_ESCAPED: f32 = 2.0;
 // the f32 precision on the hit positions preserved (f16 quantizes to ~0.6 px at
 // r ~ 15 and visibly contours the disk noise).
 //
+// The sub-pixel COVERAGE and SPAN of the ring are NOT here: they are a separate
+// one-shot pass into a separate 2-byte target, precisely because this budget is
+// spent. See `refine.wgsl` and the "AA target" section of gbuffer.md.
+//
 // hit1: xy = FIRST  disk crossing, position in the y=0 plane (world x, z)
 // hit2: xy = SECOND disk crossing, same encoding; only written if hit1 exists
 //       For both: no crossing is encoded as (0, 0) — the annulus starts at
@@ -78,131 +86,9 @@ struct GBuffer {
   @location(3) view: vec4f,
 }
 
-/**
- * Packs a unit direction into 2 floats: y, plus the azimuth of the xz part.
- * Lossless enough that f16 storage beats the old 3x f16 cartesian form, and it
- * keeps the sign of y exact, which is what `side` is reconstructed from.
- */
-fn encodeDirection(direction: vec3f) -> vec2f {
-  return vec2f(direction.y, atan2(direction.z, direction.x));
-}
-
-fn geodesicAcceleration(position: vec3f, velocity: vec3f) -> vec3f {
-  let r2 = max(dot(position, position), 0.0001);
-  let angularMomentum = cross(position, velocity);
-  let h2 = dot(angularMomentum, angularMomentum);
-  return -1.5 * h2 * position / (r2 * r2 * sqrt(r2));
-}
-
 @fragment fn fs_main(@location(0) uv: vec2f) -> GBuffer {
-  let aspect = bake.resolution.x / max(bake.resolution.y, 1.0);
-  // ORIENTATION — vgpu's generated fullscreen vertex shader emits uv (0,0) at the
-  // TOP-LEFT of the target and (1,1) at the bottom-right (the WebGPU texture
-  // convention). Camera space is +Y up, so uv.y MUST be flipped here; feeding
-  // `uv.y * 2 - 1` straight into `up` renders the whole scene upside down.
-  // Every other pass is a 1:1 pass-through (shade textureLoads uv*dims, composite
-  // samples uv), so this is the single place the convention is converted, and it
-  // fixes the browser and the node harness at once. See gbuffer.md.
-  let ndc = vec2f(uv.x * 2.0 - 1.0, 1.0 - uv.y * 2.0);
-  // centerY shifts the image vertically, in NDC units: positive moves the black
-  // hole UP on screen. Kept at 0 now that the canvas covers the whole hero.
-  let screen = (ndc - vec2f(0.0, bake.centerY)) * vec2f(aspect, 1.0);
-
-  let yaw = bake.yaw;
-  let pitch = clamp(bake.pitch, -1.319, 1.319);
-  let orbitRadius = bake.orbitRadius;
-  let cameraPosition = vec3f(
-    sin(yaw) * cos(pitch) * orbitRadius,
-    sin(pitch) * orbitRadius,
-    cos(yaw) * cos(pitch) * orbitRadius,
-  );
-  let forward = normalize(vec3f(0.0) - cameraPosition);
-  let right = normalize(cross(forward, vec3f(0.0, 1.0, 0.0)));
-  let up = cross(right, forward);
-
-  var position = cameraPosition;
-  var velocity = normalize(forward * bake.fov + right * screen.x + up * screen.y);
-
-  var hit1Plane = vec2f(0.0);
-  var hit1Direction = vec2f(0.0);
-  var hit2Plane = vec2f(0.0);
-  var hit2Direction = vec2f(0.0);
-  var hitCount = 0;
-  var swallowed = 0.0;
-  var escaped = 0.0;
-  // Where the ray is declared to have reached infinity. Pushed out from 30 to
-  // 120 r_s: the deflection is already converged at 30 (raising it to 120 moves
-  // the outgoing direction by 0.002 deg at b = 3), but the far field is where
-  // the adaptive step below buys its budget back, so a farther cutoff costs
-  // almost no extra steps and makes the direction unambiguously asymptotic.
-  let escapeRadius = max(120.0, orbitRadius + 8.0);
-
-  for (var stepIndex = 0; stepIndex < MAX_STEPS; stepIndex++) {
-    let radius = length(position);
-    if (radius < HORIZON * 1.004) {
-      swallowed = 1.0;
-      break;
-    }
-    if (radius > escapeRadius && dot(position, velocity) > 0.0) {
-      escaped = 1.0;
-      break;
-    }
-
-    // Adaptive to gravity: finer near the horizon where the geodesic curves
-    // hardest. Much finer than the live version could afford (one-shot cost).
-    //
-    // The ceiling grows LINEARLY with radius past r = 6 instead of staying
-    // pinned at 0.075. The acceleration falls off as h^2 / r^5, so out there a
-    // 0.075 step resolves a straight line 20x more finely than needed and the
-    // fixed cap was burning ~20% of MAX_STEPS on the flight in and out. Inside
-    // r = 6 the factor is exactly 1, so the strong-field part of every geodesic
-    // — everything that produces the deflection, the shadow edge and the disk
-    // crossings — integrates bit-for-bit as before. Measured effect of the
-    // relaxation (evidence/geo3.mjs): deflection unchanged to <= 0.03 deg, and
-    // the freed budget shrinks the out-of-steps band from 8.6 px to 2.3 px at
-    // 720p.
-    let stepSize = clamp((radius - HORIZON) * 0.035, 0.0045, 0.075 * max(1.0, radius / 6.0));
-
-    let previousPosition = position;
-    let previousVelocity = velocity;
-
-    // Velocity-Verlet style integration of the light geodesic.
-    let acceleration0 = geodesicAcceleration(position, velocity);
-    velocity += acceleration0 * (0.5 * stepSize);
-    position += velocity * stepSize;
-    let acceleration1 = geodesicAcceleration(position, velocity);
-    velocity += acceleration1 * (0.5 * stepSize);
-    velocity = normalize(velocity);
-
-    // Hard disk: exact intersection with the y=0 annulus. No slab, no volume,
-    // no oversampling heuristics -> no concentric ring aliasing either.
-    //
-    // The crossing test is a strict side change rather than `prevY * y <= 0`:
-    // now that two hits are recorded, a step that lands exactly on y = 0 would
-    // otherwise satisfy the product test twice and register the same crossing
-    // as both hits. Folding y == 0 into the positive side makes every sign flip
-    // fire exactly once, and keeps the interpolation denominator non-zero.
-    if (hitCount < 2) {
-      let previousSide = select(-1.0, 1.0, previousPosition.y >= 0.0);
-      let currentSide = select(-1.0, 1.0, position.y >= 0.0);
-      if (previousSide != currentSide) {
-        let t = clamp(previousPosition.y / (previousPosition.y - position.y), 0.0, 1.0);
-        let crossing = mix(previousPosition, position, t);
-        let planeRadius = length(crossing.xz);
-        if (planeRadius >= ISCO && planeRadius <= bake.diskOuter) {
-          let direction = encodeDirection(normalize(mix(previousVelocity, velocity, t)));
-          if (hitCount == 0) {
-            hit1Plane = crossing.xz;
-            hit1Direction = direction;
-          } else {
-            hit2Plane = crossing.xz;
-            hit2Direction = direction;
-          }
-          hitCount += 1;
-        }
-      }
-    }
-  }
+  let ray = cameraRay(uv, bake.resolution, bake.yaw, bake.pitch, bake.orbitRadius, bake.fov, bake.centerY);
+  var traced = traceRay(ray.position, ray.velocity, bake.diskOuter, escapeRadiusFor(bake.orbitRadius));
 
   // OUT-OF-STEPS RAYS ARE SHADOW, NOT SKY.
   //
@@ -220,19 +106,19 @@ fn geodesicAcceleration(position: vec3f, velocity: vec3f) -> vec3f {
   // more slowly than any escaping ray: black is a much better approximation of
   // its (infinitely thin, infinitely wound) contribution than a truncated
   // direction, so it is folded into the shadow. With the relaxed far-field step
-  // above this band is ~2.3 px at 720p, just outside the shadow edge.
+  // in geodesic.wgsl this band is ~2.3 px at 720p, just outside the shadow edge.
   //
   // The loop can only end three ways — fell in, escaped, ran out of steps — so
   // "neither flag set" identifies the third case exactly, and after this the
   // G-buffer never contains a sample with both flags clear.
-  if (swallowed < 0.5 && escaped < 0.5) {
-    swallowed = 1.0;
+  if (traced.swallowed < 0.5 && traced.escaped < 0.5) {
+    traced.swallowed = 1.0;
   }
 
   return GBuffer(
-    hit1Plane,
-    hit2Plane,
-    vec4f(velocity, swallowed * FLAG_HOLE + escaped * FLAG_ESCAPED),
-    vec4f(hit1Direction, hit2Direction),
+    traced.hit1Plane,
+    traced.hit2Plane,
+    vec4f(traced.finalVelocity, traced.swallowed * FLAG_HOLE + traced.escaped * FLAG_ESCAPED),
+    vec4f(traced.hit1Direction, traced.hit2Direction),
   );
 }

--- a/apps/docs/components/hero/debug-render.mjs
+++ b/apps/docs/components/hero/debug-render.mjs
@@ -21,7 +21,9 @@
 //   --out <dir>          output directory (default /home/user/reports/hero-debug)
 //   --size <WxH>         render size in pixels (default 1280x720)
 //   --time <seconds>     animation clock handed to the shaders (default 2.5)
-//   --views <list>       comma list of: final,normals,diskuv,flags,raydir,density,skylod,hit2,all
+//   --views <list>       comma list of: final,normals,diskuv,flags,raydir,density,skylod,hit2,aa,all
+//   --aa <0|1>           1 = consume the refine pass's ring coverage/span (default),
+//                        0 = ignore it, i.e. exactly the pre-AA image. The A/B.
 //   --<key> <value>      any geometry setting: cameraY, distance, diskRadius, fov, centerY
 //   --diskLayers <1|2>   1 = front disk hit only, 2 = also the hidden second hit (A/B)
 //   --yaw <radians>      SCENE yaw applied by the frame pass (default 0). This is the
@@ -33,6 +35,17 @@
 //   --stars.<key> <v>    any StarLook field (brightness, density, contrast, warmth, twinkle)
 //   --noiseSize <n>      edge of the tiled 3D noise lattice (default 64; try 128 to
 //                        A/B whether the tiling repeats visibly)
+//   --ssaa <n>           render n x size and box-downsample IN LINEAR LIGHT (decode
+//                        2.2, average, re-encode) to `--size`. n = 1 is the shipped
+//                        path, bit-for-bit. This is the AA REFERENCE: n = 3 is what
+//                        the photon-ring antialiasing is judged against, and n = 2
+//                        already agrees closely with it (~9 samples/px is converged).
+//                        Note the bake runs at the supersampled resolution too, so
+//                        this is true SSAA, not a post filter.
+//   --crop <x,y,w,h[,s]> after downsampling, also write `<view>-crop.png`: the given
+//                        rect of the FINAL image, nearest-neighbour zoomed by s
+//                        (default 10). Coordinates are in `--size` pixels, so the
+//                        same rect lands on the same features at any `--ssaa`.
 //   --set <json>         deep-merged JSON settings patch (wins over flags)
 //   --json               print the resolved settings and per-image stats as JSON
 //
@@ -63,6 +76,9 @@ const DEFAULT_SETTINGS = {
   centerY: 0,
   debugView: 0,
   diskLayers: 2,
+  // Photon-ring antialiasing A/B: `--aa 0` reproduces the pre-AA image exactly
+  // (the refine pass still runs; the frame pass just ignores its target).
+  aa: 1,
   // Mouse amplitude in the browser. The harness has no pointer: use --yaw to set
   // an instantaneous scene rotation instead.
   mouseYaw: 0.15,
@@ -100,13 +116,16 @@ const VIEWS = {
   density: 5,
   skylod: 6,
   hit2: 7,
+  aa: 8,
 };
 
 /** hit1, hit2, sky, view. Must match GBUFFER_FORMATS in renderer.ts. */
 const GBUFFER_FORMATS = ['rg32float', 'rg32float', 'rgba16float', 'rgba16float'];
+/** Photon-ring AA target (coverage, span). Must match AA_FORMAT in renderer.ts. */
+const AA_FORMAT = 'rg8unorm';
 
 function parseArgs(argv) {
-  const options = { views: ['all'], size: [1280, 720], time: 2.5, out: '/home/user/reports/hero-debug', json: false, yaw: 0, bakeYaw: 0, noiseSize: NOISE_VOLUME_SIZE };
+  const options = { views: ['all'], size: [1280, 720], time: 2.5, out: '/home/user/reports/hero-debug', json: false, yaw: 0, bakeYaw: 0, noiseSize: NOISE_VOLUME_SIZE, ssaa: 1, crop: undefined };
   const patch = {};
   for (let i = 0; i < argv.length; i++) {
     const token = argv[i];
@@ -125,6 +144,12 @@ function parseArgs(argv) {
     }
     if (key === 'time') { options.time = Number(value); continue; }
     if (key === 'noiseSize') { options.noiseSize = Math.max(2, Number(value) | 0); continue; }
+    if (key === 'ssaa') { options.ssaa = Math.max(1, Number(value) | 0); continue; }
+    if (key === 'crop') {
+      const [x, y, w, h, scale] = value.split(/[x,]/).map(Number);
+      options.crop = { x: x | 0, y: y | 0, w: Math.max(1, w | 0), h: Math.max(1, h | 0), scale: Math.max(1, (scale || 10) | 0) };
+      continue;
+    }
     // Scene yaw vs camera yaw: `--yaw t` rotates the scene in the frame pass and
     // must produce the same image as `--bakeYaw -t`, which rotates the camera and
     // re-bakes. That equivalence is the whole justification for the feature.
@@ -174,6 +199,65 @@ function writePng(path, width, height, rgba) {
   });
 }
 
+/**
+ * Box-downsamples an `n`x supersampled RGBA image IN LINEAR LIGHT.
+ *
+ * The gamma round trip is the whole point: `shade.wgsl` writes display-referred
+ * sRGB-ish bytes (`pow(color, 1/2.2)`), and averaging those directly is
+ * averaging the wrong quantity — it under-weights the bright sub-samples, which
+ * is exactly the light the reference is supposed to prove is missing. Decode
+ * 2.2, average, re-encode.
+ */
+function downsampleLinear(rgba, width, height, n) {
+  if (n <= 1) return rgba;
+  const outWidth = Math.floor(width / n);
+  const outHeight = Math.floor(height / n);
+  const out = Buffer.alloc(outWidth * outHeight * 4);
+  const inverse = 1 / (n * n);
+  for (let y = 0; y < outHeight; y++) {
+    for (let x = 0; x < outWidth; x++) {
+      let r = 0;
+      let g = 0;
+      let b = 0;
+      let a = 0;
+      for (let sy = 0; sy < n; sy++) {
+        for (let sx = 0; sx < n; sx++) {
+          const i = ((y * n + sy) * width + (x * n + sx)) * 4;
+          r += (rgba[i] / 255) ** 2.2;
+          g += (rgba[i + 1] / 255) ** 2.2;
+          b += (rgba[i + 2] / 255) ** 2.2;
+          a += rgba[i + 3];
+        }
+      }
+      const o = (y * outWidth + x) * 4;
+      out[o] = Math.round(255 * (r * inverse) ** (1 / 2.2));
+      out[o + 1] = Math.round(255 * (g * inverse) ** (1 / 2.2));
+      out[o + 2] = Math.round(255 * (b * inverse) ** (1 / 2.2));
+      out[o + 3] = Math.round(a * inverse);
+    }
+  }
+  return out;
+}
+
+/** Nearest-neighbour zoom of a rect — the only honest way to look at a 1 px ring. */
+function cropZoom(rgba, width, height, rect) {
+  const { x, y, w, h, scale } = rect;
+  const out = Buffer.alloc(w * scale * h * scale * 4);
+  for (let dy = 0; dy < h * scale; dy++) {
+    const sy = Math.min(height - 1, Math.max(0, y + Math.floor(dy / scale)));
+    for (let dx = 0; dx < w * scale; dx++) {
+      const sx = Math.min(width - 1, Math.max(0, x + Math.floor(dx / scale)));
+      const i = (sy * width + sx) * 4;
+      const o = (dy * w * scale + dx) * 4;
+      out[o] = rgba[i];
+      out[o + 1] = rgba[i + 1];
+      out[o + 2] = rgba[i + 2];
+      out[o + 3] = rgba[i + 3];
+    }
+  }
+  return { rgba: out, width: w * scale, height: h * scale };
+}
+
 function stats(rgba) {
   let sum = 0;
   let sumSquares = 0;
@@ -196,25 +280,36 @@ async function main() {
     if (!(name in VIEWS)) throw new Error(`unknown view "${name}"; expected ${Object.keys(VIEWS).join(', ')} or all`);
   }
 
-  const [bakeWgsl, shadeWgsl] = await Promise.all([
+  const [bakeWgsl, refineWgsl, shadeWgsl] = await Promise.all([
     loadShader('bake.wgsl'),
+    loadShader('refine.wgsl'),
     loadShader('shade.wgsl'),
   ]);
 
   await mkdir(options.out, { recursive: true });
   const gpu = await init();
-  const [width, height] = options.size;
+  // True SSAA: the BAKE runs at the supersampled resolution too, so every
+  // sub-sample is a real geodesic. That is what makes `--ssaa 3` a reference the
+  // photon-ring antialiasing can be judged against rather than a post filter.
+  const [outWidth, outHeight] = options.size;
+  const ssaa = options.ssaa;
+  const width = outWidth * ssaa;
+  const height = outHeight * ssaa;
 
   const gbuffer = vgpu.target(gpu, {
     size: [width, height],
     colors: GBUFFER_FORMATS.map((format) => ({ format })),
     label: 'hero-debug-gbuffer',
   });
+  // Photon-ring AA data: one-shot, written by the refine pass right after the
+  // bake, read 1:1 by shade. Same size as the G-buffer, 2 B/px.
+  const aaTarget = vgpu.target(gpu, { size: [width, height], colors: [{ format: AA_FORMAT }], label: 'hero-debug-aa' });
   // Display-referred, exactly what the swap chain gets in the browser: shade
   // tone maps in place, so this is the only pass target after the G-buffer.
   const output = vgpu.target(gpu, { size: [width, height], format: 'rgba8unorm', label: 'hero-debug-output' });
 
   const bake = vgpu.effect(gpu, bakeWgsl, { label: 'hero-debug-bake' });
+  const refine = vgpu.effect(gpu, refineWgsl, { label: 'hero-debug-refine' });
   // The same shade.wgsl the browser renderer compiles, from the same imports:
   // a PNG from this harness and a frame from the page are the same program.
   const shade = vgpu.effect(gpu, shadeWgsl, { label: 'hero-debug-shade' });
@@ -226,7 +321,8 @@ async function main() {
   const noiseSampler = noiseVolumeSampler(vgpu, gpu);
 
   const [hit1Texture, hit2Texture, skyTexture, viewTexture] = gbuffer.colors;
-  bake.set({ bake: {
+  const [aaTexture] = aaTarget.colors;
+  const geometry = {
     resolution: gbuffer.size,
     // Camera yaw. The page always bakes with 0 and rotates the scene in the frame
     // pass instead; this exists only as the ground truth for that rotation.
@@ -236,21 +332,29 @@ async function main() {
     diskOuter: settings.diskRadius,
     fov: settings.fov,
     centerY: settings.centerY,
-  } });
+  };
+  // One geometry description for both one-shot passes, exactly like renderer.ts:
+  // the sub-rays must come from the same camera as the centre rays.
+  bake.set({ bake: geometry });
+  refine.set({ gHit1: hit1Texture, gSky: skyTexture, refine: geometry });
   shade.set({
     gHit1: hit1Texture,
     gHit2: hit2Texture,
     gSky: skyTexture,
     gView: viewTexture,
+    gAa: aaTexture,
     noiseVolume,
     noiseSampler,
     disk: settings.disk,
     stars: settings.stars,
   });
 
-  // One bake for every view: that is the whole point of the split.
+  // One bake (and one refine) for every view: that is the whole point of the
+  // split. The refine pass reads the G-buffer, so it goes in the same frame,
+  // after it — the same ordering renderer.ts uses.
   vgpu.frame(gpu, (frame) => {
     frame.pass({ target: gbuffer, clear: [0, 0, 0, 1] }, (pass) => pass.draw(bake));
+    frame.pass({ target: aaTarget, clear: [0, 0, 0, 1] }, (pass) => pass.draw(refine));
   });
 
   const results = [];
@@ -262,6 +366,7 @@ async function main() {
       diskOuter: settings.diskRadius,
       debugView,
       diskLayers: settings.diskLayers,
+      aa: settings.aa,
       // Instantaneous scene rotation; the browser smooths it from the pointer.
       sceneYaw: options.yaw,
     } });
@@ -270,20 +375,29 @@ async function main() {
     vgpu.frame(gpu, (frame) => {
       frame.pass({ target: output, clear: [0, 0, 0, 1] }, (pass) => pass.draw(shade));
     });
-    const pixels = await output.read();
+    const rendered = await output.read();
+    // At --ssaa 1 this is the identity (same Buffer), so the shipped path stays
+    // bit-for-bit what it always was.
+    const pixels = downsampleLinear(rendered, width, height, ssaa);
     const path = join(options.out, `${name}.png`);
-    await writePng(path, width, height, pixels);
-    results.push({ view: name, debugView, path, ...stats(pixels) });
+    await writePng(path, outWidth, outHeight, pixels);
+    const result = { view: name, debugView, path, ...stats(pixels) };
+    if (options.crop) {
+      const zoom = cropZoom(pixels, outWidth, outHeight, options.crop);
+      result.crop = join(options.out, `${name}-crop.png`);
+      await writePng(result.crop, zoom.width, zoom.height, zoom.rgba);
+    }
+    results.push(result);
   }
 
   noiseVolume.destroy();
   gpu.dispose();
 
   if (options.json) {
-    console.log(JSON.stringify({ size: options.size, time: options.time, noiseSize: options.noiseSize, settings, images: results }, null, 2));
+    console.log(JSON.stringify({ size: options.size, ssaa, time: options.time, noiseSize: options.noiseSize, settings, images: results }, null, 2));
     return;
   }
-  console.log(`hero debug render ${width}x${height} @ t=${options.time}s noise=${options.noiseSize}^3 -> ${options.out}`);
+  console.log(`hero debug render ${outWidth}x${outHeight} (ssaa ${ssaa}x -> rendered ${width}x${height}) @ t=${options.time}s noise=${options.noiseSize}^3 -> ${options.out}`);
   for (const result of results) {
     console.log(`  ${result.view.padEnd(8)} debugView=${result.debugView}  mean=${result.mean}  std=${result.std}  ${result.path}`);
   }

--- a/apps/docs/components/hero/gbuffer.md
+++ b/apps/docs/components/hero/gbuffer.md
@@ -6,12 +6,17 @@ raymarch, runs only when the camera/geometry changes) and a **cheap frame pass**
 the infrastructure and the two shading workstreams.
 
 ```
-bake.wgsl ──► G-buffer (MRT, 4 attachments) ──► shade.wgsl ──► canvas
- one-shot                                       every frame
-                                                   ├── disk.wgsl   (disk pixels)
-                                                   ├── stars.wgsl  (escaped rays)
-                                                   └── tonemap()   (ACES + vignette, in place)
+bake.wgsl ──► G-buffer (MRT, 4 attachments) ──┬─► shade.wgsl ──► canvas
+ one-shot      │                              │   every frame
+               │                              │      ├── disk.wgsl   (disk pixels)
+               ▼                              │      ├── stars.wgsl  (escaped rays)
+        refine.wgsl ──► AA target (rg8unorm) ─┘      └── tonemap()   (ACES + vignette, in place)
+         one-shot        (coverage, span)
 ```
+
+Both `bake.wgsl` and `refine.wgsl` are ONE-SHOT and share the geodesic integrator
+in `geodesic.wgsl`; only `shade.wgsl` runs per frame. See
+[The AA target](#the-aa-target--photon-ring-coverage-and-span).
 
 **Two passes, not three.** `shade.wgsl` tone maps in a register and writes the
 swap chain directly. There is no intermediate `scene` target and no
@@ -24,6 +29,8 @@ handful of ALU ops. See [Tone mapping](#tone-mapping-lives-at-the-end-of-shadewg
 | File | Owner | Edit? |
 |---|---|---|
 | `bake.wgsl` | infrastructure | no |
+| `geodesic.wgsl` | infrastructure | no (the shared null-geodesic integrator) |
+| `refine.wgsl` | infrastructure | no (one-shot photon-ring coverage/span) |
 | `gbuffer.wgsl` | infrastructure | no (read it — it defines `GBufferSample`) |
 | `shade.wgsl` | infrastructure | no (thin dispatcher + debug views + tone map) |
 | `renderer.ts` | infrastructure | only to add a new look field (see below) |
@@ -75,6 +82,11 @@ If you need another channel, take it from redundancy the same way, or measure
 `maxColorAttachmentBytesPerSample` on the target hardware first. Simply appending
 an attachment will validate fine on a desktop GPU and fail on a spec-minimum
 device.
+
+This budget is exactly why the photon-ring AA data lives in its **own pass and
+own target** rather than as a 5th attachment here — see
+[The AA target](#the-aa-target--photon-ring-coverage-and-span). The limit is
+per-PASS, so a second pass gets a fresh 32 B.
 
 ## G-buffer layout
 
@@ -162,8 +174,13 @@ struct GBufferLayers {
   front: GBufferSample,  // crossing nearest the camera
   back: GBufferSample,   // the crossing it hides; isHit only if front.isHit
 }
-fn decodeGBuffer(hit1: vec2f, hit2: vec2f, sky: vec4f, view: vec4f, diskOuter: f32) -> GBufferLayers
+fn decodeGBuffer(hit1: vec2f, hit2: vec2f, sky: vec4f, view: vec4f, diskOuter: f32, aa: vec2f) -> GBufferLayers
 ```
+
+`aa` is the matching texel of the [AA target](#the-aa-target--photon-ring-coverage-and-span)
+— `(covFront, spanFront)`. It describes the **front** crossing only; the back
+layer is handed `(1, 0)` and therefore decodes exactly as it did before the AA
+target existed. Pass `vec2f(1.0, 0.0)` to opt out entirely.
 
 Each layer is the same `GBufferSample` the single-hit version used — `shadeDisk`
 shades one layer at a time and never has to know which one it got. Values that
@@ -179,11 +196,174 @@ struct GBufferSample {
   rayDirection: vec3f,  // final lensed direction — for the sky
   viewDirection: vec3f, // direction at the disk hit — for Doppler
   side: f32,            // +1 / -1 / 0
+  coverage: f32,        // fraction of the pixel this crossing covers (1 outside the AA band)
+  span: f32,            // disk radius the pixel spans here, in normalized annulus units
   isHit: bool,
   isBlackHole: bool,
   escaped: bool,
 }
 ```
+
+## The AA target — photon ring coverage and span
+
+A second one-shot pass, `refine.wgsl`, writes a **2 B/px `rg8unorm`** target next
+to the G-buffer:
+
+| Channel | Name | Meaning |
+|---|---|---|
+| `x` | `covFront` | fraction of the pixel the FIRST disk crossing covers, from 16 sub-rays (`n/16`) |
+| `y` | `spanFront` | how much DISK RADIUS the pixel spans at that crossing, in normalized annulus units, **centred on the pixel's own radius** |
+
+Outside the refined band it is exactly `(isHit ? 1 : 0, 0)`. `1.0` is exact in
+`rg8unorm`, so every unrefined pixel multiplies its alpha by a literal one and its
+final colour is **bit-for-bit** what it was before this target existed (verified
+with `cmp` on all eight debug views).
+
+### What the artifact actually is (measure before you tune)
+
+The visible "line around the shadow" is **not** the shadow silhouette. The
+shadow/sky step measures `0 -> 4/255` — invisible. The line is the **lensed
+photon-ring image of the disk**: at the shipped defaults the entire
+`[ISCO, diskOuter]` annulus is compressed into ~1.5 px at screen radius
+r ≈ 190 px (720p). Debug view 2 shows `diskUv.x` going **0.12 -> 0.71 between two
+adjacent pixels** at constant azimuth. One ray per pixel therefore draws a random
+radius out of the whole annulus, and every analytic softness in `disk.wgsl`
+(`innerEdge`, `outerEdge`, `flux`) is soft in *disk* space and a hard step in
+*screen* space there.
+
+Measured tangential profile of the ring (max luma over the radial band,
+20°..70° in 1° steps, harness at 1280x720, t = 2.5):
+
+| | min | max | std | neighbour steps > 2x |
+|---|---|---|---|---|
+| 1x, no AA | 10 | 112 | 25.6 | 21 / 50 |
+| 1x, AA on | 14 | 63 | 9.97 | 4 / 50 |
+| 3x SSAA reference | 26 | 70 | 8.53 | 1 / 50 |
+
+So the artifact is a **dotted, brightness-jittering 1 px wire**, and the fix has
+to antialias disk-hit coverage *and* disk attribute variation — not a silhouette.
+
+### Why a separate pass and a separate target
+
+- The bake's MRT already spends exactly the 32 B/sample WebGPU guarantees
+  (`maxColorAttachmentBytesPerSample`), so there is no 5th attachment to take.
+  The limit is per-pass, so a second pass gets a fresh budget.
+- It is **additive and deletable**: one uniform (`Shade.aa`) disables it, one
+  target and one pass remove it.
+- MSAA cannot do this job: `shade.wgsl` is a fullscreen quad, so every sample of
+  a pixel has identical coverage and identical `textureLoad` — a 4x resolve
+  returns the same colour for 4x the cost. A 4x MSAA G-buffer would also cost
+  265 MB at 1080p.
+- Supersampling the G-buffer itself is the mathematically best answer and dies on
+  memory: 32 B/px x 4 subsamples x 1920x1080 = 265 MB (3x: 597 MB).
+
+### The refine pass
+
+1. **Band detection**, per pixel: a **5x5** neighbourhood that differs in `isHit`,
+   differs in the shadow flag, or spans more than 0.12 of the annulus in radius.
+   5x5 rather than 3x3 because the ring is thinner than a pixel: a pixel whose
+   *centre* ray misses it entirely still has to be refined. 25 texel loads,
+   one-shot.
+2. **16 sub-rays** on a regular 4x4 grid inside the pixel, through
+   `geodesic.wgsl::cameraRay` + `traceRay` — the *same* integrator, from the *same*
+   geometry uniform (`renderer.ts::setBakeUniforms` uploads one struct to both
+   passes), so the sub-rays can never describe a different ray bundle than the
+   G-buffer's centre rays. A fixed grid, not a jittered one: a fixed pattern makes
+   the residual quantisation of `coverage` vary *smoothly* along the ring, which is
+   the entire goal, where per-pixel jitter would trade a bias for noise.
+3. `span` is measured **symmetrically about the centre ray**, i.e. the smallest
+   interval centred on `r0` containing every sub-ray crossing — not `rmax - rmin`.
+   The frame pass can only anchor its taps at `r0` (the only radius it has), so a
+   raw range would let a centre ray sitting at one end shift the whole tap set off
+   the measured span and bias the radial mean. The price is a span up to 2x wider
+   than the raw range: a slightly wider prefilter, never a shifted one.
+
+**Shadow coverage is deliberately not stored.** It was measured at `0 -> 4/255`
+(invisible), and consuming a fractional shadow would composite stars from the
+*truncated* `gSky.xyz` of a swallowed ray — new speckle in a 1 px rim, plus a
+perturbed derivative field under the star prefilter. If it is ever wanted it needs
+an escaped sub-sample's **direction** stored next to it, and a third channel.
+
+### The tap protocol (`sampleAtRadius`) — read before touching `disk.wgsl`
+
+Where `spanFront > 0.15`, `shade.wgsl` replaces its single `shadeDisk` call with
+**K = 6** calls at radii spanning the measured span at the same azimuth, via
+`gbuffer.wgsl::sampleAtRadius`, and averages. `disk.wgsl` and `stars.wgsl` are
+**not touched**: the disk owns the look, not the filtering.
+
+- Mean of `color * alpha` and mean of `alpha` are accumulated **separately** and
+  recombined, because emission-absorption is linear in exactly those two.
+- Taps outside `[ISCO, diskOuter]` are dropped from the sum **and** the divisor.
+  Clamping instead would pile weight on the two edge radii and bias the mean.
+- **`footprint` is now sometimes explicit rather than fwidth-derived.** The taps
+  are *not* the pixel: each stands for a slice `span / K` wide, so the tap
+  footprint is rebuilt from the same two terms `disk.wgsl` inverts at its
+  `pixelWorld` line — `max(angular term of the pixel, disk.detail * span / K)` —
+  with the radial term replaced. If you change how `disk.wgsl` inverts
+  `footprint`, this is the second caller you have to keep in step. Passing the
+  pixel's collapsed fwidth footprint here instead measures worse: it prefilters
+  every tap across the whole annulus.
+- No `fwidth` in the tap branch, ever: the loop runs in non-uniform control flow.
+  All derivatives stay in `fs_main`'s uniform prologue (`diskFootprintAxes`,
+  which now returns the two axes separately for exactly this reason).
+- Do **not** "fix" the ring by attenuating it where the footprint is large. That
+  is the `starLod` fade-to-black mistake documented above, in a new place:
+  radiance is conserved, so prefilter it.
+- Do **not** average the baked hit *positions* across sub-rays. It lies about the
+  geometry and it shrinks the fwidth footprints, making the noise aliasing worse.
+
+### Rotation invariance
+
+`covFront` and `spanFront` are properties of the ray bundle and of the
+axisymmetric geometry (Schwarzschild gravity + a ring centred on `y = 0`), so
+`sceneYaw` leaves them exact — the same argument that makes the G-buffer itself
+rotation-invariant. `sampleAtRadius` only moves the radial coordinates and
+commutes with `rotateSample`. Verified: `--yaw 0.15` and `--bakeYaw -0.15` still
+agree (frame mean 0.0238 both), and the AA view is unchanged by scene rotation.
+
+### Cost and the thermal gate
+
+The AA data costs the frame pass **+2 B/px** of read (~6% of the 32 B/px the shade
+pass already reads, and that pass is ALU-bound, not bandwidth-bound) plus the tap
+loop. Static counts at 1280x720, shipped defaults:
+
+| Set | Pixels | Share |
+|---|---|---|
+| refined band (partial coverage or non-zero span) | 19 946 | 2.16% |
+| **tap path actually taken** (`isHit && span > 0.15`) | **1 986** | **0.215%** |
+| 8x8 tiles (~one 64-lane wave) containing any tap pixel | 202 / 14 400 | 1.40% |
+
+So even in the worst case — a whole wave paying K x the disk cost because one lane
+straddles the ring — the tap loop adds `5 extra shadeDisk x 1.40% of waves` ≈
+**7% of the disk-shading work**, and the disk is only part of the shade pass.
+**Hard gate: shade GPU time <= 1.45 ms at DPR 1 (from 1.3 ms), measured with the
+`?debug` panel's `measure` button on real hardware.** Numbers from the Node
+harness in a container are CPU/SwiftShader and say nothing about GPU time.
+
+The refine pass itself is one-shot and lives *inside* `renderChain`'s
+`if (bake)` block, after the G-buffer pass. That placement is load-bearing: the
+bake is suppressed while `measure()` is sampling, so none of the refine cost can
+be attributed to the shade pass, exactly as for the bake. It is also why the AA
+target can never go stale — it is regenerated by the same throttled bake that
+invalidated it.
+
+If the gate ever fails at K = 4, the documented fallback is a **single**
+`shadeDisk` call at the span's mid-radius with an explicit footprint equal to the
+whole span, scaled by coverage: smooth and continuous at ~1 tap, at the price of a
+radial-profile bias.
+
+### Known gap (do not rediscover it)
+
+Coverage can only ever *scale* a sample that exists. A pixel whose centre ray
+misses the ring has no radius, azimuth or view direction to rebuild a sample from,
+so it cannot be shaded no matter what `covFront` says. Within the 5x5 mask this
+does not happen (measured: 0 such pixels at the shipped defaults). What *does*
+happen is one step further out: a sub-pixel arc that lives entirely **inside** the
+shadow silhouette, where no centre ray in a 5x5 neighbourhood sees the disk, so
+the mask never fires. Example at 720p, 45°, r = 188: the 3x reference has luma 58,
+the 1x frame and `covFront` are both 0. Closing it needs the crossing geometry
+stored per pixel (promote the target to `rgba8unorm`/`rgba16float` with radius +
+azimuth), not a wider dilation.
 
 ## The two shading entry points
 
@@ -632,9 +812,10 @@ directions right where the prefilter now keeps the sky alive.
 | `@group(0) @binding(6)` | `stars` | `StarLook` uniform | `settings.stars` (verbatim) |
 | `@group(0) @binding(7)` | `noiseVolume` | `texture_3d<f32>` (`r8unorm`) | `noise-volume.mjs::createNoiseVolume` |
 | `@group(0) @binding(8)` | `noiseSampler` | `sampler` (linear, `repeat` xyz) | `noise-volume.mjs::noiseVolumeSampler` |
+| `@group(0) @binding(9)` | `gAa` | `texture_2d<f32>` (`rg8unorm`) | `targets.aa.colors[0]`, written by `refine.wgsl` |
 
-`Shade` carries `resolution`, `time`, `diskOuter`, `debugView`, `diskLayers` and
-`sceneYaw` — nothing camera-related, the bake froze it (`sceneYaw` rotates the
+`Shade` carries `resolution`, `time`, `diskOuter`, `debugView`, `diskLayers`, `aa`
+and `sceneYaw` — nothing camera-related, the bake froze it (`sceneYaw` rotates the
 *scene*, not the camera; see below). G-buffer textures are read with
 `textureLoad` (no sampler): the 32-bit float formats are not filterable, and
 interpolating G-buffer values across silhouettes would be wrong anyway.
@@ -1036,11 +1217,14 @@ The lil-gui panel has a **debug** folder with a *g-buffer view* dropdown:
 | 5 | disk density | `DiskSample.density` |
 | 6 | sky footprint / star prefilter | R = star cells crossed per pixel ÷ 16, G = `starPrefilterRatio` (1 = star at least a pixel wide and at full brightness, → 0 = one pixel swallows many cells and every star is dimmed by the square of it), B = 1 where stars are sampled. G → 0 no longer means "no sky here": the flux is still rendered, spread out. |
 | 7 | second disk hit | **B = 1 exactly where a hidden second crossing exists**, R/G = its normalized disk coords (radius, azimuth) |
+| 8 | ring aa (cov/span/taps) | R = `covFront`, G = `spanFront`, B = 1 where the K-tap radial prefilter ran. Yellow + blue = the compressed photon-ring band. A pixel with R > 0, G = 0, no B **and** a black final image is the known gap: the 5×5 dilation found coverage the centre ray missed, and there is no radius to rebuild a sample from (see [The AA target](#the-aa-target--photon-ring-coverage-and-span)). |
 
 Views 1–5 describe the **front** crossing. Next to the dropdown, **disk layers**
 switches between `front hit only` (what the renderer did before the second hit
 existed) and `front + hidden hit` (the default) — the quickest way to see what
-the second layer contributes.
+the second layer contributes. **photon-ring aa** is the other A/B: `off` is
+bit-for-bit the pre-AA image (verified with `cmp`), because the frame pass forces
+`coverage` to a literal 1 and never enters the tap loop.
 
 A separate **perf (frame time)** folder times ~180 frames of the real loop and
 copies the result as JSON — see [Measuring it yourself](#measuring-it-yourself).
@@ -1096,11 +1280,29 @@ node apps/docs/components/hero/debug-render.mjs --views final,hit2              
 node apps/docs/components/hero/debug-render.mjs --views final --diskLayers 1 --out /tmp/before
 node apps/docs/components/hero/debug-render.mjs --views final,raydir --yaw 0.15        # scene rotation
 node apps/docs/components/hero/debug-render.mjs --views final,raydir --bakeYaw -0.15   # its ground truth
+node apps/docs/components/hero/debug-render.mjs --views final,aa --aa 0                # ring AA A/B (off)
+node apps/docs/components/hero/debug-render.mjs --views final --ssaa 3 --out /tmp/ref3x # the AA reference
+node apps/docs/components/hero/debug-render.mjs --views final --crop 740,225,60,60,10   # 10x ring zoom
 ```
 
+- `--ssaa n` renders `n x --size` and box-downsamples **in linear light** (decode
+  2.2, average, re-encode), with the BAKE running at the supersampled resolution
+  too — real geodesics per sub-sample, not a post filter. This is the reference
+  the photon-ring AA is judged against; `n = 1` is the shipped path, bit-for-bit.
+  Note that mean luma of a supersampled frame is **not** an energy measurement:
+  ACES + gamma are concave, so averaging tone-mapped sub-samples reads brighter
+  than a point sample on ANY high-contrast content (measured uniformly across the
+  star field, the resolved disk and the ring band). Use it to compare structure,
+  not to conclude that light was "lost".
+- `--crop x,y,w,h[,scale]` also writes `<view>-crop.png`: that rect of the FINAL
+  image, nearest-neighbour zoomed (default 10x). Coordinates are in `--size`
+  pixels, so the same rect lands on the same features at any `--ssaa`.
+- `--aa 0|1` is the ring-antialiasing A/B (default 1). At `0` the refine pass
+  still runs and the frame pass ignores it, which reproduces the pre-AA frame
+  byte-for-byte.
 - Output directory: `--out` (default `/home/user/reports/hero-debug/`), one PNG
   per view: `final.png`, `normals.png`, `diskuv.png`, `flags.png`,
-  `raydir.png`, `density.png`, `skylod.png`, `hit2.png`.
+  `raydir.png`, `density.png`, `skylod.png`, `hit2.png`, `aa.png`.
 - It prints `mean` and `std` luminance per image — use them as objective
   regression numbers (a black frame is `mean=0`, a blown-out one is `mean≈1`).
 - The script resolves the WGSL import graph with `resolveShader`, exactly like

--- a/apps/docs/components/hero/gbuffer.wgsl
+++ b/apps/docs/components/hero/gbuffer.wgsl
@@ -37,6 +37,26 @@ export struct GBufferSample {
   viewDirection: vec3f,
   /** +1 hit from above, -1 from below, 0 no hit. Same sign as `normal.y`. */
   side: f32,
+  /**
+   * Fraction of the pixel this crossing actually covers, 0..1, measured by the
+   * refine pass (`refine.wgsl`) with 16 sub-rays. `1` everywhere outside the
+   * ~2% compressed band, and `1` on the back layer, which is not refined.
+   *
+   * It is a FRACTIONAL AREA: multiply `alpha` by it, never the colour — the
+   * radiance of the covered part does not change because the part is small.
+   */
+  coverage: f32,
+  /**
+   * How much DISK RADIUS this pixel spans at this crossing, in normalized
+   * annulus units (the same scale as `diskUv.x`), and centred on `diskPolar.x`:
+   * the crossing radii of the pixel's ray bundle all lie inside
+   * `diskPolar.x +/- span/2 * (diskOuter - ISCO)`.
+   *
+   * `0` outside the band. Where it is large the pixel is a radial AVERAGE of the
+   * disk, not a sample of it, which is what `sampleAtRadius` + a tap loop in the
+   * frame pass turn it into.
+   */
+  span: f32,
   /** True when this pixel sees the accretion disk. */
   isHit: bool,
   /** True when the ray ended inside the event horizon (render black). */
@@ -72,7 +92,7 @@ fn decodeDirection(encoded: vec2f) -> vec3f {
 }
 
 /** Decodes one crossing. `flags` and `sky` are shared by both layers. */
-fn decodeLayer(plane: vec2f, encodedDirection: vec2f, sky: vec4f, flags: i32, diskOuter: f32) -> GBufferSample {
+fn decodeLayer(plane: vec2f, encodedDirection: vec2f, sky: vec4f, flags: i32, diskOuter: f32, aa: vec2f) -> GBufferSample {
   var sample: GBufferSample;
   let planeRadius = length(plane);
   // The bake only ever writes crossings inside [ISCO, diskOuter] and leaves a
@@ -101,6 +121,8 @@ fn decodeLayer(plane: vec2f, encodedDirection: vec2f, sky: vec4f, flags: i32, di
   sample.rayDirection = sky.xyz;
   sample.viewDirection = direction;
   sample.side = select(0.0, side, isHit);
+  sample.coverage = clamp(aa.x, 0.0, 1.0);
+  sample.span = clamp(aa.y, 0.0, 1.0);
   sample.isHit = isHit;
   sample.isBlackHole = (flags & 1) != 0;
   sample.escaped = (flags & 2) != 0;
@@ -110,12 +132,18 @@ fn decodeLayer(plane: vec2f, encodedDirection: vec2f, sky: vec4f, flags: i32, di
 /**
  * Decodes the four raw G-buffer texels written by `bake.wgsl` into both disk
  * layers. `diskOuter` must be the same disk radius the bake ran with.
+ *
+ * `aa` is the matching texel of the refine pass's target — `(covFront,
+ * spanFront)`, see refine.wgsl. It describes the FRONT crossing only: the back
+ * layer is handed `(1, 0)`, i.e. "fully covered, not compressed", so it decodes
+ * exactly as it did before the AA target existed. Pass `vec2f(1.0, 0.0)` to opt
+ * out entirely.
  */
-export fn decodeGBuffer(hit1: vec2f, hit2: vec2f, sky: vec4f, view: vec4f, diskOuter: f32) -> GBufferLayers {
+export fn decodeGBuffer(hit1: vec2f, hit2: vec2f, sky: vec4f, view: vec4f, diskOuter: f32, aa: vec2f) -> GBufferLayers {
   let flags = i32(sky.w + 0.5);
   var layers: GBufferLayers;
-  layers.front = decodeLayer(hit1, view.xy, sky, flags, diskOuter);
-  layers.back = decodeLayer(hit2, view.zw, sky, flags, diskOuter);
+  layers.front = decodeLayer(hit1, view.xy, sky, flags, diskOuter, aa);
+  layers.back = decodeLayer(hit2, view.zw, sky, flags, diskOuter, vec2f(1.0, 0.0));
   // The bake already guarantees this ordering; enforcing it here too means a
   // second layer can never be shaded without a first one in front of it.
   if (!layers.front.isHit) {
@@ -124,4 +152,36 @@ export fn decodeGBuffer(hit1: vec2f, hit2: vec2f, sky: vec4f, view: vec4f, diskO
     layers.back.normal = vec3f(0.0);
   }
   return layers;
+}
+
+/**
+ * The same crossing, moved to a different DISK RADIUS at the same azimuth.
+ *
+ * This is the tap generator for the frame pass's radial prefilter: where the
+ * refine pass measured a large `span`, one pixel covers a wide range of disk
+ * radii, and the honest value for it is the MEAN of `shadeDisk` over that range
+ * rather than a point sample at whichever radius the centre ray happened to hit.
+ * `shade.wgsl` calls this K times and averages; `disk.wgsl` never learns that it
+ * is being oversampled, which is what keeps the look's ownership intact.
+ *
+ * Only the radial coordinates move. Azimuth, view direction, normal, side and
+ * the flags are properties of the ray bundle and the axisymmetric geometry, so
+ * they are shared by every tap — and because they are, this is exact under
+ * `sceneYaw`: it commutes with `rotateSample`.
+ *
+ * The position is rebuilt from (radius, azimuth) rather than scaled, so it stays
+ * consistent with `diskPolar` after a rotation to within float rounding of the
+ * cos/sin pair the rotation itself used.
+ */
+export fn sampleAtRadius(g: GBufferSample, radius: f32, diskOuter: f32) -> GBufferSample {
+  var moved = g;
+  let clamped = clamp(radius, ISCO, max(diskOuter, ISCO));
+  let azimuth = g.diskPolar.y;
+  moved.position = vec3f(cos(azimuth) * clamped, 0.0, sin(azimuth) * clamped);
+  moved.diskPolar = vec2f(clamped, azimuth);
+  moved.diskUv = vec2f(
+    clamp((clamped - ISCO) / max(diskOuter - ISCO, 0.001), 0.0, 1.0),
+    g.diskUv.y,
+  );
+  return moved;
 }

--- a/apps/docs/components/hero/geodesic.wgsl
+++ b/apps/docs/components/hero/geodesic.wgsl
@@ -1,0 +1,219 @@
+// GEODESIC TRACER — the null-geodesic integrator, shared by the two one-shot
+// passes that need it.
+//
+// INFRASTRUCTURE MODULE — read it, do not edit it. Like `gbuffer.wgsl` it is a
+// pure WGSL module: no @group/@binding, only exported constants, structs and
+// functions. The entry shaders (`bake.wgsl`, `refine.wgsl`) own their bindings
+// and pass everything in.
+//
+// It exists because the ANTIALIASING refine pass has to trace sub-pixel rays
+// with *exactly* the integrator the G-buffer was baked with. A second copy of
+// the Verlet loop would drift the moment either file was tuned, and the whole
+// premise of the AA data (coverage and span of the same ray bundle) depends on
+// the sub-rays and the centre ray coming from one program. The extraction was
+// verbatim and is gated on byte-identical debug renders; see gbuffer.md.
+//
+// Everything here is a one-shot cost: nothing in this file runs per frame.
+
+/** Event horizon radius. The whole scene uses r_s = 1 units. */
+export const HORIZON: f32 = 1.0;
+/** Innermost stable circular orbit = inner edge of the accretion disk. */
+export const ISCO: f32 = 3.0;
+/** Integration budget per ray. Affordable because the bake is one-shot. */
+export const MAX_STEPS: i32 = 768;
+
+/**
+ * One traced ray, in the raw form `bake.wgsl` writes to the G-buffer.
+ *
+ * `hitCount` is the number of recorded crossings of the [ISCO, diskOuter]
+ * annulus (0, 1 or 2, nearest first). `swallowed` / `escaped` are 0 or 1 and are
+ * NOT yet folded: the caller decides what an out-of-steps ray means (the bake
+ * folds it into the shadow — see the comment at the end of `bake.wgsl`).
+ */
+export struct TraceResult {
+  hit1Plane: vec2f,
+  hit1Direction: vec2f,
+  hit2Plane: vec2f,
+  hit2Direction: vec2f,
+  hitCount: i32,
+  swallowed: f32,
+  escaped: f32,
+  /** Direction the ray is travelling when the loop ends; the sky lookup. */
+  finalVelocity: vec3f,
+}
+
+/** A camera ray for one point on the screen, in world space. */
+export struct CameraRay {
+  position: vec3f,
+  velocity: vec3f,
+}
+
+/**
+ * Where a ray is declared to have reached infinity. Pushed out from 30 to
+ * 120 r_s: the deflection is already converged at 30 (raising it to 120 moves
+ * the outgoing direction by 0.002 deg at b = 3), but the far field is where the
+ * adaptive step below buys its budget back, so a farther cutoff costs almost no
+ * extra steps and makes the direction unambiguously asymptotic.
+ */
+export fn escapeRadiusFor(orbitRadius: f32) -> f32 {
+  return max(120.0, orbitRadius + 8.0);
+}
+
+/**
+ * Packs a unit direction into 2 floats: y, plus the azimuth of the xz part.
+ * Lossless enough that f16 storage beats the old 3x f16 cartesian form, and it
+ * keeps the sign of y exact, which is what `side` is reconstructed from.
+ */
+export fn encodeDirection(direction: vec3f) -> vec2f {
+  return vec2f(direction.y, atan2(direction.z, direction.x));
+}
+
+fn geodesicAcceleration(position: vec3f, velocity: vec3f) -> vec3f {
+  let r2 = max(dot(position, position), 0.0001);
+  let angularMomentum = cross(position, velocity);
+  let h2 = dot(angularMomentum, angularMomentum);
+  return -1.5 * h2 * position / (r2 * r2 * sqrt(r2));
+}
+
+/**
+ * Screen point -> world camera ray. `uv` is the fullscreen-quad coordinate,
+ * (0,0) at the TOP-LEFT of the target.
+ *
+ * Both one-shot passes call this, and the refine pass calls it with SUB-PIXEL
+ * offsets, which is the whole reason it is a function: the sub-rays have to come
+ * out of the same NDC/basis arithmetic as the centre ray or the measured
+ * coverage would be of a slightly different ray bundle than the G-buffer's.
+ */
+export fn cameraRay(
+  uv: vec2f,
+  resolution: vec2f,
+  yaw: f32,
+  pitch: f32,
+  orbitRadius: f32,
+  fov: f32,
+  centerY: f32,
+) -> CameraRay {
+  let aspect = resolution.x / max(resolution.y, 1.0);
+  // ORIENTATION — vgpu's generated fullscreen vertex shader emits uv (0,0) at the
+  // TOP-LEFT of the target and (1,1) at the bottom-right (the WebGPU texture
+  // convention). Camera space is +Y up, so uv.y MUST be flipped here; feeding
+  // `uv.y * 2 - 1` straight into `up` renders the whole scene upside down.
+  // Every other pass is a 1:1 pass-through (shade textureLoads uv*dims), so this
+  // is the single place the convention is converted, and it fixes the browser
+  // and the node harness at once. See gbuffer.md.
+  let ndc = vec2f(uv.x * 2.0 - 1.0, 1.0 - uv.y * 2.0);
+  // centerY shifts the image vertically, in NDC units: positive moves the black
+  // hole UP on screen. Kept at 0 now that the canvas covers the whole hero.
+  let screen = (ndc - vec2f(0.0, centerY)) * vec2f(aspect, 1.0);
+
+  let clampedPitch = clamp(pitch, -1.319, 1.319);
+  let cameraPosition = vec3f(
+    sin(yaw) * cos(clampedPitch) * orbitRadius,
+    sin(clampedPitch) * orbitRadius,
+    cos(yaw) * cos(clampedPitch) * orbitRadius,
+  );
+  let forward = normalize(vec3f(0.0) - cameraPosition);
+  let right = normalize(cross(forward, vec3f(0.0, 1.0, 0.0)));
+  let up = cross(right, forward);
+
+  var ray: CameraRay;
+  ray.position = cameraPosition;
+  ray.velocity = normalize(forward * fov + right * screen.x + up * screen.y);
+  return ray;
+}
+
+/**
+ * Integrates one null geodesic and records the first two crossings of the
+ * [ISCO, diskOuter] annulus.
+ *
+ * `escapeRadius` is passed in rather than derived from `|position|` so the
+ * caller's exact float value is used — this function must be bit-for-bit the
+ * loop that produced the shipped G-buffer.
+ *
+ * The ray is NOT terminated at a disk hit: it keeps marching, so the final
+ * velocity describes what is *behind* both disk layers, which is what lets the
+ * disk shader be semi-transparent and let stars bleed through its fringes.
+ */
+export fn traceRay(cameraPosition: vec3f, initialVelocity: vec3f, diskOuter: f32, escapeRadius: f32) -> TraceResult {
+  var position = cameraPosition;
+  var velocity = initialVelocity;
+
+  var result: TraceResult;
+  result.hit1Plane = vec2f(0.0);
+  result.hit1Direction = vec2f(0.0);
+  result.hit2Plane = vec2f(0.0);
+  result.hit2Direction = vec2f(0.0);
+  result.hitCount = 0;
+  result.swallowed = 0.0;
+  result.escaped = 0.0;
+
+  for (var stepIndex = 0; stepIndex < MAX_STEPS; stepIndex++) {
+    let radius = length(position);
+    if (radius < HORIZON * 1.004) {
+      result.swallowed = 1.0;
+      break;
+    }
+    if (radius > escapeRadius && dot(position, velocity) > 0.0) {
+      result.escaped = 1.0;
+      break;
+    }
+
+    // Adaptive to gravity: finer near the horizon where the geodesic curves
+    // hardest. Much finer than the live version could afford (one-shot cost).
+    //
+    // The ceiling grows LINEARLY with radius past r = 6 instead of staying
+    // pinned at 0.075. The acceleration falls off as h^2 / r^5, so out there a
+    // 0.075 step resolves a straight line 20x more finely than needed and the
+    // fixed cap was burning ~20% of MAX_STEPS on the flight in and out. Inside
+    // r = 6 the factor is exactly 1, so the strong-field part of every geodesic
+    // — everything that produces the deflection, the shadow edge and the disk
+    // crossings — integrates bit-for-bit as before. Measured effect of the
+    // relaxation (evidence/geo3.mjs): deflection unchanged to <= 0.03 deg, and
+    // the freed budget shrinks the out-of-steps band from 8.6 px to 2.3 px at
+    // 720p.
+    let stepSize = clamp((radius - HORIZON) * 0.035, 0.0045, 0.075 * max(1.0, radius / 6.0));
+
+    let previousPosition = position;
+    let previousVelocity = velocity;
+
+    // Velocity-Verlet style integration of the light geodesic.
+    let acceleration0 = geodesicAcceleration(position, velocity);
+    velocity += acceleration0 * (0.5 * stepSize);
+    position += velocity * stepSize;
+    let acceleration1 = geodesicAcceleration(position, velocity);
+    velocity += acceleration1 * (0.5 * stepSize);
+    velocity = normalize(velocity);
+
+    // Hard disk: exact intersection with the y=0 annulus. No slab, no volume,
+    // no oversampling heuristics -> no concentric ring aliasing either.
+    //
+    // The crossing test is a strict side change rather than `prevY * y <= 0`:
+    // now that two hits are recorded, a step that lands exactly on y = 0 would
+    // otherwise satisfy the product test twice and register the same crossing
+    // as both hits. Folding y == 0 into the positive side makes every sign flip
+    // fire exactly once, and keeps the interpolation denominator non-zero.
+    if (result.hitCount < 2) {
+      let previousSide = select(-1.0, 1.0, previousPosition.y >= 0.0);
+      let currentSide = select(-1.0, 1.0, position.y >= 0.0);
+      if (previousSide != currentSide) {
+        let t = clamp(previousPosition.y / (previousPosition.y - position.y), 0.0, 1.0);
+        let crossing = mix(previousPosition, position, t);
+        let planeRadius = length(crossing.xz);
+        if (planeRadius >= ISCO && planeRadius <= diskOuter) {
+          let direction = encodeDirection(normalize(mix(previousVelocity, velocity, t)));
+          if (result.hitCount == 0) {
+            result.hit1Plane = crossing.xz;
+            result.hit1Direction = direction;
+          } else {
+            result.hit2Plane = crossing.xz;
+            result.hit2Direction = direction;
+          }
+          result.hitCount += 1;
+        }
+      }
+    }
+  }
+
+  result.finalVelocity = velocity;
+  return result;
+}

--- a/apps/docs/components/hero/hero-black-hole.tsx
+++ b/apps/docs/components/hero/hero-black-hole.tsx
@@ -314,7 +314,15 @@ export function HeroBlackHole() {
         'disk density': 5,
         'sky footprint / prefilter': 6,
         'second disk hit': 7,
+        'ring aa (cov/span/taps)': 8,
       }).name('g-buffer view');
+      // A/B for the photon-ring antialiasing. `off` is exactly the pre-AA image:
+      // the one-shot refine pass still runs, the frame pass just ignores its
+      // coverage/span target, so this is a pure shading switch with no re-bake.
+      debug.add(settings, 'aa', {
+        'off (point sampled)': 0,
+        'on (coverage + radial prefilter)': 1,
+      }).name('photon-ring aa');
       // A/B for the second baked disk crossing: 1 shows what the renderer looked
       // like when a ray stopped at its first hit, 2 is the intended result.
       debug.add(settings, 'diskLayers', {

--- a/apps/docs/components/hero/refine.wgsl
+++ b/apps/docs/components/hero/refine.wgsl
@@ -1,0 +1,180 @@
+// REFINE PASS — one-shot sub-pixel coverage/span of the photon ring.
+//
+// Runs immediately after the bake, in the same throttled `if (bake)` block, and
+// never per frame. Reads the G-buffer the bake just wrote, finds the ~2% of
+// pixels where the lensed disk image is compressed below one pixel, and traces
+// 16 sub-rays there with the SAME integrator (`geodesic.wgsl`) to measure two
+// numbers the per-frame pass cannot recover on its own:
+//
+//   covFront  fraction of the pixel covered by the FIRST disk crossing;
+//   spanFront how much DISK RADIUS the pixel spans at that crossing.
+//
+// WHY THIS PASS EXISTS. At the shipped defaults the whole [ISCO, diskOuter]
+// annulus is squeezed into ~1.5 px at screen radius r ~ 190 px (720p): measured
+// on debug view 2, `diskUv.x` goes 0.12 -> 0.71 between two ADJACENT pixels at
+// constant azimuth. One ray per pixel therefore draws a random radius out of the
+// whole annulus, and every analytic softness in disk.wgsl (`innerEdge`,
+// `outerEdge`, `flux`) is soft in DISK space and a hard step in SCREEN space
+// there. The result is a dotted 1 px wire whose brightness jitters 10x between
+// neighbouring degrees of azimuth, and a frame that is missing ~24% of the light
+// a 3x supersampled reference collects. See gbuffer.md, "AA target".
+//
+// WHY IT IS A SEPARATE PASS AND A SEPARATE TARGET. The bake's MRT already spends
+// exactly 32 B/sample, which is all WebGPU guarantees
+// (`maxColorAttachmentBytesPerSample`), so a 5th attachment is not available. A
+// second pass with its own 2 B/px `rg8unorm` target is additive, deletable, and
+// costs the frame pass one extra texel fetch.
+//
+// COST. One-shot, and amortised the same way the bake is (the 200 ms re-bake
+// throttle, renderer.ts). 25 texel loads per pixel for the mask, plus 16
+// geodesics on the ~2% of pixels that fail it. The refined pixels are the
+// EXPENSIVE near-b_crit geodesics, so the pass is roughly a third of the bake in
+// practice; if a geometry drag ever feels sticky, cut SUB_STEPS 4 -> 3 (9
+// sub-rays) before touching MAX_STEPS — a 2x reference is already close to a 3x
+// one, so 16 sub-rays is more than converged.
+
+import { ISCO, cameraRay, escapeRadiusFor, traceRay } from "./geodesic.wgsl";
+
+/**
+ * Same fields as `Bake` in bake.wgsl, in the same order: `renderer.ts` uploads
+ * one geometry description to both passes, so they can never disagree about the
+ * camera the sub-rays are traced from.
+ */
+struct Refine {
+  resolution: vec2f,
+  yaw: f32,
+  pitch: f32,
+  orbitRadius: f32,
+  diskOuter: f32,
+  fov: f32,
+  centerY: f32,
+}
+
+@group(0) @binding(0) var<uniform> refine: Refine;
+/** First-crossing plane position, from the bake pass. `(0,0)` = no hit. */
+@group(0) @binding(1) var gHit1: texture_2d<f32>;
+/** Only `w` is read here: flag bit 0 = the ray ended in the shadow. */
+@group(0) @binding(2) var gSky: texture_2d<f32>;
+
+/** Sub-rays per axis inside one pixel: 4x4 = 16 samples. */
+const SUB_STEPS: i32 = 4;
+/**
+ * Half-width of the neighbourhood the boundary test looks at, in pixels.
+ *
+ * 5x5 (radius 2), not 3x3: the ring is thinner than a pixel, so a pixel whose
+ * CENTRE ray misses it entirely must still be refined or it stays a hole in the
+ * wire. Dilating the mask by 2 px is cheap one-shot insurance (25 loads).
+ */
+const MASK_RADIUS: i32 = 2;
+/**
+ * Radial-gradient trigger, in normalized annulus units. A pixel whose neighbour
+ * sits 12% of the annulus away at the same azimuth is already in the compressed
+ * regime even if both of them hit, which is the case coverage alone would miss.
+ */
+const GRADIENT_LIMIT: f32 = 0.12;
+
+/** The bake writes a plain (0,0) for "no crossing"; the annulus starts at ISCO. */
+fn isHitAt(plane: vec2f) -> bool {
+  return length(plane) > ISCO * 0.5;
+}
+
+@fragment fn fs_main(@location(0) uv: vec2f) -> @location(0) vec2f {
+  let dimensions = vec2i(textureDimensions(gHit1, 0));
+  let texel = vec2i(clamp(uv * refine.resolution, vec2f(0.0), refine.resolution - vec2f(1.0)));
+  let annulus = max(refine.diskOuter - ISCO, 0.001);
+
+  let centerPlane = textureLoad(gHit1, texel, 0).xy;
+  let centerHit = isHitAt(centerPlane);
+  let centerHole = (i32(textureLoad(gSky, texel, 0).w + 0.5) & 1) != 0;
+  let centerRadiusNorm = clamp((length(centerPlane) - ISCO) / annulus, 0.0, 1.0);
+
+  // --- band detection ---------------------------------------------------------
+  // Mixed state in the 5x5 neighbourhood: a different hit/miss answer, a
+  // different shadow flag, or a steep radial gradient. Any of the three means
+  // the pixel's ray bundle straddles something the single centre ray cannot
+  // describe.
+  var boundary = false;
+  for (var dy = -MASK_RADIUS; dy <= MASK_RADIUS; dy++) {
+    for (var dx = -MASK_RADIUS; dx <= MASK_RADIUS; dx++) {
+      let neighbor = clamp(texel + vec2i(dx, dy), vec2i(0), dimensions - vec2i(1));
+      let plane = textureLoad(gHit1, neighbor, 0).xy;
+      let hit = isHitAt(plane);
+      let hole = (i32(textureLoad(gSky, neighbor, 0).w + 0.5) & 1) != 0;
+      if (hit != centerHit || hole != centerHole) {
+        boundary = true;
+      }
+      if (hit && centerHit) {
+        let radiusNorm = clamp((length(plane) - ISCO) / annulus, 0.0, 1.0);
+        if (abs(radiusNorm - centerRadiusNorm) > GRADIENT_LIMIT) {
+          boundary = true;
+        }
+      }
+    }
+  }
+
+  // Everything outside the band is exactly what it is today: full coverage on a
+  // hit, none on a miss, and zero span so the frame pass takes its single-tap
+  // path. `1.0` and `0.0` are both exact in rg8unorm, so a non-band pixel
+  // multiplies its alpha by a literal 1 and stays bit-for-bit unchanged.
+  if (!boundary) {
+    return vec2f(select(0.0, 1.0, centerHit), 0.0);
+  }
+
+  // --- 16 sub-rays ------------------------------------------------------------
+  // A regular 4x4 stratified grid inside the pixel, deterministic and identical
+  // for every pixel: a fixed pattern makes the residual quantisation of
+  // `coverage` vary SMOOTHLY along the ring, which is the whole point of the
+  // exercise, where a per-pixel jitter would trade a bias for pixel-to-pixel
+  // noise in exactly the band being fixed.
+  let escapeRadius = escapeRadiusFor(refine.orbitRadius);
+  var hits = 0.0;
+  var minRadius = 1e9;
+  var maxRadius = -1e9;
+  // Shadow coverage is deliberately NOT accumulated: measured, the shadow/sky
+  // step is 0 -> 4/255, i.e. invisible, and consuming a fractional shadow would
+  // composite stars from the truncated `gSky.xyz` of a swallowed ray — new
+  // speckle in a 1 px rim, plus a perturbed derivative field under the star
+  // prefilter. If it is ever wanted, it needs an escaped sub-sample's DIRECTION
+  // stored alongside it, and a third channel. See gbuffer.md.
+  for (var sy = 0; sy < SUB_STEPS; sy++) {
+    for (var sx = 0; sx < SUB_STEPS; sx++) {
+      let offset = (vec2f(f32(sx), f32(sy)) + vec2f(0.5)) / f32(SUB_STEPS);
+      let subUv = (vec2f(texel) + offset) / refine.resolution;
+      let ray = cameraRay(subUv, refine.resolution, refine.yaw, refine.pitch, refine.orbitRadius, refine.fov, refine.centerY);
+      let traced = traceRay(ray.position, ray.velocity, refine.diskOuter, escapeRadius);
+      if (traced.hitCount > 0) {
+        let radius = length(traced.hit1Plane);
+        hits += 1.0;
+        minRadius = min(minRadius, radius);
+        maxRadius = max(maxRadius, radius);
+      }
+    }
+  }
+
+  let coverage = hits / f32(SUB_STEPS * SUB_STEPS);
+  if (hits < 0.5) {
+    return vec2f(0.0, 0.0);
+  }
+
+  // --- span, measured SYMMETRICALLY ABOUT THE CENTRE RAY ----------------------
+  // The frame pass places its taps on [r0 - span/2, r0 + span/2], anchored at the
+  // centre ray's own radius `r0`, because that is the only radius it has. So the
+  // useful quantity is not (rmax - rmin) but the smallest interval CENTRED ON r0
+  // that contains every sub-ray crossing: with (rmax - rmin), a centre ray
+  // sitting at one end of the range would shift the whole tap set off the
+  // measured span by up to half of it and bias the radial mean (the plan's
+  // risk 2). The price is a span up to 2x wider than the raw range, i.e. a
+  // slightly wider prefilter — never a fade, and never a shifted one.
+  //
+  // When the centre ray missed the disk entirely there is no r0 and no radius to
+  // rebuild the sample from, so the frame pass cannot shade the pixel at all;
+  // the raw range is written for the diagnostic (debug view 8) instead.
+  var span: f32;
+  if (centerHit) {
+    let r0 = length(centerPlane);
+    span = 2.0 * max(abs(maxRadius - r0), abs(r0 - minRadius));
+  } else {
+    span = maxRadius - minRadius;
+  }
+  return vec2f(coverage, clamp(span / annulus, 0.0, 1.0));
+}

--- a/apps/docs/components/hero/renderer.ts
+++ b/apps/docs/components/hero/renderer.ts
@@ -10,6 +10,7 @@ type VgpuApi = typeof import('vgpu');
 
 import bakeWgsl from './bake.wgsl';
 import { createNoiseVolume, NOISE_VOLUME_SIZE, noiseVolumeSampler } from './noise-volume.mjs';
+import refineWgsl from './refine.wgsl';
 import shadeWgsl from './shade.wgsl';
 
 /**
@@ -72,8 +73,18 @@ export interface HeroSettings {
   centerY: number;
 
   // --- Frame-only settings. No re-bake. ---
-  /** 0 = final image, 1..7 = G-buffer debug views. */
+  /** 0 = final image, 1..8 = G-buffer debug views. */
   debugView: number;
+  /**
+   * Photon-ring antialiasing: 1 consumes the one-shot refine pass's
+   * coverage/span target, 0 ignores it. A/B knob, not a look setting — 1 is the
+   * intended result.
+   *
+   * Frame-only despite depending on baked data: the refine pass runs with the
+   * bake either way (it is one-shot and throttled with it), so flipping this
+   * costs one uniform and no re-bake.
+   */
+  aa: number;
   /**
    * How many baked disk crossings to composite: 1 = front band only,
    * 2 = also the second, lensed image hidden behind it. A/B knob, not a look
@@ -110,6 +121,7 @@ export function defaultHeroSettings(): HeroSettings {
     centerY: 0,
     debugView: 0,
     diskLayers: 2,
+    aa: 1,
     // ~8.6 degrees each way: enough to read as a living, turnable scene without
     // ever swinging the disk far enough to look like a camera cut.
     mouseYaw: 0.15,
@@ -367,6 +379,11 @@ type Output = Surface | Target;
 
 interface Effects {
   bake: Effect;
+  /**
+   * One-shot sub-pixel coverage/span of the photon ring; runs right after the
+   * bake, in the same throttled block, and never per frame. See refine.wgsl.
+   */
+  refine: Effect;
   /** Compiled and warmed at init, so the first measured frame never pays for it. */
   shade: Effect;
   /**
@@ -387,6 +404,16 @@ type NoiseVolume = ReturnType<typeof createNoiseVolume>;
 interface Targets {
   /** G-buffer written once by the bake pass (MRT: hit1 / hit2 / sky / view). */
   gbuffer: Target;
+  /**
+   * Photon-ring AA data, written once by the refine pass: 2 B/px of
+   * (coverage, span) for the front disk crossing.
+   *
+   * A separate target and a separate pass rather than a 5th bake attachment,
+   * because `maxColorAttachmentBytesPerSample` is only guaranteed to be 32 and
+   * the G-buffer already spends exactly 32. Created, resized and destroyed with
+   * the G-buffer — it is indexed 1:1 by the same texel.
+   */
+  aa: Target;
 }
 
 /**
@@ -422,6 +449,15 @@ const RENDER_DPR = 1;
  * stored as (y, azimuth) pairs and lose nothing.
  */
 const GBUFFER_FORMATS: readonly GPUTextureFormat[] = ['rg32float', 'rg32float', 'rgba16float', 'rgba16float'];
+/**
+ * Photon-ring AA target: 2 bytes per pixel, (coverage, span).
+ *
+ * `rg8unorm`, not a float format: coverage is 16 sub-rays (5 bits would do) and
+ * span is a filter width, where 1/255 of the annulus is far below what the disk
+ * look can resolve. It is also the smallest format that keeps 1.0 EXACT, which is
+ * what makes every non-band pixel bit-for-bit unchanged.
+ */
+const AA_FORMAT: GPUTextureFormat = 'rg8unorm';
 const CLEAR: readonly [number, number, number, number] = [0, 0, 0, 1];
 
 export function createRenderer(options: HeroRendererOptions): HeroRenderer {
@@ -919,6 +955,7 @@ export function createRenderer(options: HeroRendererOptions): HeroRenderer {
 function createEffects(vgpu: VgpuApi, gpu: Gpu, label: string): Effects {
   return {
     bake: vgpu.effect(gpu, bakeWgsl, { label: `${label}-bake` }),
+    refine: vgpu.effect(gpu, refineWgsl, { label: `${label}-refine` }),
     shade: vgpu.effect(gpu, shadeWgsl, { label: `${label}-shade` }),
     // Built and uploaded here, synchronously, before the first bind: the
     // lattice is a pure function of its size, so there is nothing to await and
@@ -936,11 +973,13 @@ function createTargets(vgpu: VgpuApi, gpu: Gpu, size: readonly [number, number],
       colors: GBUFFER_FORMATS.map((format) => ({ format })),
       label: `${label}-gbuffer`,
     }),
+    aa: vgpu.target(gpu, { size: full, colors: [{ format: AA_FORMAT }], label: `${label}-aa` }),
   };
 }
 
 function destroyTargets(targets: Targets): void {
   destroyTarget(targets.gbuffer);
+  destroyTarget(targets.aa);
 }
 
 function destroyTarget(target: Target | undefined): void {
@@ -949,13 +988,24 @@ function destroyTarget(target: Target | undefined): void {
 
 function setBindings(effects: Effects, targets: Targets): void {
   const [hit1, hit2, sky, view] = targets.gbuffer.colors;
+  const [aa] = targets.aa.colors;
   effects.bake.set({ bake: { resolution: targets.gbuffer.size } });
+  // The refine pass reads the two G-buffer channels it needs (first crossing +
+  // flags) and writes the AA target. Same geometry uniform as the bake, uploaded
+  // by `setBakeUniforms`, so the sub-rays can never come from a different camera
+  // than the centre rays.
+  effects.refine.set({
+    gHit1: hit1,
+    gSky: sky,
+    refine: { resolution: targets.gbuffer.size },
+  });
   {
     effects.shade.set({
       gHit1: hit1,
       gHit2: hit2,
       gSky: sky,
       gView: view,
+      gAa: aa,
       // Resize-invariant, but re-bound with the rest: `setBindings` rebuilds the
       // whole shade bind group when the G-buffer is recreated, and a bind group
       // is all-or-nothing.
@@ -969,7 +1019,7 @@ function setBindings(effects: Effects, targets: Targets): void {
 }
 
 function setBakeUniforms(effects: Effects, targets: Targets, settings: HeroSettings): void {
-  effects.bake.set({ bake: {
+  const geometry = {
     resolution: targets.gbuffer.size,
     yaw: 0,
     pitch: settings.cameraY,
@@ -977,7 +1027,13 @@ function setBakeUniforms(effects: Effects, targets: Targets, settings: HeroSetti
     diskOuter: settings.diskRadius,
     fov: settings.fov,
     centerY: settings.centerY,
-  } });
+  };
+  effects.bake.set({ bake: geometry });
+  // ONE geometry description, uploaded to both one-shot passes: `Refine` mirrors
+  // `Bake` field for field precisely so this cannot drift. The AA target is
+  // therefore always regenerated by the same bake that invalidated it — a rebake
+  // with a different yaw or diskRadius can never leave stale coverage behind.
+  effects.refine.set({ refine: geometry });
 }
 
 function setShadeUniforms(
@@ -994,6 +1050,7 @@ function setShadeUniforms(
       diskOuter: settings.diskRadius,
       debugView: settings.debugView,
       diskLayers: settings.diskLayers,
+      aa: settings.aa,
       // Active rotation of the SCENE (camera yaw would be -sceneYaw). Smoothed
       // from the pointer by the render loop; the bake never sees it.
       sceneYaw,
@@ -1059,6 +1116,7 @@ function summarizeMeasurement(m: Measurement, resolution: readonly [number, numb
 async function prewarm(effects: Effects, targets: Targets, output: Output): Promise<void> {
   await Promise.all([
     effects.bake.compile(targets.gbuffer),
+    effects.refine.compile(targets.aa),
     // Compiled against the OUTPUT format (the swap chain), not an HDR target:
     // shade is the last pass and writes display-referred unorm.
     effects.shade.compile({ colors: [output.format] }),
@@ -1075,8 +1133,16 @@ function renderChain(
   /** Set only while `measure()` is sampling; otherwise the pass is untimed. */
   timer?: TimerSpan,
 ): void {
-  if (bake) frame.pass({ target: targets.gbuffer, clear: CLEAR }, (pass) => pass.draw(effects.bake));
-  // Two passes, not three: shade reads the G-buffer and writes the swap chain.
+  if (bake) {
+    frame.pass({ target: targets.gbuffer, clear: CLEAR }, (pass) => pass.draw(effects.bake));
+    // The refine pass reads what the bake just wrote, so it MUST stay in this
+    // block and after it: same throttle, same invalidation, and — because
+    // `renderFrame` suppresses the bake while `measure()` is sampling — the same
+    // guarantee that none of its cost is attributed to the shade pass.
+    frame.pass({ target: targets.aa, clear: CLEAR }, (pass) => pass.draw(effects.refine));
+  }
+  // Two passes per frame, still: shade reads the G-buffer plus 2 B/px of AA data
+  // and writes the swap chain. The two above are one-shot.
   frame.pass({ target: output, clear: CLEAR, timer }, (pass) => pass.draw(effects.shade));
 }
 

--- a/apps/docs/components/hero/shade.wgsl
+++ b/apps/docs/components/hero/shade.wgsl
@@ -19,7 +19,7 @@
 // No raymarching happens here: the geodesics were solved once by bake.wgsl.
 // See gbuffer.md for the full contract.
 
-import { GBufferSample, GBufferLayers, decodeGBuffer, ISCO, PI_CONST, TAU } from "./gbuffer.wgsl";
+import { GBufferSample, GBufferLayers, decodeGBuffer, sampleAtRadius, ISCO, PI_CONST, TAU } from "./gbuffer.wgsl";
 import { DiskLook, DiskSample, shadeDisk, SHEAR_PERIOD } from "./disk.wgsl";
 import { StarLook, shadeStars, starPrefilterRatio } from "./stars.wgsl";
 
@@ -29,8 +29,18 @@ struct Shade {
   time: f32,
   /** Outer disk radius the G-buffer was baked with. */
   diskOuter: f32,
-  /** 0 = final image, 1..7 = G-buffer debug views (see gbuffer.md). */
+  /** 0 = final image, 1..8 = G-buffer debug views (see gbuffer.md). */
   debugView: f32,
+  /**
+   * Photon-ring antialiasing: 1 consumes the refine pass's coverage/span target,
+   * 0 ignores it completely.
+   *
+   * The A/B knob, and it is a real one: at 0 every pixel is shaded exactly as it
+   * was before the AA target existed (`coverage` is forced to a literal 1 and the
+   * tap loop is never entered), so the two settings differ only inside the ~2% of
+   * pixels the refine pass flagged.
+   */
+  aa: f32,
   /** 1 = front disk crossing only, 2 = also composite the second crossing. */
   diskLayers: f32,
   /**
@@ -104,14 +114,37 @@ const SATURATION: f32 = 0.0;
  */
 @group(0) @binding(7) var noiseVolume: texture_3d<f32>;
 @group(0) @binding(8) var noiseSampler: sampler;
+/**
+ * Photon-ring AA data from the one-shot refine pass: `rg8unorm`, x = coverage of
+ * the front crossing, y = the disk radius the pixel spans there (normalized
+ * annulus units, centred on the pixel's own radius). See refine.wgsl.
+ *
+ * 2 B/px on top of the 32 B/px the G-buffer already costs this pass, read with
+ * the same 1:1 `textureLoad` as everything else. It is a separate target rather
+ * than a 5th bake attachment because the bake's MRT already spends the full
+ * 32 B/sample WebGPU guarantees.
+ */
+@group(0) @binding(9) var gAa: texture_2d<f32>;
 
 /**
  * Screen-space footprint of the disk noise for one layer, in noise units per
- * pixel. MUST be called from uniform control flow: it takes derivatives, which
- * are undefined inside the `isHit` branches, so both layers are measured for
- * every pixel and the results are only *used* on hits.
+ * pixel, SPLIT INTO ITS TWO AXES: `x` = the angular term (`disk.stretch` x the
+ * azimuth a pixel covers), `y` = the radial term (`disk.detail` x the disk radius
+ * a pixel covers).
+ *
+ * MUST be called from uniform control flow: it takes derivatives, which are
+ * undefined inside the `isHit` branches, so both layers are measured for every
+ * pixel and the results are only *used* on hits.
+ *
+ * The two axes are kept apart because the ring prefilter needs exactly one of
+ * them. Inside the compressed band the radial term is enormous (the pixel spans
+ * most of the annulus) and it is the term each TAP replaces with its own, much
+ * narrower slice — while the angular term is the pixel's and stays the pixel's.
+ * Collapsing them here first, and then handing the collapsed value to the taps,
+ * would prefilter every tap over the whole span and flatten precisely the
+ * emission crests the tap loop exists to average.
  */
-fn diskFootprint(g: GBufferSample) -> f32 {
+fn diskFootprintAxes(g: GBufferSample) -> vec2f {
   let angular = max(disk.stretch, 0.05);
   let noiseAngle = g.diskPolar.y - min(shade.time, SHEAR_PERIOD * 0.5) * (disk.speed * 0.55 / pow(g.diskPolar.x, 1.5));
   let noiseCoords = vec3f(
@@ -119,10 +152,18 @@ fn diskFootprint(g: GBufferSample) -> f32 {
     sin(noiseAngle) * angular,
     g.diskPolar.x * disk.detail,
   );
-  return min(
-    max(max(fwidth(noiseCoords.x), fwidth(noiseCoords.y)), fwidth(noiseCoords.z)),
-    4.0,
+  return vec2f(
+    max(fwidth(noiseCoords.x), fwidth(noiseCoords.y)),
+    fwidth(noiseCoords.z),
   );
+}
+
+/**
+ * The scalar `shadeDisk` takes: the wider of the two axes, capped. Unchanged —
+ * this is bit-for-bit the value `diskFootprint` returned before it was split.
+ */
+fn diskFootprint(axes: vec2f) -> f32 {
+  return min(max(axes.x, axes.y), 4.0);
 }
 
 /**
@@ -176,6 +217,117 @@ fn rotateLayers(layers: GBufferLayers, angle: f32) -> GBufferLayers {
   rotated.front = rotateSample(layers.front, angle);
   rotated.back = rotateSample(layers.back, angle);
   return rotated;
+}
+
+// --- Photon-ring radial prefilter --------------------------------------------
+//
+// The artifact this exists for is NOT a jaggy silhouette. At screen radius
+// r ~ 190 px (720p) the whole [ISCO, diskOuter] annulus is compressed into
+// ~1.5 px, so one ray per pixel draws a random disk radius out of the entire
+// annulus: measured on debug view 2, `diskUv.x` jumps 0.12 -> 0.71 between two
+// adjacent pixels. Every softness in disk.wgsl (`innerEdge`, `outerEdge`, `flux`)
+// is soft in DISK space and therefore a hard step in SCREEN space there. The
+// visible result is a dotted 1 px wire whose brightness jitters 10x between
+// neighbouring degrees of azimuth (measured tangential profile: min 9, max 112,
+// against 28..70 for a 3x supersampled reference).
+//
+// Coverage alone does not fix that — it makes the wire continuous and leaves it
+// jittering. The fix is to PREFILTER: where the refine pass measured a large
+// radial span, evaluate `shadeDisk` at K radii across the span and average, which
+// is the disk's analogue of `starPrefilterRatio`. Radiance is conserved; do not
+// fade the ring out, ever (gbuffer.md documents `starLod` as exactly that
+// mistake).
+
+/**
+ * Taps across the measured span. 6, not 8: the sub-pixel span is at most the
+ * whole annulus and 6 samples of a smooth radial profile already put the residual
+ * well under the 8-bit output quantisation, while the thermal budget scales
+ * linearly with this number. Drop to 4 before dropping the whole loop.
+ */
+const AA_TAPS: i32 = 6;
+/**
+ * Span (normalized annulus units) above which a pixel is treated as compressed.
+ *
+ * Below it the single centre sample is already representative and the taps would
+ * be six evaluations of nearly the same radius. It is also the static gate on the
+ * thermal cost: on the shipped defaults ~1.4% of pixels clear it.
+ */
+const AA_SPAN_MIN: f32 = 0.15;
+
+/**
+ * `shadeDisk` for the front layer, radially prefiltered where the pixel is
+ * compressed.
+ *
+ * Mean of `color * alpha` and mean of `alpha` are accumulated SEPARATELY and
+ * recombined, because emission-absorption is linear in exactly those two (see
+ * `compositeDisk`): averaging `color` instead would weight the transparent taps
+ * as heavily as the opaque ones and wash the ring out.
+ *
+ * Taps that fall outside [ISCO, diskOuter] are dropped from BOTH the sum and the
+ * divisor rather than clamped: the fractional area of the annulus inside the pixel
+ * is already carried by `coverage`, so clamping would pile weight onto the two
+ * edge radii and bias the mean toward them.
+ *
+ * `footprint` comes from the caller's uniform prologue — no derivative is taken
+ * in here, and none can be: this runs in non-uniform control flow. `shadeDisk`
+ * samples the noise volume through `textureSampleLevel` (explicit LOD), which is
+ * legal here for the same reason the existing `isHit` branches are.
+ */
+fn shadeFront(g: GBufferSample, footprint: f32, angularFootprint: f32) -> DiskSample {
+  let annulus = max(shade.diskOuter - ISCO, 0.001);
+  let spanWorld = g.span * annulus;
+  if (shade.aa < 0.5 || g.span <= AA_SPAN_MIN) {
+    return shadeDisk(g, disk, shade.time, footprint, noiseVolume, noiseSampler);
+  }
+
+  // Per-tap footprint, EMPHATICALLY NOT the pixel's. `disk.wgsl` inverts
+  // `footprint = max(detail * dRadius, stretch * dAngle)` for its anisotropic
+  // pixel ellipse, so the footprint is rebuilt here from the same two terms with
+  // the radial one replaced: each tap stands for a slice `spanWorld / K` wide, not
+  // for the whole span, while the angular term is still the pixel's own measured
+  // one (`frontAxes.x`, from uniform control flow).
+  //
+  // Passing the pixel's collapsed `footprint` here instead — which is what the
+  // radial term of the fwidth measurement dominates inside the band — measures
+  // MEASURABLY worse: it prefilters every tap over the entire annulus, and because
+  // the disk's emissivity is a 5th power of the noise field, flattening the field
+  // destroys the crest energy the taps are supposed to be averaging. Measured on
+  // the shipped defaults: the ring band's mean luma came out at 0.0324 (the
+  // un-antialiased value) with the collapsed footprint, versus a 0.0425 reference.
+  let tapFootprint = min(max(angularFootprint, max(disk.detail, 0.05) * (spanWorld / f32(AA_TAPS))), 4.0);
+  let step = spanWorld / f32(AA_TAPS);
+  let start = g.diskPolar.x - spanWorld * 0.5;
+
+  var sumEmission = vec3f(0.0);
+  var sumAlpha = 0.0;
+  var sumDensity = 0.0;
+  var taps = 0.0;
+  for (var i = 0; i < AA_TAPS; i++) {
+    let radius = start + (f32(i) + 0.5) * step;
+    if (radius < ISCO || radius > shade.diskOuter) {
+      continue;
+    }
+    let tap = shadeDisk(sampleAtRadius(g, radius, shade.diskOuter), disk, shade.time, tapFootprint, noiseVolume, noiseSampler);
+    sumEmission += tap.color * tap.alpha;
+    sumAlpha += tap.alpha;
+    sumDensity += tap.density;
+    taps += 1.0;
+  }
+  // Every tap outside the annulus: only reachable if the centre radius itself is
+  // at an edge with a full-annulus span, and the honest answer then is the sample
+  // we actually have.
+  if (taps < 0.5) {
+    return shadeDisk(g, disk, shade.time, footprint, noiseVolume, noiseSampler);
+  }
+
+  var sample: DiskSample;
+  let meanAlpha = sumAlpha / taps;
+  sample.alpha = meanAlpha;
+  // Reconstruct the colour that reproduces the mean EMISSION through
+  // `compositeDisk`'s `color * alpha`.
+  sample.color = select(vec3f(0.0), (sumEmission / taps) / max(meanAlpha, 1e-6), meanAlpha > 1e-6);
+  sample.density = sumDensity / taps;
+  return sample;
 }
 
 /** A layer that contributes nothing, so it can be composited unconditionally. */
@@ -246,12 +398,19 @@ fn tonemap(linearColor: vec3f, uv: vec2f) -> vec3f {
   let dimensions = vec2f(textureDimensions(gHit1, 0));
   let texel = vec2i(clamp(uv * dimensions, vec2f(0.0), dimensions - vec2f(1.0)));
 
+  // Photon-ring AA data for THIS pixel: (coverage, span) of the front crossing,
+  // written by the one-shot refine pass. Outside its ~2% band it is exactly
+  // (1, 0) — an exact 1 in rg8unorm — so those pixels multiply their alpha by a
+  // literal one and stay bit-for-bit what they were.
+  let aa = textureLoad(gAa, texel, 0).xy;
+
   let baked = decodeGBuffer(
     textureLoad(gHit1, texel, 0).xy,
     textureLoad(gHit2, texel, 0).xy,
     textureLoad(gSky, texel, 0),
     textureLoad(gView, texel, 0),
     shade.diskOuter,
+    aa,
   );
 
   // Both footprints, in uniform control flow. The second layer sits at a
@@ -263,8 +422,10 @@ fn tonemap(linearColor: vec3f, uv: vec2f) -> vec3f {
   // measuring after the rotation would make the LOD breathe by up to ~sqrt(2)
   // as the mouse moves. The physical (angular / radial) footprint is invariant,
   // so the pre-rotation measurement is the correct one.
-  let frontFootprint = diskFootprint(baked.front);
-  let backFootprint = diskFootprint(baked.back);
+  let frontAxes = diskFootprintAxes(baked.front);
+  let backAxes = diskFootprintAxes(baked.back);
+  let frontFootprint = diskFootprint(frontAxes);
+  let backFootprint = diskFootprint(backAxes);
 
   // Angular footprint of the LENSED direction map, in cube-face units per pixel
   // (the units `stars.wgsl` measures its point radius in). Also derivatives, so
@@ -331,7 +492,15 @@ fn tonemap(linearColor: vec3f, uv: vec2f) -> vec3f {
     backSample = shadeDisk(layers.back, disk, shade.time, backFootprint, noiseVolume, noiseSampler);
   }
   if (layers.front.isHit) {
-    frontSample = shadeDisk(layers.front, disk, shade.time, frontFootprint, noiseVolume, noiseSampler);
+    frontSample = shadeFront(layers.front, frontFootprint, frontAxes.x);
+    // Fractional area, applied to alpha ONLY: the covered part of the pixel keeps
+    // its full radiance, it simply covers less of the pixel, so the background
+    // (stars, or the hidden second image) shows through the rest. Scaling the
+    // colour instead would be the `starLod` fade-to-black mistake in a new place.
+    // `density` follows because it IS the opacity debug view 5 reads.
+    let coverage = select(1.0, layers.front.coverage, shade.aa > 0.5);
+    frontSample.alpha *= coverage;
+    frontSample.density *= coverage;
   }
 
   // Back to front. Both composites are unconditional: an empty layer has
@@ -386,6 +555,23 @@ fn tonemap(linearColor: vec3f, uv: vec2f) -> vec3f {
   // disk coordinates (radius, azimuth) to confirm the geometry is sane.
   if (mode == 7) {
     return vec4f(select(vec3f(0.0), vec3f(layers.back.diskUv, 1.0), layers.back.isHit), 1.0);
+  }
+  // Photon-ring AA diagnostic (the refine pass's whole output plus what the frame
+  // pass did with it). R = coverage of the front crossing, G = the radial span the
+  // pixel covers in normalized annulus units, B = 1 exactly where the K-tap
+  // prefilter ran. So:
+  //   dark red rim, B = 0  -> partial coverage, no compression: coverage only.
+  //   yellow + blue        -> the compressed band; this is the ring being fixed.
+  //   R > 0 with G = 0 and no B on a pixel that renders black -> the failure mode
+  //     to look for: the 5x5 dilation found coverage the centre ray missed, and
+  //     there is no radius to rebuild the sample from (see refine.wgsl).
+  if (mode == 8) {
+    return vec4f(
+      aa.x,
+      aa.y,
+      select(0.0, 1.0, shade.aa > 0.5 && g.isHit && g.span > AA_SPAN_MIN),
+      1.0,
+    );
   }
 
   // Display-referred output, written straight to the swap chain: the linear HDR


### PR DESCRIPTION
The bright line around the black-hole shadow — the lensed disk image (photon ring) compressed into ~1.5px — rendered as a dotted, flickering wire at DPR 1. Diagnosis and plan by a reasoning review: the shadow edge itself was innocent (4/255 step).

**Technique**: one-shot banded refine pass after the bake (16 sub-rays for the ~2% mixed-state pixels -> coverage + radial span, 2B/px rg8unorm) + per-frame K=6 radial prefilter taps only where the span is wide (0.2% of pixels). Star field / gSky path is bit-for-bit unchanged; `--aa 0` reproduces the previous frame byte-exactly.

**Results** (harness, 1280x720): tangential ring scan std 3.00x -> 1.17x of the 3x-SSAA reference; worst neighbour step 10.4x -> 4.5x. Crops in the PR discussion.

**Thermal**: static accounting predicts shade 1.30 -> ~1.35ms @DPR1 (hard gate 1.45ms) — to be confirmed on real hardware via `?debug` -> measure.

**Documented honest negatives** (see `gbuffer.md`): the apparent ~19% 'lost light' vs SSAA is a tone-map concavity artifact (91% of it lives outside the ring mask — not recoverable by any band-local AA); sub-pixel arcs entirely inside the shadow silhouette are a known remaining gap requiring a G-buffer promotion.