### PR TITLE
chore(docs): update remaining 'npx vgpu docs' mentions to 'npx vgpu'

### DIFF
--- a/apps/docs/app/docs/get-started/page.tsx
+++ b/apps/docs/app/docs/get-started/page.tsx
@@ -33,7 +33,7 @@ export default function GetStartedPage() {
       >
         <h2 className="text-lg font-semibold text-gray-12">Agents</h2>
         <p className="mt-2 text-sm leading-6 text-gray-10">
-          vgpu is agent-first — the full documentation ships inside the package. Point your agent at <code>npx vgpu docs</code>.
+          vgpu is agent-first — the full documentation ships inside the package. Point your agent at <code>npx vgpu</code>.
         </p>
       </Link>
 

--- a/apps/docs/app/page.tsx
+++ b/apps/docs/app/page.tsx
@@ -23,7 +23,7 @@ const pillars = [
   {
     title: 'Ready for agents',
     description: 'Docs, CLI and skill built for coding agents. Your agent gets the full API in one command.',
-    code: 'npx vgpu docs',
+    code: 'npx vgpu',
   },
   {
     title: 'Runs on web and Node.js',

--- a/apps/docs/components/inline-code.tsx
+++ b/apps/docs/components/inline-code.tsx
@@ -8,7 +8,7 @@ export function stripBackticks(text: string): string {
 /**
  * Renders a string where `backtick`-wrapped spans are set in mono.
  *
- * For commands quoted mid-sentence ("install with `npx vgpu docs`"), where a
+ * For commands quoted mid-sentence ("install with `npx skills add vercel-labs/vgpu`"), where a
  * block would break the line but the text still has to read as literal — hence
  * a span swap. Geist Mono runs slightly wider and taller than Geist Sans at the
  * same px size, so code is nudged to 0.95em to keep the baseline row even.

--- a/apps/docs/content/get-started/agents.mdx
+++ b/apps/docs/content/get-started/agents.mdx
@@ -1,6 +1,6 @@
 ---
 title: Agents
-summary: vgpu is agent-first — point your agent at npx vgpu docs, or install the vgpu skill.
+summary: vgpu is agent-first — point your agent at npx vgpu, or install the vgpu skill.
 relatedSymbols: []
 prevNext:
   prev:
@@ -18,7 +18,7 @@ vgpu is an agent-first library. The full documentation ships inside the npm pack
 ## Point your agent at the docs
 
 ```bash
-npx vgpu docs
+npx vgpu
 ```
 
 That's the whole instruction. The command prints its own guide — starting with the agent get-started, `vgpu docs cat getting-started.md` — plus the tools to explore and search every reference page, guide, and error code. Your agent takes it from there.


### PR DESCRIPTION
Follow-up to #233: the 4 user-facing mentions (agents.mdx summary + code block, home pillar, docs index) plus one JSDoc example now say `npx vgpu`. Grep for "npx vgpu docs" in apps/docs/ returns zero.