### PR TITLE
chore(docs): hero prompt says 'npx vgpu'

### DIFF
--- a/apps/docs/components/hero-tabs.tsx
+++ b/apps/docs/components/hero-tabs.tsx
@@ -15,11 +15,11 @@ import { InlineCode, stripBackticks } from './inline-code';
  * fragment as code mislabelled it; it read as two registers spliced together
  * when it is one instruction throughout.
  *
- * Prompt stays fenced regardless, because "npx vgpu docs" must not wrap: unset,
- * it breaks after "vgpu" on a phone and strands "docs" alone on line two.
+ * Prompt stays fenced regardless, because "npx vgpu" must not wrap: unset, it
+ * breaks after "npx" on a phone and strands the command name on line two.
  */
 const tabContent = {
-  Prompt: { text: 'Setup vgpu on my project, run `npx vgpu docs`', mono: false },
+  Prompt: { text: 'Setup vgpu on my project, run `npx vgpu`', mono: false },
   Skill: { text: '`npx skills add vercel-labs/vgpu`', mono: true },
 } as const;
 


### PR DESCRIPTION
`npx vgpu` now leads to the docs directly, so the hero Prompt tab drops the `docs` argument: "Setup vgpu on my project, run `npx vgpu`". Copy-to-clipboard verified at 1440/390; the prompt now fits a single line on mobile.

Note: 4 other user-facing occurrences of `npx vgpu docs` remain in the repo (get-started/agents.mdx x2, home pillar, docs index) — left untouched on purpose, candidates for a follow-up if they are equally stale.