### PR TITLE
feat(docs): synthesize photon-ring crossings inside the shadow silhouette

### DIFF
--- a/apps/docs/components/hero/debug-render.mjs
+++ b/apps/docs/components/hero/debug-render.mjs
@@ -21,7 +21,8 @@
 //   --out <dir>          output directory (default /home/user/reports/hero-debug)
 //   --size <WxH>         render size in pixels (default 1280x720)
 //   --time <seconds>     animation clock handed to the shaders (default 2.5)
-//   --views <list>       comma list of: final,normals,diskuv,flags,raydir,density,skylod,hit2,aa,all
+//   --views <list>       comma list of: final,normals,diskuv,flags,raydir,density,
+//                        skylod,hit2,aa,aageom,all
 //   --aa <0|1>           1 = consume the refine pass's ring coverage/span (default),
 //                        0 = ignore it, i.e. exactly the pre-AA image. The A/B.
 //   --<key> <value>      any geometry setting: cameraY, distance, diskRadius, fov, centerY
@@ -117,12 +118,16 @@ const VIEWS = {
   skylod: 6,
   hit2: 7,
   aa: 8,
+  aageom: 9,
 };
 
 /** hit1, hit2, sky, view. Must match GBUFFER_FORMATS in renderer.ts. */
 const GBUFFER_FORMATS = ['rg32float', 'rg32float', 'rgba16float', 'rgba16float'];
-/** Photon-ring AA target (coverage, span). Must match AA_FORMAT in renderer.ts. */
-const AA_FORMAT = 'rg8unorm';
+/**
+ * Photon-ring AA attachments: (coverage, span) and the synthesized crossing
+ * (plane xz + encoded direction). Must match AA_FORMATS in renderer.ts.
+ */
+const AA_FORMATS = ['rg8unorm', 'rgba16float'];
 
 function parseArgs(argv) {
   const options = { views: ['all'], size: [1280, 720], time: 2.5, out: '/home/user/reports/hero-debug', json: false, yaw: 0, bakeYaw: 0, noiseSize: NOISE_VOLUME_SIZE, ssaa: 1, crop: undefined };
@@ -302,8 +307,14 @@ async function main() {
     label: 'hero-debug-gbuffer',
   });
   // Photon-ring AA data: one-shot, written by the refine pass right after the
-  // bake, read 1:1 by shade. Same size as the G-buffer, 2 B/px.
-  const aaTarget = vgpu.target(gpu, { size: [width, height], colors: [{ format: AA_FORMAT }], label: 'hero-debug-aa' });
+  // bake, read 1:1 by shade. Same size as the G-buffer, 10 B/px: 2 for
+  // (coverage, span) plus 8 for the synthesized crossing of the sub-pixel arcs
+  // that live inside the shadow silhouette.
+  const aaTarget = vgpu.target(gpu, {
+    size: [width, height],
+    colors: AA_FORMATS.map((format) => ({ format })),
+    label: 'hero-debug-aa',
+  });
   // Display-referred, exactly what the swap chain gets in the browser: shade
   // tone maps in place, so this is the only pass target after the G-buffer.
   const output = vgpu.target(gpu, { size: [width, height], format: 'rgba8unorm', label: 'hero-debug-output' });
@@ -321,7 +332,7 @@ async function main() {
   const noiseSampler = noiseVolumeSampler(vgpu, gpu);
 
   const [hit1Texture, hit2Texture, skyTexture, viewTexture] = gbuffer.colors;
-  const [aaTexture] = aaTarget.colors;
+  const [aaTexture, aaGeomTexture] = aaTarget.colors;
   const geometry = {
     resolution: gbuffer.size,
     // Camera yaw. The page always bakes with 0 and rotates the scene in the frame
@@ -343,6 +354,7 @@ async function main() {
     gSky: skyTexture,
     gView: viewTexture,
     gAa: aaTexture,
+    gAaGeom: aaGeomTexture,
     noiseVolume,
     noiseSampler,
     disk: settings.disk,

--- a/apps/docs/components/hero/gbuffer.md
+++ b/apps/docs/components/hero/gbuffer.md
@@ -10,8 +10,9 @@ bake.wgsl ──► G-buffer (MRT, 4 attachments) ──┬─► shade.wgsl ─
  one-shot      │                              │   every frame
                │                              │      ├── disk.wgsl   (disk pixels)
                ▼                              │      ├── stars.wgsl  (escaped rays)
-        refine.wgsl ──► AA target (rg8unorm) ─┘      └── tonemap()   (ACES + vignette, in place)
-         one-shot        (coverage, span)
+        refine.wgsl ──► AA target (2 attachments) ─┘  └── tonemap()   (ACES + vignette, in place)
+         one-shot        rg8unorm    (coverage, span)
+                         rgba16float (synthesized crossing)
 ```
 
 Both `bake.wgsl` and `refine.wgsl` are ONE-SHOT and share the geodesic integrator
@@ -86,7 +87,8 @@ device.
 This budget is exactly why the photon-ring AA data lives in its **own pass and
 own target** rather than as a 5th attachment here — see
 [The AA target](#the-aa-target--photon-ring-coverage-and-span). The limit is
-per-PASS, so a second pass gets a fresh 32 B.
+per-PASS, so a second pass gets a fresh 32 B, of which the refine pass spends 10
+(`rg8unorm` + `rgba16float`).
 
 ## G-buffer layout
 
@@ -174,13 +176,21 @@ struct GBufferLayers {
   front: GBufferSample,  // crossing nearest the camera
   back: GBufferSample,   // the crossing it hides; isHit only if front.isHit
 }
-fn decodeGBuffer(hit1: vec2f, hit2: vec2f, sky: vec4f, view: vec4f, diskOuter: f32, aa: vec2f) -> GBufferLayers
+fn decodeGBuffer(hit1: vec2f, hit2: vec2f, sky: vec4f, view: vec4f, diskOuter: f32, aa: vec2f, aaGeom: vec4f) -> GBufferLayers
 ```
 
-`aa` is the matching texel of the [AA target](#the-aa-target--photon-ring-coverage-and-span)
-— `(covFront, spanFront)`. It describes the **front** crossing only; the back
-layer is handed `(1, 0)` and therefore decodes exactly as it did before the AA
-target existed. Pass `vec2f(1.0, 0.0)` to opt out entirely.
+`aa` is the matching texel of the [AA target](#the-aa-target--photon-ring-coverage-and-span)'s
+first attachment — `(covFront, spanFront)`. It describes the **front** crossing
+only; the back layer is handed `(1, 0)` and therefore decodes exactly as it did
+before the AA target existed. Pass `vec2f(1.0, 0.0)` to opt out entirely.
+
+`aaGeom` is the second attachment: a **synthesized front crossing**
+(`xy` = plane position, `zw` = encoded direction — the same encoding `hit1` and
+`view.xy` use) for the pixels whose centre ray missed the ring while the refine
+pass's sub-rays hit it. `decodeGBuffer` substitutes it for `hit1`/`view.xy` when
+and only when `hit1` is a miss and `aaGeom.xy` is a hit, and marks the result
+`synthesized`. Pass `vec4f(0.0)` to opt out — that is exactly what `Shade.aa = 0`
+does, which is why the A/B is bit-for-bit.
 
 Each layer is the same `GBufferSample` the single-hit version used — `shadeDisk`
 shades one layer at a time and never has to know which one it got. Values that
@@ -199,6 +209,7 @@ struct GBufferSample {
   coverage: f32,        // fraction of the pixel this crossing covers (1 outside the AA band)
   span: f32,            // disk radius the pixel spans here, in normalized annulus units
   isHit: bool,
+  synthesized: bool,  // this crossing came from the refine pass, not the G-buffer
   isBlackHole: bool,
   escaped: bool,
 }
@@ -206,18 +217,48 @@ struct GBufferSample {
 
 ## The AA target — photon ring coverage and span
 
-A second one-shot pass, `refine.wgsl`, writes a **2 B/px `rg8unorm`** target next
-to the G-buffer:
+A second one-shot pass, `refine.wgsl`, writes a **10 B/px target with two
+attachments** next to the G-buffer:
+
+**Attachment 0 — `rg8unorm`, 2 B/px: coverage and span**
 
 | Channel | Name | Meaning |
 |---|---|---|
 | `x` | `covFront` | fraction of the pixel the FIRST disk crossing covers, from 16 sub-rays (`n/16`) |
-| `y` | `spanFront` | how much DISK RADIUS the pixel spans at that crossing, in normalized annulus units, **centred on the pixel's own radius** |
+| `y` | `spanFront` | how much DISK RADIUS the pixel spans at that crossing, in normalized annulus units, **centred on the radius the frame pass will anchor its taps at** |
 
 Outside the refined band it is exactly `(isHit ? 1 : 0, 0)`. `1.0` is exact in
 `rg8unorm`, so every unrefined pixel multiplies its alpha by a literal one and its
 final colour is **bit-for-bit** what it was before this target existed (verified
-with `cmp` on all eight debug views).
+with `cmp`: `--aa 0` reproduces the pre-AA frame byte for byte, and the sky views
+4 and 6 are byte-identical with the AA on).
+
+**Attachment 1 — `rgba16float`, 8 B/px: the synthesized crossing**
+
+| Channel | Meaning |
+|---|---|
+| `xy` | crossing position in the `y = 0` plane (world x, z) — same encoding as `gHit1`; `(0,0)` = nothing to substitute |
+| `zw` | ray direction at that crossing, `(y, azimuth of xz)` — same encoding as `gView.xy` |
+
+Written **only** for pixels whose CENTRE ray missed the disk while the sub-rays
+hit it: the sub-pixel arcs that live inside the shadow silhouette. Everywhere else
+— including every pixel that has a real centre hit, which already has the exact
+f32 thing in the G-buffer — it is all zeros. `decodeGBuffer` substitutes it for
+`hit1`/`view.xy` and marks the sample `synthesized`; from that point on nothing
+downstream (footprints, rotation, the tap loop, `disk.wgsl`) can tell the
+difference, because it is a real crossing of a real geodesic in the same encoding.
+
+*Why `rgba16float` and not `rgba8unorm` for this.* 8 bits of azimuth quantize to
+`2*pi/255` = 0.0246 rad, and the azimuth along the ring only moves ~0.005 rad per
+pixel: an 8-bit `(radius, azimuth)` pair would freeze the disk's noise and Doppler
+pattern into ~5 px stairs along a 1 px arc — a new artifact inside the very band
+being fixed. Stored as an f16 PLANE POSITION the same crossing keeps 0.0039 world
+units at r ≈ 6 (10-bit mantissa, exponent 2) = 6.5e-4 rad of azimuth (~0.13 px)
+and 0.1% of the annulus in radius, and it needs no new decode path. The direction
+rides in the same 8 bytes because `disk.wgsl` reads it for the slab path length
+(`1/|dir.y|`), the face-on `arcLift` and the Doppler beaming — a synthesized
+sample without it would be shaded as if seen exactly edge-on, pinned at the 34x
+`grazing` ceiling with no lift, which is the one thing these arcs are not.
 
 ### What the artifact actually is (measure before you tune)
 
@@ -278,6 +319,25 @@ to antialias disk-hit coverage *and* disk attribute variation — not a silhouet
    the measured span and bias the radial mean. The price is a span up to 2x wider
    than the raw range: a slightly wider prefilter, never a shifted one.
 
+4. **The synthesized crossing.** If the centre ray missed the disk but sub-rays
+   hit it, the pass also writes attachment 1: the surviving sub-ray CLOSEST TO THE
+   PIXEL CENTRE, kept whole — its own plane position and its own direction, one
+   real geodesic — with only its radial coordinate moved to the midpoint of the
+   measured `[rmin, rmax]`, because in this case the pass also chooses the anchor
+   the frame pass's taps will be centred on. `span` is then the raw range, not the
+   doubled symmetric one, because doubling makes the tap loop average `shadeDisk`
+   over radii no sub-ray ever crossed. Measured against the algorithm-free
+   reference below, the midpoint anchor wins BAND-WIDE and not everywhere: inner
+   band 77.6% -> 79.7% of the reference's energy, ring std 0.93x -> 0.86x, darkest
+   pixel of the scanned ring 22 -> 31/255, while at the single 357 deg column the
+   doubled variant is the closer of the two (51,49,43,47 against the reference's
+   47,43,38,33, versus 32,36,32,50 shipped).
+   Not an average of the sub-rays: averaging positions lies about the geometry, and
+   averaging DIRECTIONS is worse, because sub-rays on either side of a fold cross
+   opposite faces and their `dir.y` cancels — `disk.wgsl` reads `1/|dir.y|` as its
+   slab path length, so a cancelled `y` would shade the arc at the 34x edge-on
+   ceiling.
+
 **Shadow coverage is deliberately not stored.** It was measured at `0 -> 4/255`
 (invisible), and consuming a fractional shadow would composite stars from the
 *truncated* `gSky.xyz` of a swallowed ray — new speckle in a 1 px rim, plus a
@@ -323,19 +383,38 @@ agree (frame mean 0.0238 both), and the AA view is unchanged by scene rotation.
 
 ### Cost and the thermal gate
 
-The AA data costs the frame pass **+2 B/px** of read (~6% of the 32 B/px the shade
-pass already reads, and that pass is ALU-bound, not bandwidth-bound) plus the tap
-loop. Static counts at 1280x720, shipped defaults:
+The AA data costs the frame pass **+10 B/px** of read (two extra `textureLoad`s on
+top of the 32 B/px of G-buffer; the pass is ALU-bound, not bandwidth-bound) plus
+the tap loop and the synthesized samples. Static counts at 1280x720, shipped
+defaults, from `/home/user/reports/aa-dropout/static-count.mjs` (which reads debug
+views 8 and 9, so these are the shader's own numbers):
 
-| Set | Pixels | Share |
-|---|---|---|
-| refined band (partial coverage or non-zero span) | 19 946 | 2.16% |
-| **tap path actually taken** (`isHit && span > 0.15`) | **1 986** | **0.215%** |
-| 8x8 tiles (~one 64-lane wave) containing any tap pixel | 202 / 14 400 | 1.40% |
+| Set | Pixels | Share | Before this pass existed |
+|---|---|---|---|
+| refined band (partial coverage or non-zero span) | 20 490 | 2.22% | 19 946 / 2.16% |
+| **tap path actually taken** (`isHit && span > 0.15`) | **2 512** | **0.273%** | 1 986 / 0.215% |
+| **synthesized crossing shaded** (`aaGeom` substituted) | **4 030** | **0.437%** | 0 |
+| 8x8 tiles (~one 64-lane wave) containing any tap pixel | 220 / 14 400 | 1.53% | 202 / 1.40% |
+| 8x8 tiles containing a tap OR a synthesized pixel | 890 / 14 400 | 6.18% | 202 / 1.40% |
 
-So even in the worst case — a whole wave paying K x the disk cost because one lane
-straddles the ring — the tap loop adds `5 extra shadeDisk x 1.40% of waves` ≈
-**7% of the disk-shading work**, and the disk is only part of the shade pass.
+Read that as ADDED work, not as pixels, and mind the double count: 1 986 of the
+2 512 tap pixels were already taking the tap path before this change, so only 526
+are new. The frame gains 4 030 pixels that call `shadeDisk` once where they
+previously called it not at all (`isHit` goes 195 264 -> 199 294, +2.1% of the
+disk-shaded pixels) plus 526 pixels that newly enter the 6-tap loop:
+`4 030 + 5 x 526 = 6 660` added evaluations against 195 264 already being shaded =
+**+3.4% of the disk-shading work**, and the disk is only part of the shade pass.
+
+The wave bound has to be normalized against DISK work, not against the frame: only
+21% of the frame shades the disk at all, so `195 264 / 64 ≈ 3 051` wave-equivalents
+of disk shading exist. Against that, 890 tiles each paying one extra `shadeDisk`
+for all 64 lanes is **~+29%** (~+25% if only the 688 tiles that were not already
+paying for taps are counted, +3% for the 18 newly-tapping tiles). That bound
+assumes zero coherence inside a wave, which a 1 px arc violates by construction —
+it is a ceiling, not an estimate, and the real number has to come from a GPU
+measurement, not from this sandbox. The near-critical mask criterion itself is one
+`cameraRay` + one cross product per pixel in the ONE-SHOT pass — nothing per
+frame.
 **Hard gate: shade GPU time <= 1.45 ms at DPR 1 (from 1.3 ms), measured with the
 `?debug` panel's `measure` button on real hardware.** Numbers from the Node
 harness in a container are CPU/SwiftShader and say nothing about GPU time.
@@ -352,18 +431,92 @@ If the gate ever fails at K = 4, the documented fallback is a **single**
 whole span, scaled by coverage: smooth and continuous at ~1 tap, at the price of a
 radial-profile bias.
 
-### Known gap (do not rediscover it)
+### Sub-pixel arcs inside the silhouette (the old "known gap", partly closed)
 
-Coverage can only ever *scale* a sample that exists. A pixel whose centre ray
-misses the ring has no radius, azimuth or view direction to rebuild a sample from,
-so it cannot be shaded no matter what `covFront` says. Within the 5x5 mask this
-does not happen (measured: 0 such pixels at the shipped defaults). What *does*
-happen is one step further out: a sub-pixel arc that lives entirely **inside** the
-shadow silhouette, where no centre ray in a 5x5 neighbourhood sees the disk, so
-the mask never fires. Example at 720p, 45°, r = 188: the 3x reference has luma 58,
-the 1x frame and `covFront` are both 0. Closing it needs the crossing geometry
-stored per pixel (promote the target to `rgba8unorm`/`rgba16float` with radius +
-azimuth), not a wider dilation.
+Coverage can only ever *scale* a sample that exists. The failure mode this used to
+document was a pixel whose centre ray missed the ring: with no radius, azimuth or
+view direction there is nothing to shade, no matter what `covFront` says. The
+**synthesized crossing** (attachment 1, step 4 above) is that missing sample, and
+it is what closed the arcs near the disk plane. The near-critical mask criterion is
+NOT what closed them — see its own note above; at 720p defaults every recovered arc
+sat in a neighbourhood the 5x5 test already flagged.
+
+#### Use the algorithm-free reference
+
+```bash
+node debug-render.mjs --views final --ssaa 3 --aa 0 --out /home/user/reports/ref-noaa
+```
+
+`--aa 0` is the point. A `--ssaa 3` reference rendered with the AA **on** is not a
+reference for the AA: it bakes in whatever the refine pass did that day (partial
+coverage dims a sub-pixel arc even at 3x), so it moves whenever the shader moves and
+numbers taken against it cannot be reproduced after a merge. With `--aa 0` the
+reference is 3x supersampled point sampling — byte-identical from any tree that has
+the A/B knob, and the only stable yardstick here. Every number below is against it.
+
+Measured, 1280x720, shipped defaults, t = 2.5 (`/home/user/reports/aa-dropout/`):
+
+| | pre-AA (`--aa 0`) | before (AA, pre-change) | after | reference |
+|---|---|---|---|---|
+| luma at (828, 364..373), the 357 deg arc | 0 x9, 10 | 0 x9, 51 | **22, 24, 25, 25, 25, 32, 36, 32, 50, 51** | 48, 51, 53, 53, 51, 47, 43, 38, 33, 33 |
+| inner-band (r = 176..189) energy, 0..359 deg | 48.6% | 33.1% | **79.7%** | 100% |
+| ring band std (20..70 deg, `ring-scan.mjs`) | 25.6 = 3.0x ref | 9.97 = 1.17x ref | **7.30 = 0.86x ref** | 8.5 |
+| ring band min / neighbour steps > 2x | 10 / 21 of 50 | 14 / 4 of 50 | **31 / 0 of 50** | 26 / 1 of 50 |
+
+Note what the pre-AA column says: the old AA made the inner band WORSE than point
+sampling (48.6% -> 33.1%), because coverage scaling dims a real hit and had nothing
+to add back. That is the asymmetry the synthesized crossing removes.
+
+#### What is still broken (the new known gap): 45 deg
+
+The reference has a SECOND, deeper inner arc — one more half turn around the photon
+sphere, ~1 px wide, running diagonally through (770,224) -> (775,229) at 45 deg,
+where it reads 14, 38, 58, 58, 38, 14. We render **0** along all of it, and debug
+view 8 says why: `covFront` is 0 there, i.e. **none of the 16 sub-rays finds the
+crossing** even though the pixels are inside the near-critical band and are flagged
+shadow. A 4x4 stratified grid samples every 0.25 px; the 3x reference samples every
+0.33 px and does find it, so this is not simply "too thin for 16 rays" — the sub-ray
+and the reference ray disagree about the same geometry and that disagreement is not
+yet explained. Unchanged by this work (pre-AA, pre-change AA and current all render
+0), and it is the reason the strict inner-band sweep still reports 8 failing
+azimuths (see below) rather than 1 or 2.
+
+Reproduce: `node inner-arc.mjs <frame>.png ref-noaa/final.png` and look at the
+`45(0/58@r187.5)` entry; `node probe.mjs final-on/aa.png 769 223 7 7` for the zero
+coverage.
+
+#### The rest of the residual
+
+Against the algorithm-free reference the strict inner-band sweep goes from **9 of
+360 azimuths below half the reference to 8** — the composition changes far more than
+the count: of the six azimuths that rendered a total zero (3, 35, 39, 45, 357, 358)
+only 45 deg still does, the others now render 3..25 against a 42..63 reference, and
+band energy more than doubles. State the reference when quoting this gate: 8 of 360
+against `--ssaa 3 --aa 0`, 2 of 360 against a `--ssaa 3` reference rendered with the
+AA on (which is why that number looked better and meant less), 8 of 360 for plain
+point sampling.
+
+Two classes make up most of what is left:
+
+- **187 deg (28 vs 58), unchanged by this work.** The centre ray there really does
+  hit, the 5x5 block is uniform, and the deficit is *tangential* compression — the
+  radial prefilter does not address it and neither does a synthesized sample.
+- **Occlusion darkening, by construction.** A synthesized front layer composites IN
+  FRONT of light that previously reached the camera unobstructed, so some pixels
+  must lose energy: 547 pixels get darker (483 of them further from the reference),
+  mean loss 4.1/255, worst 22/255, against 1 550 pixels that get brighter (973 of
+  them closer to the reference). Not a bug — it is what a newly opaque front layer
+  does — but it is why the band does not improve monotonically pixel by pixel.
+
+One thing that was tried and **rejected**: rebuilding the synthesized pixel's noise
+footprint from the measured span instead of from `fwidth` (the derivative really is
+meaningless there — the neighbours are misses, so the pixel's `fwidth` footprint
+saturates the `min(..., 4.0)` clamp and the noise is fully prefiltered). Defensible
+in principle, measured worse: inner-band energy overshot the reference (144% against
+the AA-on reference of the day), the worst azimuth got *worse* (18 vs 51) and the
+ring std went from 0.86x to 0.93x. Left as is; if it is revisited, the missing
+ingredient is the AZIMUTHAL extent of the sub-ray crossings, which the refine pass
+could measure and would need a third channel to carry.
 
 ## The two shading entry points
 
@@ -813,6 +966,7 @@ directions right where the prefilter now keeps the sky alive.
 | `@group(0) @binding(7)` | `noiseVolume` | `texture_3d<f32>` (`r8unorm`) | `noise-volume.mjs::createNoiseVolume` |
 | `@group(0) @binding(8)` | `noiseSampler` | `sampler` (linear, `repeat` xyz) | `noise-volume.mjs::noiseVolumeSampler` |
 | `@group(0) @binding(9)` | `gAa` | `texture_2d<f32>` (`rg8unorm`) | `targets.aa.colors[0]`, written by `refine.wgsl` |
+| `@group(0) @binding(10)` | `gAaGeom` | `texture_2d<f32>` (`rgba16float`) | `targets.aa.colors[1]`, written by `refine.wgsl` |
 
 `Shade` carries `resolution`, `time`, `diskOuter`, `debugView`, `diskLayers`, `aa`
 and `sceneYaw` — nothing camera-related, the bake froze it (`sceneYaw` rotates the
@@ -868,7 +1022,7 @@ straight to the swap chain.
 
 ```
 color = compositeDisk(compositeDisk(stars, back), front)   // linear HDR
-  ├── debugView 1..7 ─► return RAW, before the tone map
+  ├── debugView 1..9 ─► return RAW, before the tone map
   └── debugView 0     ─► return tonemap(color, uv)
 ```
 
@@ -1217,9 +1371,20 @@ The lil-gui panel has a **debug** folder with a *g-buffer view* dropdown:
 | 5 | disk density | `DiskSample.density` |
 | 6 | sky footprint / star prefilter | R = star cells crossed per pixel ÷ 16, G = `starPrefilterRatio` (1 = star at least a pixel wide and at full brightness, → 0 = one pixel swallows many cells and every star is dimmed by the square of it), B = 1 where stars are sampled. G → 0 no longer means "no sky here": the flux is still rendered, spread out. |
 | 7 | second disk hit | **B = 1 exactly where a hidden second crossing exists**, R/G = its normalized disk coords (radius, azimuth) |
-| 8 | ring aa (cov/span/taps) | R = `covFront`, G = `spanFront`, B = 1 where the K-tap radial prefilter ran. Yellow + blue = the compressed photon-ring band. A pixel with R > 0, G = 0, no B **and** a black final image is the known gap: the 5×5 dilation found coverage the centre ray missed, and there is no radius to rebuild a sample from (see [The AA target](#the-aa-target--photon-ring-coverage-and-span)). |
+| 8 | ring aa (cov/span/taps) | R = `covFront`, G = `spanFront`, B = 1 where the K-tap radial prefilter ran. Yellow + blue = the compressed photon-ring band. A pixel with R > 0 **and** a black final image is a dropout — coverage measured, nothing shaded with it; cross-check it against view 9 before blaming the tap loop (see [The AA target](#the-aa-target--photon-ring-coverage-and-span)). |
+| 9 | ring aa (synth crossings) | R/G = the SYNTHESIZED crossing's normalized disk coords (radius, azimuth), B = 1 exactly where the frame pass shaded a synthesized sample — the sub-pixel arcs inside the shadow silhouette that no centre ray of the neighbourhood ever hit. Entirely black at `--aa 0`. |
 
-Views 1–5 describe the **front** crossing. Next to the dropdown, **disk layers**
+Views 1–5 describe the **front** crossing, including a synthesized one, so views
+**1, 2, 3 and 5** legitimately gain the arcs inside the silhouette when the AA is
+on (view 1 too: a synthesized sample has a face and therefore a normal). The sky
+views 4 and 6 are byte-identical either way.
+
+> **Gotcha when diffing:** at `--aa 0` the frame and every G-buffer view are
+> byte-identical to the pre-AA renderer, but **view 8 is not** — it renders the
+> refine target raw, and the near-critical criterion refines 544 pixels the old
+> mask did not (span channel only, `R:0 G:544 B:0`). A `cmp` sweep over
+> `--views all --aa 0` will flag exactly that one view, and it is not a
+> regression. Next to the dropdown, **disk layers**
 switches between `front hit only` (what the renderer did before the second hit
 existed) and `front + hidden hit` (the default) — the quickest way to see what
 the second layer contributes. **photon-ring aa** is the other A/B: `off` is
@@ -1246,17 +1411,22 @@ nothing and is instantly reversible.
 > shader you must reload the page (`agent-browser ... reload`) — otherwise you
 > are looking at the previous shader and will chase ghosts.
 
-Browser session that actually has WebGPU in this sandbox:
+Browser session that actually has WebGPU in this sandbox. **`--webgpu` is gone**
+(checked against `agent-browser --help` on 0.27.0); `--headed` is NOT — it is still
+in the help and still needed, since a headless Chrome has no adapter here. Pass the
+WebGPU flags yourself with `--args`:
 
 ```bash
 export PATH="$(npm prefix -g)/bin:$PATH"
-agent-browser --session bh --webgpu --headed open http://localhost:3010/
-agent-browser --session bh --webgpu --headed set viewport 1440 900
-agent-browser --session bh --webgpu --headed screenshot canvas /home/user/reports/hero.png
+FLAGS="--enable-unsafe-webgpu,--use-angle=vulkan,--enable-features=Vulkan,--no-sandbox"
+agent-browser --session bh --headed --args "$FLAGS" open http://localhost:3010/
+agent-browser --session bh --headed --args "$FLAGS" set viewport 1440 900
+agent-browser --session bh --headed --args "$FLAGS" screenshot canvas /home/user/reports/hero.png
 ```
 
-Without `--webgpu --headed` there is no adapter and the page silently shows the
-static PNG fallback.
+Without those Chrome flags there is no adapter and the page silently shows the
+static PNG fallback — so a screenshot that looks like the fallback is a *setup*
+failure, not a shader failure. Check for the canvas, not for pixels you like.
 
 ### Headless, no browser — `debug-render.mjs`
 

--- a/apps/docs/components/hero/gbuffer.wgsl
+++ b/apps/docs/components/hero/gbuffer.wgsl
@@ -59,6 +59,19 @@ export struct GBufferSample {
   span: f32,
   /** True when this pixel sees the accretion disk. */
   isHit: bool,
+  /**
+   * True when this crossing did NOT come from the G-buffer: the pixel's centre
+   * ray missed the disk, the refine pass's sub-rays did not, and this sample is
+   * the surviving sub-ray nearest the pixel centre (see refine.wgsl).
+   *
+   * These are the sub-pixel arcs of the lensed disk image that live INSIDE the
+   * shadow silhouette, where no centre ray of the neighbourhood sees the disk at
+   * all. `coverage` is always < 1 on them, by construction. Nothing in the
+   * shading needs to branch on this — it is a real crossing of a real geodesic —
+   * it exists for debug view 9 and for the A/B: at `Shade.aa = 0` the frame pass
+   * passes a zero `aaGeom` and no sample is ever synthesized.
+   */
+  synthesized: bool,
   /** True when the ray ended inside the event horizon (render black). */
   isBlackHole: bool,
   /** True when the ray escaped to infinity (render stars). */
@@ -92,7 +105,7 @@ fn decodeDirection(encoded: vec2f) -> vec3f {
 }
 
 /** Decodes one crossing. `flags` and `sky` are shared by both layers. */
-fn decodeLayer(plane: vec2f, encodedDirection: vec2f, sky: vec4f, flags: i32, diskOuter: f32, aa: vec2f) -> GBufferSample {
+fn decodeLayer(plane: vec2f, encodedDirection: vec2f, sky: vec4f, flags: i32, diskOuter: f32, aa: vec2f, synthesized: bool) -> GBufferSample {
   var sample: GBufferSample;
   let planeRadius = length(plane);
   // The bake only ever writes crossings inside [ISCO, diskOuter] and leaves a
@@ -124,6 +137,7 @@ fn decodeLayer(plane: vec2f, encodedDirection: vec2f, sky: vec4f, flags: i32, di
   sample.coverage = clamp(aa.x, 0.0, 1.0);
   sample.span = clamp(aa.y, 0.0, 1.0);
   sample.isHit = isHit;
+  sample.synthesized = synthesized && isHit;
   sample.isBlackHole = (flags & 1) != 0;
   sample.escaped = (flags & 2) != 0;
   return sample;
@@ -133,17 +147,36 @@ fn decodeLayer(plane: vec2f, encodedDirection: vec2f, sky: vec4f, flags: i32, di
  * Decodes the four raw G-buffer texels written by `bake.wgsl` into both disk
  * layers. `diskOuter` must be the same disk radius the bake ran with.
  *
- * `aa` is the matching texel of the refine pass's target — `(covFront,
+ * `aa` is the matching texel of the refine pass's first attachment — `(covFront,
  * spanFront)`, see refine.wgsl. It describes the FRONT crossing only: the back
  * layer is handed `(1, 0)`, i.e. "fully covered, not compressed", so it decodes
  * exactly as it did before the AA target existed. Pass `vec2f(1.0, 0.0)` to opt
  * out entirely.
+ *
+ * `aaGeom` is the second attachment — a SYNTHESIZED front crossing for pixels
+ * whose centre ray missed the disk while the refine pass's sub-rays hit it:
+ * `xy` = plane position, `zw` = the encoded direction, in exactly the encoding
+ * `hit1` / `view.xy` use. It is `(0,0,0,0)` on every pixel that has a real centre
+ * hit and on every pixel outside the refined band, and `|xy| < ISCO` is the "no
+ * substitution" test — the same one that separates hit from miss above. Pass
+ * `vec4f(0.0)` to opt out entirely (that is what `Shade.aa = 0` does, which is
+ * why the A/B switch is exact).
+ *
+ * Substituting here rather than in `shade.wgsl` is deliberate: the synthesized
+ * sample is a real crossing of a real geodesic in the same encoding, so once it
+ * is in place NOTHING downstream — footprints, rotation, the tap loop, the disk
+ * shader — has to know it came from the refine pass.
  */
-export fn decodeGBuffer(hit1: vec2f, hit2: vec2f, sky: vec4f, view: vec4f, diskOuter: f32, aa: vec2f) -> GBufferLayers {
+export fn decodeGBuffer(hit1: vec2f, hit2: vec2f, sky: vec4f, view: vec4f, diskOuter: f32, aa: vec2f, aaGeom: vec4f) -> GBufferLayers {
   let flags = i32(sky.w + 0.5);
+  // The synthesized crossing only ever replaces a MISS: a pixel with a real
+  // centre hit keeps the G-buffer's f32 position and exact direction.
+  let substitute = length(hit1) <= ISCO * 0.5 && length(aaGeom.xy) > ISCO * 0.5;
+  let frontPlane = select(hit1, aaGeom.xy, substitute);
+  let frontDirection = select(view.xy, aaGeom.zw, substitute);
   var layers: GBufferLayers;
-  layers.front = decodeLayer(hit1, view.xy, sky, flags, diskOuter, aa);
-  layers.back = decodeLayer(hit2, view.zw, sky, flags, diskOuter, vec2f(1.0, 0.0));
+  layers.front = decodeLayer(frontPlane, frontDirection, sky, flags, diskOuter, aa, substitute);
+  layers.back = decodeLayer(hit2, view.zw, sky, flags, diskOuter, vec2f(1.0, 0.0), false);
   // The bake already guarantees this ordering; enforcing it here too means a
   // second layer can never be shaded without a first one in front of it.
   if (!layers.front.isHit) {

--- a/apps/docs/components/hero/hero-black-hole.tsx
+++ b/apps/docs/components/hero/hero-black-hole.tsx
@@ -315,6 +315,7 @@ export function HeroBlackHole() {
         'sky footprint / prefilter': 6,
         'second disk hit': 7,
         'ring aa (cov/span/taps)': 8,
+        'ring aa (synth crossings)': 9,
       }).name('g-buffer view');
       // A/B for the photon-ring antialiasing. `off` is exactly the pre-AA image:
       // the one-shot refine pass still runs, the frame pass just ignores its

--- a/apps/docs/components/hero/refine.wgsl
+++ b/apps/docs/components/hero/refine.wgsl
@@ -1,13 +1,17 @@
-// REFINE PASS — one-shot sub-pixel coverage/span of the photon ring.
+// REFINE PASS — one-shot sub-pixel coverage/span/geometry of the photon ring.
 //
 // Runs immediately after the bake, in the same throttled `if (bake)` block, and
 // never per frame. Reads the G-buffer the bake just wrote, finds the ~2% of
 // pixels where the lensed disk image is compressed below one pixel, and traces
-// 16 sub-rays there with the SAME integrator (`geodesic.wgsl`) to measure two
-// numbers the per-frame pass cannot recover on its own:
+// 16 sub-rays there with the SAME integrator (`geodesic.wgsl`) to measure what
+// the per-frame pass cannot recover on its own:
 //
 //   covFront  fraction of the pixel covered by the FIRST disk crossing;
-//   spanFront how much DISK RADIUS the pixel spans at that crossing.
+//   spanFront how much DISK RADIUS the pixel spans at that crossing;
+//   geometry  the crossing itself (plane position + direction) for pixels whose
+//             CENTRE ray missed the disk while the sub-rays found it — the
+//             sub-pixel arcs that live inside the shadow silhouette. Coverage can
+//             only scale a sample that exists; this is that sample.
 //
 // WHY THIS PASS EXISTS. At the shipped defaults the whole [ISCO, diskOuter]
 // annulus is squeezed into ~1.5 px at screen radius r ~ 190 px (720p): measured
@@ -22,8 +26,9 @@
 // WHY IT IS A SEPARATE PASS AND A SEPARATE TARGET. The bake's MRT already spends
 // exactly 32 B/sample, which is all WebGPU guarantees
 // (`maxColorAttachmentBytesPerSample`), so a 5th attachment is not available. A
-// second pass with its own 2 B/px `rg8unorm` target is additive, deletable, and
-// costs the frame pass one extra texel fetch.
+// second pass with its own two small attachments (2 B/px `rg8unorm` coverage/span
+// + 8 B/px `rgba16float` crossing geometry = 10 of a fresh 32 B budget) is
+// additive, deletable, and costs the frame pass two texel fetches.
 //
 // COST. One-shot, and amortised the same way the bake is (the 200 ms re-bake
 // throttle, renderer.ts). 25 texel loads per pixel for the mask, plus 16
@@ -33,7 +38,7 @@
 // sub-rays) before touching MAX_STEPS — a 2x reference is already close to a 3x
 // one, so 16 sub-rays is more than converged.
 
-import { ISCO, cameraRay, escapeRadiusFor, traceRay } from "./geodesic.wgsl";
+import { HORIZON, ISCO, cameraRay, encodeDirection, escapeRadiusFor, traceRay } from "./geodesic.wgsl";
 
 /**
  * Same fields as `Bake` in bake.wgsl, in the same order: `renderer.ts` uploads
@@ -72,13 +77,98 @@ const MASK_RADIUS: i32 = 2;
  * regime even if both of them hit, which is the case coverage alone would miss.
  */
 const GRADIENT_LIMIT: f32 = 0.12;
+/**
+ * Critical impact parameter of a Schwarzschild photon, `3 * sqrt(3) / 2 * r_s`,
+ * in the r_s = 1 units the whole scene uses (`HORIZON` = 1).
+ *
+ * `b = |r x v|` is the ray's conserved L/E, so `b < B_CRIT` is EXACTLY the
+ * capture condition — it is the silhouette, analytically, with no dependence on
+ * the camera. Verified against the integrator in
+ * /home/user/reports/aa-dropout/bcrit.mjs: at the shipped defaults the numerical
+ * capture boundary sits at b = 2.5914 and the out-of-steps band (which
+ * `bake.wgsl` folds into the shadow) ends at b = 2.6179, i.e. both are inside
+ * `B_CRIT +/- 0.02`.
+ */
+const B_CRIT: f32 = 2.59807621;
+/**
+ * Half-width, in impact parameter, of the NEAR-CRITICAL band that is refined
+ * regardless of what the neighbourhood looks like.
+ *
+ * WHY THIS EXISTS. The neighbourhood tests above can only see what the CENTRE
+ * rays saw. The lensed disk images formed by rays that wind past the photon
+ * sphere are compressed by e^-pi per extra half turn, so they are far thinner
+ * than a pixel and can live entirely between centre rays: a 5x5 neighbourhood in
+ * which every ray is swallowed (all-shadow, no hit, no gradient) still hides an
+ * arc, and no neighbourhood test of any width can see that.
+ *
+ * BE HONEST ABOUT WHAT IT BUYS TODAY: at the shipped 720p defaults this criterion
+ * changes NOTHING in the final image. It flags 544 extra pixels, and all 544
+ * differ from the pass-through only in the SPAN channel — coverage is identical
+ * (measured: `cmp` of debug view 8 before/after differs on 544 px, G only, R and
+ * B byte-identical). Zero new coverage means no sub-ray hit in those pixels,
+ * which means no synthesized crossing and no shading change. Every arc actually
+ * recovered at 720p sits in a neighbourhood the 5x5 test already flagged. The
+ * criterion starts to contribute at higher resolution (measured: +244 px of new
+ * coverage at 1920x1080, which is what the real browser runs — DPR 1 on a ~1500px
+ * viewport) and under camera moves (+8 px at `--distance 9.0`), because the band
+ * moves relative to the pixel grid. It is kept as the analytically correct
+ * silhouette test — `b < B_CRIT` IS the capture condition — for one `cameraRay`
+ * plus one cross product in a pass that runs once per rebake.
+ *
+ * A band in `b` rather than a wider pixel dilation because `b` is the physical
+ * coordinate the arcs are thin in: it is exact under `sceneYaw`, and it keeps
+ * covering the same arcs at any resolution, fov or camera distance, where "N
+ * pixels of dilation" would not. 0.06 is ~4.5 px at the shipped 720p defaults
+ * (db/dpx = 0.0133, measured), i.e. 3x the margin needed to contain the whole
+ * [2.5914, 2.6179] window above, and it is a one-shot cost.
+ */
+const CRITICAL_BAND: f32 = 0.06;
 
 /** The bake writes a plain (0,0) for "no crossing"; the annulus starts at ISCO. */
 fn isHitAt(plane: vec2f) -> bool {
   return length(plane) > ISCO * 0.5;
 }
 
-@fragment fn fs_main(@location(0) uv: vec2f) -> @location(0) vec2f {
+/**
+ * What the pass writes, in @location order.
+ *
+ * Two attachments instead of one because coverage can only ever SCALE a sample
+ * that exists: a pixel whose centre ray missed the ring has no radius, azimuth or
+ * view direction for the frame pass to rebuild a `GBufferSample` from, and
+ * `covFront` alone leaves it black (the old "known gap"). `geometry` is that
+ * missing crossing, in exactly the encoding `bake.wgsl` uses for `gHit1` /
+ * `gView.xy`, so `decodeGBuffer` can substitute it with no new decode path.
+ *
+ * Byte cost of the pass: 2 + 8 = 10 of a fresh 32 B/sample budget.
+ *
+ * `rgba16float` and not `rgba8unorm` for the geometry, deliberately: 8-bit
+ * azimuth quantizes to 2*pi/255 = 0.0246 rad, and along the ring the azimuth
+ * moves ~0.005 rad per pixel, so a unorm8 azimuth would freeze the disk's noise
+ * and Doppler pattern into ~5 px stairs along an arc that is 1 px wide — a new
+ * artifact in the very band being fixed. Storing the crossing as an f16 PLANE
+ * POSITION instead keeps 0.0039 world units at r ~ 6 (10-bit mantissa, exponent
+ * 2), i.e. 6.5e-4 rad of azimuth (0.13 px) and 0.1% of the annulus in radius,
+ * and it needs no new decode. The direction rides along in the same 8 bytes as
+ * the (y, azimuth) pair `gView` already stores; the disk look reads it for the
+ * slab path length, the face-on lift and the Doppler beaming, so a synthesized
+ * sample without it would be shaded as if seen exactly edge-on (grazing pinned at
+ * the 34x ceiling, no `arcLift`) — the one thing the arcs are not.
+ */
+struct RefineOut {
+  /** x = covFront, y = spanFront. `rg8unorm`, 1.0 exact. */
+  @location(0) coverage: vec2f,
+  /**
+   * SYNTHESIZED front crossing, `rgba16float`, and only for pixels whose centre
+   * ray missed the disk while sub-rays hit it:
+   *   xy = crossing position in the y = 0 plane (world x, z), (0,0) = none;
+   *   zw = ray direction at that crossing, `encodeDirection`'d (y, azimuth).
+   * All zero everywhere else, including on pixels that have a real centre hit —
+   * those already have the real thing in the G-buffer.
+   */
+  @location(1) geometry: vec4f,
+}
+
+@fragment fn fs_main(@location(0) uv: vec2f) -> RefineOut {
   let dimensions = vec2i(textureDimensions(gHit1, 0));
   let texel = vec2i(clamp(uv * refine.resolution, vec2f(0.0), refine.resolution - vec2f(1.0)));
   let annulus = max(refine.diskOuter - ISCO, 0.001);
@@ -88,12 +178,24 @@ fn isHitAt(plane: vec2f) -> bool {
   let centerHole = (i32(textureLoad(gSky, texel, 0).w + 0.5) & 1) != 0;
   let centerRadiusNorm = clamp((length(centerPlane) - ISCO) / annulus, 0.0, 1.0);
 
+  // The pixel's own centre ray. Traced nowhere — only its conserved impact
+  // parameter `b = |r x v|` is wanted, for the near-critical test below.
+  let centerRay = cameraRay(uv, refine.resolution, refine.yaw, refine.pitch, refine.orbitRadius, refine.fov, refine.centerY);
+  let impactParameter = length(cross(centerRay.position, centerRay.velocity));
+
   // --- band detection ---------------------------------------------------------
   // Mixed state in the 5x5 neighbourhood: a different hit/miss answer, a
   // different shadow flag, or a steep radial gradient. Any of the three means
   // the pixel's ray bundle straddles something the single centre ray cannot
   // describe.
-  var boundary = false;
+  //
+  // ...OR the ray is near-critical, whatever its neighbours say. The
+  // neighbourhood tests are blind to an image thinner than the gap between two
+  // centre rays, and every extra half turn around the photon sphere compresses
+  // one by e^-pi, so the arcs closest to the silhouette live BETWEEN the centre
+  // rays of an otherwise uniform, all-shadow 5x5 block. `b` is the coordinate
+  // they are thin in, so the band is defined there (see `CRITICAL_BAND`).
+  var boundary = abs(impactParameter - B_CRIT) < CRITICAL_BAND * HORIZON;
   for (var dy = -MASK_RADIUS; dy <= MASK_RADIUS; dy++) {
     for (var dx = -MASK_RADIUS; dx <= MASK_RADIUS; dx++) {
       let neighbor = clamp(texel + vec2i(dx, dy), vec2i(0), dimensions - vec2i(1));
@@ -117,7 +219,7 @@ fn isHitAt(plane: vec2f) -> bool {
   // path. `1.0` and `0.0` are both exact in rg8unorm, so a non-band pixel
   // multiplies its alpha by a literal 1 and stays bit-for-bit unchanged.
   if (!boundary) {
-    return vec2f(select(0.0, 1.0, centerHit), 0.0);
+    return RefineOut(vec2f(select(0.0, 1.0, centerHit), 0.0), vec4f(0.0));
   }
 
   // --- 16 sub-rays ------------------------------------------------------------
@@ -130,6 +232,22 @@ fn isHitAt(plane: vec2f) -> bool {
   var hits = 0.0;
   var minRadius = 1e9;
   var maxRadius = -1e9;
+  // The sub-ray that stands in for the centre ray when the centre ray itself
+  // missed: the surviving sub-ray CLOSEST TO THE PIXEL CENTRE, kept whole — its
+  // own plane position and its own direction, one real geodesic.
+  //
+  // Not an average of the sub-rays: averaging positions lies about the geometry
+  // (gbuffer.md), and averaging DIRECTIONS is worse here, because sub-rays on
+  // either side of a fold cross opposite faces of the disk and their `dir.y`
+  // would cancel — the disk look reads `1/|dir.y|` as its slab path length, so a
+  // cancelled y would shade the arc at the 34x edge-on ceiling. The nearest
+  // surviving sample is the honest answer to "what would the centre ray have seen
+  // had the arc been half a pixel wider", and it keeps position, azimuth and
+  // direction mutually consistent because they come from ONE ray.
+  var bestPlane = vec2f(0.0);
+  var bestDirection = vec2f(0.0);
+  var bestRadius = 0.0;
+  var bestDistance = 1e9;
   // Shadow coverage is deliberately NOT accumulated: measured, the shadow/sky
   // step is 0 -> 4/255, i.e. invisible, and consuming a fractional shadow would
   // composite stars from the truncated `gSky.xyz` of a swallowed ray — new
@@ -147,13 +265,23 @@ fn isHitAt(plane: vec2f) -> bool {
         hits += 1.0;
         minRadius = min(minRadius, radius);
         maxRadius = max(maxRadius, radius);
+        let distance = length(offset - vec2f(0.5));
+        if (distance < bestDistance) {
+          bestDistance = distance;
+          bestPlane = traced.hit1Plane;
+          // Already in `encodeDirection` form — `traceRay` stores it exactly as
+          // `bake.wgsl` writes it into `gView.xy`, so this is the same encoding
+          // `decodeGBuffer` reads on a real hit.
+          bestDirection = traced.hit1Direction;
+          bestRadius = radius;
+        }
       }
     }
   }
 
   let coverage = hits / f32(SUB_STEPS * SUB_STEPS);
   if (hits < 0.5) {
-    return vec2f(0.0, 0.0);
+    return RefineOut(vec2f(0.0, 0.0), vec4f(0.0));
   }
 
   // --- span, measured SYMMETRICALLY ABOUT THE CENTRE RAY ----------------------
@@ -166,15 +294,29 @@ fn isHitAt(plane: vec2f) -> bool {
   // risk 2). The price is a span up to 2x wider than the raw range, i.e. a
   // slightly wider prefilter — never a fade, and never a shifted one.
   //
-  // When the centre ray missed the disk entirely there is no r0 and no radius to
-  // rebuild the sample from, so the frame pass cannot shade the pixel at all;
-  // the raw range is written for the diagnostic (debug view 8) instead.
-  var span: f32;
+  // The SYNTHESIZED case is the one exception, and it is an exception because the
+  // anchor is ours to choose: this pass decides which radius the frame pass will
+  // put at the centre of its taps, so it picks the MIDPOINT of the measured range
+  // and writes the raw range as the span. Anchoring a synthesized pixel at the
+  // representative sub-ray's own radius instead, with the symmetric (2x) span,
+  // measurably dilutes it — the tap loop then averages `shadeDisk` over radii no
+  // sub-ray ever crossed, and at 720p/357 deg that came out at 25/255 against 51
+  // in the 3x reference. Only the radial coordinate is moved to the midpoint; the
+  // azimuth and the direction stay those of the nearest surviving sub-ray, i.e.
+  // of one real geodesic.
+  var r0 = length(centerPlane);
+  var span = 0.0;
+  var geometry = vec4f(0.0);
   if (centerHit) {
-    let r0 = length(centerPlane);
     span = 2.0 * max(abs(maxRadius - r0), abs(r0 - minRadius));
+    // On a real centre hit the frame pass must keep using the G-buffer's f32
+    // position and its exact direction — an f16 copy would be a silent,
+    // pointless downgrade — so the attachment stays zero and `(0,0)` means
+    // "nothing to substitute".
   } else {
+    r0 = 0.5 * (minRadius + maxRadius);
     span = maxRadius - minRadius;
+    geometry = vec4f(bestPlane * (r0 / max(bestRadius, ISCO)), bestDirection);
   }
-  return vec2f(coverage, clamp(span / annulus, 0.0, 1.0));
+  return RefineOut(vec2f(coverage, clamp(span / annulus, 0.0, 1.0)), geometry);
 }

--- a/apps/docs/components/hero/renderer.ts
+++ b/apps/docs/components/hero/renderer.ts
@@ -73,7 +73,7 @@ export interface HeroSettings {
   centerY: number;
 
   // --- Frame-only settings. No re-bake. ---
-  /** 0 = final image, 1..8 = G-buffer debug views. */
+  /** 0 = final image, 1..9 = G-buffer debug views. */
   debugView: number;
   /**
    * Photon-ring antialiasing: 1 consumes the one-shot refine pass's
@@ -405,8 +405,10 @@ interface Targets {
   /** G-buffer written once by the bake pass (MRT: hit1 / hit2 / sky / view). */
   gbuffer: Target;
   /**
-   * Photon-ring AA data, written once by the refine pass: 2 B/px of
-   * (coverage, span) for the front disk crossing.
+   * Photon-ring AA data, written once by the refine pass: 10 B/px in two
+   * attachments — (coverage, span) for the front disk crossing, plus the
+   * synthesized crossing of the sub-pixel arcs whose centre ray missed the disk
+   * entirely (see AA_FORMATS).
    *
    * A separate target and a separate pass rather than a 5th bake attachment,
    * because `maxColorAttachmentBytesPerSample` is only guaranteed to be 32 and
@@ -450,14 +452,26 @@ const RENDER_DPR = 1;
  */
 const GBUFFER_FORMATS: readonly GPUTextureFormat[] = ['rg32float', 'rg32float', 'rgba16float', 'rgba16float'];
 /**
- * Photon-ring AA target: 2 bytes per pixel, (coverage, span).
+ * Photon-ring AA attachments, in @location order: 10 bytes per pixel total.
  *
- * `rg8unorm`, not a float format: coverage is 16 sub-rays (5 bits would do) and
- * span is a filter width, where 1/255 of the annulus is far below what the disk
- * look can resolve. It is also the smallest format that keeps 1.0 EXACT, which is
- * what makes every non-band pixel bit-for-bit unchanged.
+ * 0 — `rg8unorm` (coverage, span). Not a float format: coverage is 16 sub-rays
+ *     (5 bits would do) and span is a filter width, where 1/255 of the annulus is
+ *     far below what the disk look can resolve. It is also the smallest format
+ *     that keeps 1.0 EXACT, which is what makes every non-band pixel
+ *     bit-for-bit unchanged.
+ * 1 — `rgba16float` (synthesized crossing: plane xz + encoded direction). This
+ *     one cannot be 8-bit: it carries the crossing GEOMETRY of the sub-pixel arcs
+ *     that live inside the shadow silhouette, and an 8-bit azimuth quantizes to
+ *     0.0246 rad — ~5 px of stair-stepping along a 1 px arc whose azimuth only
+ *     moves 0.005 rad per pixel. Stored as an f16 plane position it keeps
+ *     ~0.13 px, and it is the same encoding `gHit1` / `gView.xy` use, so
+ *     `decodeGBuffer` substitutes it with no new decode path. See refine.wgsl.
+ *
+ * The refine pass therefore spends 10 of its own fresh 32 B/sample budget
+ * (`maxColorAttachmentBytesPerSample` is per PASS), which is the whole reason this
+ * data is not a 5th bake attachment.
  */
-const AA_FORMAT: GPUTextureFormat = 'rg8unorm';
+const AA_FORMATS: readonly GPUTextureFormat[] = ['rg8unorm', 'rgba16float'];
 const CLEAR: readonly [number, number, number, number] = [0, 0, 0, 1];
 
 export function createRenderer(options: HeroRendererOptions): HeroRenderer {
@@ -973,7 +987,11 @@ function createTargets(vgpu: VgpuApi, gpu: Gpu, size: readonly [number, number],
       colors: GBUFFER_FORMATS.map((format) => ({ format })),
       label: `${label}-gbuffer`,
     }),
-    aa: vgpu.target(gpu, { size: full, colors: [{ format: AA_FORMAT }], label: `${label}-aa` }),
+    aa: vgpu.target(gpu, {
+      size: full,
+      colors: AA_FORMATS.map((format) => ({ format })),
+      label: `${label}-aa`,
+    }),
   };
 }
 
@@ -988,7 +1006,7 @@ function destroyTarget(target: Target | undefined): void {
 
 function setBindings(effects: Effects, targets: Targets): void {
   const [hit1, hit2, sky, view] = targets.gbuffer.colors;
-  const [aa] = targets.aa.colors;
+  const [aa, aaGeom] = targets.aa.colors;
   effects.bake.set({ bake: { resolution: targets.gbuffer.size } });
   // The refine pass reads the two G-buffer channels it needs (first crossing +
   // flags) and writes the AA target. Same geometry uniform as the bake, uploaded
@@ -1006,6 +1024,10 @@ function setBindings(effects: Effects, targets: Targets): void {
       gSky: sky,
       gView: view,
       gAa: aa,
+      // Second AA attachment: the synthesized crossing for pixels whose centre
+      // ray missed the sub-pixel arcs inside the shadow silhouette. Ignored
+      // entirely when `Shade.aa` is 0.
+      gAaGeom: aaGeom,
       // Resize-invariant, but re-bound with the rest: `setBindings` rebuilds the
       // whole shade bind group when the G-buffer is recreated, and a bind group
       // is all-or-nothing.
@@ -1141,7 +1163,7 @@ function renderChain(
     // guarantee that none of its cost is attributed to the shade pass.
     frame.pass({ target: targets.aa, clear: CLEAR }, (pass) => pass.draw(effects.refine));
   }
-  // Two passes per frame, still: shade reads the G-buffer plus 2 B/px of AA data
+  // Two passes per frame, still: shade reads the G-buffer plus 10 B/px of AA data
   // and writes the swap chain. The two above are one-shot.
   frame.pass({ target: output, clear: CLEAR, timer }, (pass) => pass.draw(effects.shade));
 }

--- a/apps/docs/components/hero/shade.wgsl
+++ b/apps/docs/components/hero/shade.wgsl
@@ -29,7 +29,7 @@ struct Shade {
   time: f32,
   /** Outer disk radius the G-buffer was baked with. */
   diskOuter: f32,
-  /** 0 = final image, 1..8 = G-buffer debug views (see gbuffer.md). */
+  /** 0 = final image, 1..9 = G-buffer debug views (see gbuffer.md). */
   debugView: f32,
   /**
    * Photon-ring antialiasing: 1 consumes the refine pass's coverage/span target,
@@ -119,12 +119,25 @@ const SATURATION: f32 = 0.0;
  * the front crossing, y = the disk radius the pixel spans there (normalized
  * annulus units, centred on the pixel's own radius). See refine.wgsl.
  *
- * 2 B/px on top of the 32 B/px the G-buffer already costs this pass, read with
- * the same 1:1 `textureLoad` as everything else. It is a separate target rather
- * than a 5th bake attachment because the bake's MRT already spends the full
- * 32 B/sample WebGPU guarantees.
+ * 2 B/px on top of the 32 B/px the G-buffer already costs this pass (the other
+ * 8 are `gAaGeom` below), read with the same 1:1 `textureLoad` as everything else.
+ * It is a separate target rather than a 5th bake attachment because the bake's MRT
+ * already spends the full 32 B/sample WebGPU guarantees.
  */
 @group(0) @binding(9) var gAa: texture_2d<f32>;
+/**
+ * Second attachment of the refine pass: a SYNTHESIZED front crossing
+ * (`rgba16float`, xy = plane position, zw = encoded direction) for the pixels
+ * whose centre ray missed the ring while the sub-rays found it — the sub-pixel
+ * arcs inside the shadow silhouette. `(0,0,0,0)` everywhere else.
+ *
+ * Coverage can only SCALE a sample; this is the sample. 8 B/px more read on top
+ * of the 32 B/px G-buffer and the 2 B/px coverage pair, one extra `textureLoad`,
+ * and it is consumed exclusively through `decodeGBuffer` — see refine.wgsl for
+ * why the crossing is stored as an f16 plane position instead of an 8-bit
+ * (radius, azimuth) pair.
+ */
+@group(0) @binding(10) var gAaGeom: texture_2d<f32>;
 
 /**
  * Screen-space footprint of the disk noise for one layer, in noise units per
@@ -403,6 +416,16 @@ fn tonemap(linearColor: vec3f, uv: vec2f) -> vec3f {
   // (1, 0) — an exact 1 in rg8unorm — so those pixels multiply their alpha by a
   // literal one and stay bit-for-bit what they were.
   let aa = textureLoad(gAa, texel, 0).xy;
+  // The synthesized crossing, and the ONLY place `Shade.aa` gates something
+  // before the decode. It has to be gated here rather than downstream because a
+  // substituted sample changes `isHit`, and `isHit` feeds the derivative prologue
+  // below: at `aa = 0` the frame pass must see the same G-buffer it saw before
+  // this pass existed, footprints included, or the A/B would not be exact.
+  //
+  // The load itself is unconditional (uniform control flow, one texel) and only
+  // the value is selected — a branch here would be a non-uniform texture fetch in
+  // the middle of the derivative prologue.
+  let aaGeom = select(vec4f(0.0), textureLoad(gAaGeom, texel, 0), shade.aa > 0.5);
 
   let baked = decodeGBuffer(
     textureLoad(gHit1, texel, 0).xy,
@@ -411,6 +434,7 @@ fn tonemap(linearColor: vec3f, uv: vec2f) -> vec3f {
     textureLoad(gView, texel, 0),
     shade.diskOuter,
     aa,
+    aaGeom,
   );
 
   // Both footprints, in uniform control flow. The second layer sits at a
@@ -562,14 +586,31 @@ fn tonemap(linearColor: vec3f, uv: vec2f) -> vec3f {
   // prefilter ran. So:
   //   dark red rim, B = 0  -> partial coverage, no compression: coverage only.
   //   yellow + blue        -> the compressed band; this is the ring being fixed.
-  //   R > 0 with G = 0 and no B on a pixel that renders black -> the failure mode
-  //     to look for: the 5x5 dilation found coverage the centre ray missed, and
-  //     there is no radius to rebuild the sample from (see refine.wgsl).
+  //   R > 0 on a pixel that renders black -> a dropout: coverage was measured and
+  //     nothing was shaded with it. Inside the silhouette that used to be the
+  //     documented "known gap"; it is now covered by the synthesized crossing, so
+  //     cross-check any such pixel against view 9 before blaming the tap loop.
   if (mode == 8) {
     return vec4f(
       aa.x,
       aa.y,
       select(0.0, 1.0, shade.aa > 0.5 && g.isHit && g.span > AA_SPAN_MIN),
+      1.0,
+    );
+  }
+  // Synthesized-crossing diagnostic — the sub-pixel arcs that live INSIDE the
+  // shadow silhouette, where no centre ray of the neighbourhood ever hit the disk
+  // and coverage alone had nothing to scale. R = that crossing's normalized disk
+  // radius, G = its azimuth (0..1), B = 1 exactly where the frame pass shaded a
+  // synthesized sample. Black everywhere else, and black everywhere at `--aa 0`.
+  //
+  // Read it together with view 8: R > 0 in view 8 with a black final image and no
+  // B here means a dropout the refine pass measured but could not rebuild.
+  if (mode == 9) {
+    return vec4f(
+      select(0.0, g.diskUv.x, g.synthesized),
+      select(0.0, g.diskUv.y, g.synthesized),
+      select(0.0, 1.0, g.synthesized),
       1.0,
     );
   }


### PR DESCRIPTION
Closes most of the AA 'known gap' from #232: sub-pixel arcs of the lensed disk living entirely inside the shadow silhouette rendered as luma 0 because no centre ray ever saw the disk — coverage had nothing to scale.

**How**: the one-shot refine pass now also fires on a physical near-critical band (|b − b_crit| < 0.06, impact parameter conserved along geodesics) and stores the surviving sub-ray's crossing (plane position + encoded direction, f16) in a second AA attachment; `decodeGBuffer` substitutes it when the centre ray missed, and everything downstream (footprints, rotation, K-tap prefilter, disk shading) treats it as a real crossing.

**Measured** (against the algorithm-free `--ssaa 3 --aa 0` reference): inner-band energy 33% → 80%, ring std 1.17× → 0.86× ref, zero-azimuths 6 → 1, neighbour jumps 0/50. `--aa 0` stays byte-identical; star/sky path bit-for-bit untouched. Per-frame cost: +3.4% of the disk-shading work (thermal gate: user-measured 1.3ms shade, gate 1.45ms).

**Review cycle**: implementation independently validated by a second agent (byte-level A/B against a fresh baseline worktree); doc corrections applied (cost double-count, wave-bound normalization, reproducible reference pinned).

**Honest residuals documented in gbuffer.md**: the near-critical criterion changes nothing at 720p defaults (contributes from ~1080p); 8/360 strict-sweep azimuths remain under 50% of ref (was 9/360); and a second, deeper inner arc at ~45° that 16 sub-rays miss while the 3× reference finds it — pre-existing, unexplained, left as the new known gap with repro commands.