### PR TITLE
chore(docs): code-viewer WCAG contrast + Previous/Next on the guides index

### DIFF
--- a/apps/docs/components/code-viewer.tsx
+++ b/apps/docs/components/code-viewer.tsx
@@ -33,7 +33,7 @@ export async function CodeViewer({ files, activeFile }: CodeViewerProps) {
 
   if (!selected) {
     return (
-      <div className="rounded-lg border border-gray-4 bg-gray-1 p-4 text-sm text-gray-9">
+      <div className="rounded-lg border border-gray-4 bg-gray-1 p-4 text-sm text-gray-11">
         No source files available.
       </div>
     );
@@ -53,7 +53,7 @@ export async function CodeViewer({ files, activeFile }: CodeViewerProps) {
                 href={`?file=${encodeURIComponent(file.name)}`}
                 scroll={false}
                 className={`px-4 py-2.5 text-sm border-r border-gray-4 whitespace-nowrap transition-colors hover:text-gray-12 ${
-                  isActive ? 'bg-[#0a0a0a] text-gray-12' : 'text-gray-9'
+                  isActive ? 'bg-[#0a0a0a] text-gray-12' : 'text-gray-11'
                 }`}
               >
                 {file.name}

--- a/apps/docs/lib/nav.ts
+++ b/apps/docs/lib/nav.ts
@@ -122,13 +122,20 @@ export const navSections: NavSection[] = [
   {
     title: 'Guides',
     href: '/guides',
-    groups: guideGroups.map((group) => ({
-      title: group.title,
-      items: group.slugs.flatMap((slug) => {
-        const record = getGuideRecord(slug);
-        return record ? [{ title: titleForRecord(record), href: `/guides/${record.symbol}` }] : [];
-      }),
-    })).filter((group) => group.items.length > 0),
+    // The overview link is a real item in the chain (same pattern as ML's
+    // "Overview" below), not just the section header, so the guides index
+    // page gets Previous/Next like every other section: it should not be
+    // the one page in the sidebar you can only reach and never leave.
+    groups: [
+      { title: '', items: [{ title: 'Overview', href: '/guides' }] },
+      ...guideGroups.map((group) => ({
+        title: group.title,
+        items: group.slugs.flatMap((slug) => {
+          const record = getGuideRecord(slug);
+          return record ? [{ title: titleForRecord(record), href: `/guides/${record.symbol}` }] : [];
+        }),
+      })).filter((group) => group.items.length > 0),
+    ],
   },
   {
     title: 'Examples',


### PR DESCRIPTION
Two small docs fixes:

1. **code-viewer.tsx contrast**: the empty-state copy and inactive file-tab labels used gray-9 (3.15:1 on gray-1 / 3.00:1 on #111 — fails WCAG 4.5:1). Now gray-11 (9.55:1 / 9.11:1), the same token chosen for code-block.tsx headers.
2. **/docs/guides pagination**: the guides index rendered no Previous/Next because sections with groups never join the flat nav chain. Guides now has an Overview item (same pattern as the ML section): prev ← Render bundles, next → Getting started.

Agent-reviewed (APPROVE). Non-blocking notes, both matching the existing ML precedent: the Overview item double-highlights while inside a guide, and the index breadcrumb reads Docs / Guides / Overview — candidates for a shared fix with ML if ever desired. vgpu suite green (709 tests, concepts-single-source included).