### PR TITLE
chore(release): version packages for 0.2.0

### DIFF
--- a/packages/adapter-mock/package.json
+++ b/packages/adapter-mock/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vgpu/adapter-mock",
-  "version": "0.2.0-rc.2",
+  "version": "0.2.0",
   "description": "Mock GPU adapter for testing vgpu code without real WebGPU hardware.",
   "keywords": [
     "webgpu",

--- a/packages/adapter-node/package.json
+++ b/packages/adapter-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vgpu/adapter-node",
-  "version": "0.1.7-rc.2",
+  "version": "0.1.7",
   "description": "Node.js GPU adapter for vgpu, using Dawn-based WebGPU bindings.",
   "keywords": [
     "webgpu",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vgpu/core",
-  "version": "0.2.0-rc.2",
+  "version": "0.2.0",
   "description": "Core WebGPU runtime primitives (device, buffer, texture, shader, queue) for vgpu.",
   "keywords": [
     "webgpu",

--- a/packages/render/package.json
+++ b/packages/render/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vgpu/render",
-  "version": "0.1.7-rc.2",
+  "version": "0.1.7",
   "description": "Render pipeline + render pass abstractions for vgpu.",
   "keywords": [
     "webgpu",

--- a/packages/vgpu-api/package.json
+++ b/packages/vgpu-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vgpu",
-  "version": "0.2.0-rc.2",
+  "version": "0.2.0",
   "description": "Public VGPU API entrypoint scaffold for browser, Node, mock, scene, and client typing surfaces.",
   "keywords": [
     "webgpu",

--- a/packages/wgsl-std/package.json
+++ b/packages/wgsl-std/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vgpu/wgsl-std",
-  "version": "0.2.0-rc.2",
+  "version": "0.2.0",
   "description": "Pure WGSL utility snippets for vgpu shaders.",
   "keywords": [
     "webgpu",

--- a/packages/wgsl/package.json
+++ b/packages/wgsl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vgpu/wgsl",
-  "version": "0.2.0-rc.2",
+  "version": "0.2.0",
   "description": "WGSL shader compilation, runtime resolution, and webpack/vite loaders for vgpu.",
   "keywords": [
     "webgpu",


### PR DESCRIPTION
## chore(release): version packages for 0.2.0

Mechanical rc-suffix drop for the 0.2.0 stable release. CHANGELOGs were already written in PR #237; this PR only updates `version` fields.

| Package | rc.2 | Estable |
|---|---|---|
| `@vgpu/core` | 0.2.0-rc.2 | **0.2.0** |
| `@vgpu/wgsl` | 0.2.0-rc.2 | **0.2.0** |
| `@vgpu/wgsl-std` | 0.2.0-rc.2 | **0.2.0** |
| `@vgpu/adapter-mock` | 0.2.0-rc.2 | **0.2.0** |
| `vgpu` (vgpu-api) | 0.2.0-rc.2 | **0.2.0** |
| `@vgpu/adapter-node` | 0.1.7-rc.2 | **0.1.7** |
| `@vgpu/render` | 0.1.7-rc.2 | **0.1.7** |

Untouched (private): `@vgpu/cli` 0.1.8, `apps/docs` 0.1.2. Cross-deps remain `workspace:*`.

### Validation

- `0.2.0-rc.2` was dogfooded across 3 independent setups — Next.js + perlin noise, Vite + draw, and Node headless — **3/3 success, zero major issues**.
- `.changeset/` has no pending `.md` files (nothing to consume).
- `pnpm pack` on `packages/vgpu-api` confirms the tarball manifest: version `0.2.0`, deps pinned to exact stable versions (`0.2.0`/`0.1.7`, `@vgpu/wgsl-std@0.2.0` present).
- `pnpm install` (lockfile unchanged), `pnpm build`, `pnpm typecheck`, `pnpm vitest run packages/vgpu` (709 passed, 45 skipped, 0 failed), and `pnpm bundle-check` all pass.

Tagging `v0.2.0` (no prerelease identifier) will publish to the `latest` npm dist-tag.
