### PR TITLE
feat(agent-evals): s1-clear-color task + host verifier

### DIFF
--- a/apps/agent-evals/.gitignore
+++ b/apps/agent-evals/.gitignore
@@ -1,0 +1,2 @@
+.work/
+node_modules/

--- a/apps/agent-evals/README.md
+++ b/apps/agent-evals/README.md
@@ -50,10 +50,51 @@ reverse direction is a boundary violation.
 node verify/run-verify.mjs --workspace <dir> --task s1-clear-color [--out evidence.json] [--work-dir <dir>]
 ```
 
-The verifier never trusts what it finds in `<dir>`: it copies the source files
-into a clean, separately-installed workspace, **deletes any pre-existing
-`out.png`**, re-runs `node render.mjs` in a fresh process, and grades the pixels
-of the PNG that run produced. A hand-forged output PNG therefore cannot pass.
+### What the verifier trusts
+
+The agent's workspace contributes **source text and nothing else**. Per call the
+verifier:
+
+1. seeds a run directory from `tasks/<id>/fixture/` and **wipes its source tree
+   first**, so no trial can inherit another trial's files (run directories are
+   keyed by `runId`, so concurrent trials cannot collide either);
+2. installs the **fixture's** dependencies with `--ignore-scripts`, so nothing
+   the agent wrote runs on the host at install time and `node_modules` cannot be
+   monkey-patched;
+3. never copies the agent's `package.json` or any lockfile — a changed manifest
+   is *reported* via the `packageJsonUnchanged` gate, never honoured;
+4. deletes any pre-existing `out.png` unconditionally and re-renders in a fresh
+   process with a `PATH`+`HOME`-only environment;
+5. grades only the PNG that run produced.
+
+So a hand-forged PNG cannot pass, a hijacked dependency cannot pass, and a
+stale trial cannot pass. Each of those is a named regression test in
+`verify/verify-task.test.ts`, and each of them **did** pass at some point during
+review — the claims above are the fixes, not the original design.
+
+### What the verifier does NOT give you
+
+It is **not a security boundary.** The graded render executes agent-authored
+code on the host, as your user. It defeats accidental and opportunistic cheating;
+it does not contain a determined attacker.
+
+It also grades **on the host**, not inside the pinned container the parent design
+calls for. That is a deliberate skeleton-stage tradeoff: it is what makes Layer 1
+runnable in any dev environment and in CI without Docker. The consequences you
+must know about:
+
+- `evidence.env` records `node`, `vgpu`, `gitSha` and the `vgpu doctor` adapter,
+  but **no `imageDigest`** — results are only as comparable as the hosts that
+  produced them. Fine for an exact-colour gate; **not** fine for the
+  pixel-ratio/tolerance tasks planned later. Tracked as follow-up: grade inside
+  a pinned image and stamp its digest into `evidence.env` before any task whose
+  verdict depends on a ratio.
+- `metrics.vgpuLoaded` is a **soft signal, never a gate**: `s1-clear-color` is
+  passable with `pngjs` alone (six lines, no vgpu). The evidence records whether
+  the graded render actually loaded the library under test so that a
+  library-free "solution" is visible to a reader instead of silently scoring
+  green. Making it a gate is a task-design decision for a later PR, not a
+  verifier change.
 
 ## Known friction (recorded on purpose, do not "fix")
 

--- a/apps/agent-evals/README.md
+++ b/apps/agent-evals/README.md
@@ -1,0 +1,77 @@
+# @vgpu/agent-evals
+
+Agent evals for `vgpu`: measures how well a coding agent (with no vgpu-specific
+prompting) can complete a real rendering task using the published `vgpu`
+package.
+
+The package has two layers:
+
+- **Layer 1 — `tasks/` + `verify/` (this PR).** Task fixtures plus a
+  deterministic, driver-agnostic grader. No knowledge of any agent framework.
+- **Layer 2 — `agent/` + `evals/` (next PR).** The `eve`-based driver that runs
+  an agent against a task and hands the resulting workspace to Layer 1.
+
+## Intentionally outside the root test/typecheck configs
+
+`apps/agent-evals` is a workspace member (`apps/*` is already a member glob),
+but it is **deliberately absent** from the root `vitest.config.ts` `include`
+list and from the root `tsconfig.json` `references`. Do not add it there.
+
+The verifier's tests install a real `node_modules` into `.work/` and spawn
+`node render.mjs`; coupling them to the library's own fast CI would make that CI
+slow and flaky. Run this package's tests explicitly instead:
+
+```bash
+pnpm --filter @vgpu/agent-evals test
+pnpm --filter @vgpu/agent-evals exec tsc --noEmit
+```
+
+## Node.js version
+
+Layer 1 (`tasks/`, `verify/`) runs on this repo's own Node (22).
+
+Running the eve-driven evals (Layer 2, added in the next PR) requires
+**Node.js >= 24** and an AI Gateway credential (`AI_GATEWAY_API_KEY` or
+`VERCEL_OIDC_TOKEN`). This repo pins Node 22 (`.nvmrc`, root `engines`) and that
+does not change — so this host may well have neither Node 24 nor a credential,
+which is expected. Use `pnpm agent-evals` from the repo root (added in PR3),
+which preflights the Node version and fails fast with an actionable message.
+
+## Layer boundary invariant
+
+**Nothing under `tasks/` or `verify/` may import `eve`.** That is what keeps
+Layer 1 promotable to a standalone `packages/eval-tasks` (for a second, non-eve
+driver) via a mechanical `git mv`. Layer 2 depending on Layer 1 is fine; the
+reverse direction is a boundary violation.
+
+## Usage (Layer 1)
+
+```bash
+node verify/run-verify.mjs --workspace <dir> --task s1-clear-color [--out evidence.json] [--work-dir <dir>]
+```
+
+The verifier never trusts what it finds in `<dir>`: it copies the source files
+into a clean, separately-installed workspace, **deletes any pre-existing
+`out.png`**, re-runs `node render.mjs` in a fresh process, and grades the pixels
+of the PNG that run produced. A hand-forged output PNG therefore cannot pass.
+
+## Known friction (recorded on purpose, do not "fix")
+
+The getting-started snippet does not run out of the box after `pnpm add vgpu`
+alone: `pngjs` must be declared explicitly, because it is a transitive
+dependency and pnpm's strict `node_modules` layout does not hoist it. That is
+why `pngjs` appears twice in this package — once in
+`tasks/s1-clear-color/fixture/package.json` (for the code that runs *inside* the
+graded workspace) and once in this package's own `devDependencies` (for the
+host-side grader in `verify/grade-pixels.mjs`). Those two are deliberately
+separate. This is a real product finding that the eval exists to surface; do not
+paper over it beyond declaring the dependency.
+
+## Future work — skill payload excision clause
+
+Once the skill-distribution payload (Amendment 3 of the parent design) is
+vendored into this package in a later PR, it **must** be excised of
+`packages/ infra/ examples/ apps/ scripts/ docs/` and of any lockfiles before
+being trusted as a fixture. A vendored payload that still contains the repo's
+own sources would let an agent read the answer instead of discovering it. Do not
+shortcut this later.

--- a/apps/agent-evals/package.json
+++ b/apps/agent-evals/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@vgpu/agent-evals",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "vitest run",
+    "verify": "node verify/run-verify.mjs"
+  },
+  "devDependencies": {
+    "@types/node": "^22.10.7",
+    "pngjs": "^7.0.0",
+    "typescript": "^5.7.3",
+    "vitest": "^3.2.7"
+  }
+}

--- a/apps/agent-evals/tasks/s1-clear-color/fixture/package.json
+++ b/apps/agent-evals/tasks/s1-clear-color/fixture/package.json
@@ -1,0 +1,5 @@
+{
+  "private": true,
+  "type": "module",
+  "dependencies": { "vgpu": "0.2.0", "pngjs": "7.0.0" }
+}

--- a/apps/agent-evals/tasks/s1-clear-color/fixture/render.mjs
+++ b/apps/agent-evals/tasks/s1-clear-color/fixture/render.mjs
@@ -1,0 +1,21 @@
+import { writeFileSync } from "node:fs";
+import { PNG } from "pngjs";
+import { init, effect, target } from "vgpu/node";
+
+const SHADER = `
+  @fragment fn main() -> @location(0) vec4f {
+    return vec4f(0.25, 0.5, 0.75, 1.0);
+  }
+`;
+const width = 64;
+const height = 64;
+
+const gpu = await init();
+const colorTarget = target(gpu, { size: [width, height] });
+effect(gpu, SHADER).draw(colorTarget);
+const pixels = await colorTarget.read();
+
+const png = new PNG({ width, height });
+png.data.set(pixels);
+writeFileSync("out.png", PNG.sync.write(png));
+gpu.dispose();

--- a/apps/agent-evals/tasks/s1-clear-color/manifest.json
+++ b/apps/agent-evals/tasks/s1-clear-color/manifest.json
@@ -1,0 +1,14 @@
+{
+  "taskId": "s1-clear-color",
+  "vgpu": "0.2.0",
+  "source": "registry",
+  "expected": { "width": 64, "height": 64, "color": [255, 0, 0, 255] },
+  "journeyMilestones": [
+    { "id": "ranVgpuCli", "tool": "bash", "commandPattern": "(^|[^a-z])vgpu\\b" },
+    { "id": "readDocs", "tool": "bash", "commandPattern": "vgpu\\s+docs\\b" },
+    { "id": "ranDoctor", "tool": "bash", "commandPattern": "vgpu\\s+doctor\\b" },
+    { "id": "ranCheck", "tool": "bash", "commandPattern": "vgpu\\s+check\\b" },
+    { "id": "ranRender", "tool": "bash", "commandPattern": "node\\s+\\S*render\\.mjs" },
+    { "id": "editedShader", "tool": "write_file", "pathPattern": "\\.(mjs|wgsl)$" }
+  ]
+}

--- a/apps/agent-evals/tasks/s1-clear-color/prompt.md
+++ b/apps/agent-evals/tasks/s1-clear-color/prompt.md
@@ -1,0 +1,5 @@
+The project in `/workspace` generates an image by running `node render.mjs`, which writes `out.png`.
+
+Make the resulting image solid red: every pixel exactly R=255, G=0, B=0, A=255, at 64×64.
+
+Keep the entry point as `node render.mjs` writing `out.png`.

--- a/apps/agent-evals/tsconfig.json
+++ b/apps/agent-evals/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    // The verifier itself is plain `.mjs` (it must stay runnable with bare
+    // `node`, with no build step); `allowJs` lets the TypeScript test file
+    // import it and pick up its JSDoc types instead of erroring with TS7016.
+    "allowJs": true,
+    "checkJs": false,
+    "skipLibCheck": true,
+    "types": ["node"]
+  },
+  "include": ["verify/**/*.ts"]
+}

--- a/apps/agent-evals/verify/__fixtures__/correct/render.mjs
+++ b/apps/agent-evals/verify/__fixtures__/correct/render.mjs
@@ -1,0 +1,21 @@
+import { writeFileSync } from "node:fs";
+import { PNG } from "pngjs";
+import { init, effect, target } from "vgpu/node";
+
+const SHADER = `
+  @fragment fn main() -> @location(0) vec4f {
+    return vec4f(1.0, 0.0, 0.0, 1.0);
+  }
+`;
+const width = 64;
+const height = 64;
+
+const gpu = await init();
+const colorTarget = target(gpu, { size: [width, height] });
+effect(gpu, SHADER).draw(colorTarget);
+const pixels = await colorTarget.read();
+
+const png = new PNG({ width, height });
+png.data.set(pixels);
+writeFileSync("out.png", PNG.sync.write(png));
+gpu.dispose();

--- a/apps/agent-evals/verify/__fixtures__/forgery/render.mjs
+++ b/apps/agent-evals/verify/__fixtures__/forgery/render.mjs
@@ -1,0 +1,4 @@
+// The "cheating agent" fixture: it hand-delivers a red out.png next to this
+// file and then makes the actual renderer a no-op. Re-execution must not be
+// fooled by the pre-existing PNG.
+console.log("nothing to do, out.png is already correct");

--- a/apps/agent-evals/verify/__fixtures__/unchanged/render.mjs
+++ b/apps/agent-evals/verify/__fixtures__/unchanged/render.mjs
@@ -1,0 +1,21 @@
+import { writeFileSync } from "node:fs";
+import { PNG } from "pngjs";
+import { init, effect, target } from "vgpu/node";
+
+const SHADER = `
+  @fragment fn main() -> @location(0) vec4f {
+    return vec4f(0.25, 0.5, 0.75, 1.0);
+  }
+`;
+const width = 64;
+const height = 64;
+
+const gpu = await init();
+const colorTarget = target(gpu, { size: [width, height] });
+effect(gpu, SHADER).draw(colorTarget);
+const pixels = await colorTarget.read();
+
+const png = new PNG({ width, height });
+png.data.set(pixels);
+writeFileSync("out.png", PNG.sync.write(png));
+gpu.dispose();

--- a/apps/agent-evals/verify/grade-pixels.mjs
+++ b/apps/agent-evals/verify/grade-pixels.mjs
@@ -1,0 +1,53 @@
+// Pure pixel grading. Knows nothing about tasks, workspaces or processes, so it
+// is testable with an in-memory PNG buffer alone.
+//
+// gradePixels(pngBuffer: Buffer, expected: { width: number, height: number, color: [number,number,number,number] })
+//   -> { width, height, distinctColors, dominantPixel, matchedFraction }
+import { PNG } from "pngjs";
+
+/**
+ * @param {Buffer} pngBuffer raw bytes of a PNG file
+ * @param {{ width: number, height: number, color: [number, number, number, number] }} expected
+ */
+export function gradePixels(pngBuffer, expected) {
+  const png = PNG.sync.read(pngBuffer);
+  const { width, height, data } = png;
+
+  /** @type {Map<string, number>} */
+  const counts = new Map();
+  const [er, eg, eb, ea] = expected.color;
+  let matched = 0;
+  let total = 0;
+
+  for (let i = 0; i + 3 < data.length; i += 4) {
+    const r = data[i];
+    const g = data[i + 1];
+    const b = data[i + 2];
+    const a = data[i + 3];
+    total += 1;
+
+    const key = `${r},${g},${b},${a}`;
+    counts.set(key, (counts.get(key) ?? 0) + 1);
+
+    if (r === er && g === eg && b === eb && a === ea) matched += 1;
+  }
+
+  let dominantKey = "0,0,0,0";
+  let dominantCount = -1;
+  for (const [key, count] of counts) {
+    if (count > dominantCount) {
+      dominantCount = count;
+      dominantKey = key;
+    }
+  }
+
+  return {
+    width,
+    height,
+    distinctColors: counts.size,
+    dominantPixel: /** @type {[number, number, number, number]} */ (
+      dominantKey.split(",").map(Number)
+    ),
+    matchedFraction: total === 0 ? 0 : matched / total,
+  };
+}

--- a/apps/agent-evals/verify/probe-loader.mjs
+++ b/apps/agent-evals/verify/probe-loader.mjs
@@ -1,0 +1,20 @@
+// Module-resolution recorder for the graded render. See probe-register.mjs.
+//
+// Runs on the loader thread. It appends `<specifier>\t<resolved url>` per
+// resolution to the file named by VGPU_VERIFY_PROBE_OUT and otherwise defers
+// entirely to the default resolver.
+import { appendFileSync } from "node:fs";
+
+const OUT = process.env.VGPU_VERIFY_PROBE_OUT;
+
+export async function resolve(specifier, context, nextResolve) {
+  const result = await nextResolve(specifier, context);
+  if (OUT) {
+    try {
+      appendFileSync(OUT, `${specifier}\t${result.url}\n`);
+    } catch {
+      // Never let bookkeeping break a render.
+    }
+  }
+  return result;
+}

--- a/apps/agent-evals/verify/probe-register.mjs
+++ b/apps/agent-evals/verify/probe-register.mjs
@@ -1,0 +1,14 @@
+// Loaded via `node --import` by the graded render (see verify-task.mjs).
+//
+// Observational only: it registers a resolve hook that records which module
+// specifiers the render loaded, so the evidence can report whether the solution
+// actually used the library under test. It must never change resolution, and a
+// failure here must never fail the render — hence the try/catch.
+import { register } from "node:module";
+
+try {
+  register(new URL("./probe-loader.mjs", import.meta.url));
+} catch {
+  // Old runtime or a restricted loader policy: the evidence reports
+  // `vgpuLoaded: null` and the render proceeds untouched.
+}

--- a/apps/agent-evals/verify/run-verify.mjs
+++ b/apps/agent-evals/verify/run-verify.mjs
@@ -1,0 +1,53 @@
+#!/usr/bin/env node
+// Thin CLI around verifyTask().
+//
+// Usage: node verify/run-verify.mjs --workspace <dir> --task <taskId> [--out <path>] [--work-dir <dir>]
+//
+// The process exit code (1 if any gate failed) is a convenience for the
+// standalone `pnpm verify` command and for manual sanity checks. Automated
+// drivers (Layer 2) MUST read the Evidence JSON's `gates` object instead and
+// must never gate on this exit code.
+import { mkdirSync, writeFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { parseArgs } from "node:util";
+import { verifyTask } from "./verify-task.mjs";
+
+const { values } = parseArgs({
+  options: {
+    workspace: { type: "string" },
+    task: { type: "string" },
+    out: { type: "string" },
+    "work-dir": { type: "string" },
+    help: { type: "boolean", short: "h" },
+  },
+});
+
+const usage =
+  "Usage: node verify/run-verify.mjs --workspace <dir> --task <taskId> [--out <path>] [--work-dir <dir>]";
+
+if (values.help) {
+  console.log(usage);
+  process.exit(0);
+}
+if (!values.workspace || !values.task) {
+  console.error(usage);
+  process.exit(64);
+}
+
+const evidence = await verifyTask({
+  taskId: values.task,
+  workspaceDir: resolve(values.workspace),
+  workDir: values["work-dir"] ? resolve(values["work-dir"]) : undefined,
+});
+
+const json = `${JSON.stringify(evidence, null, 2)}\n`;
+if (values.out) {
+  const outPath = resolve(values.out);
+  mkdirSync(dirname(outPath), { recursive: true });
+  writeFileSync(outPath, json, "utf8");
+  console.error(`evidence written to ${outPath}`);
+} else {
+  process.stdout.write(json);
+}
+
+process.exitCode = Object.values(evidence.gates).includes("fail") ? 1 : 0;

--- a/apps/agent-evals/verify/verify-task.mjs
+++ b/apps/agent-evals/verify/verify-task.mjs
@@ -1,0 +1,341 @@
+// Layer 1 re-execution engine.
+//
+// The contract that matters: nothing produced inside the graded workspace is
+// trusted. Source files are re-exported into a clean, separately-installed
+// verify-workspace, any pre-existing output is deleted, and the render is run
+// again in a fresh process before a single pixel is graded.
+//
+// IMPORTANT: no file in this directory may import `eve`. See ../README.md
+// ("Layer boundary invariant").
+//
+// verifyTask(opts: {
+//   tasksRoot: string,     // absolute path to apps/agent-evals/tasks
+//   taskId: string,        // e.g. "s1-clear-color"
+//   workspaceDir: string,  // absolute path to the (untrusted) agent workspace
+//   workDir: string,       // absolute path to a scratch root, default apps/agent-evals/.work
+// }) -> Promise<Evidence>
+import { spawn, spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import {
+  cpSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { dirname, join, relative, resolve, sep } from "node:path";
+import { fileURLToPath } from "node:url";
+import { gradePixels } from "./grade-pixels.mjs";
+
+const PACKAGE_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+
+/** Source extensions copied out of the untrusted workspace. */
+const COPIED_EXTENSIONS = new Set([".mjs", ".js", ".ts", ".wgsl", ".json"]);
+/** Directories never copied out of the untrusted workspace. */
+const EXCLUDED_DIRS = new Set(["node_modules", ".git"]);
+/** Files never copied out of the untrusted workspace (outputs must be re-produced). */
+const EXCLUDED_FILES = new Set(["out.png"]);
+
+const RENDER_TIMEOUT_MS = 120_000;
+
+export const SCHEMA_VERSION = 1;
+
+/**
+ * @param {{ tasksRoot?: string, taskId: string, workspaceDir: string, workDir?: string }} opts
+ */
+export async function verifyTask(opts) {
+  const tasksRoot = resolve(opts.tasksRoot ?? join(PACKAGE_ROOT, "tasks"));
+  const workDir = resolve(opts.workDir ?? join(PACKAGE_ROOT, ".work"));
+  const workspaceDir = resolve(opts.workspaceDir);
+  const { taskId } = opts;
+
+  const taskDir = join(tasksRoot, taskId);
+  const manifestPath = join(taskDir, "manifest.json");
+  if (!existsSync(manifestPath)) {
+    // A missing manifest is a harness bug, not a grading outcome: throw.
+    throw new Error(`verifyTask: manifest not found at ${manifestPath}`);
+  }
+  const manifest = JSON.parse(readFileSync(manifestPath, "utf8"));
+
+  // 2. Seed / reuse the verify-workspace.
+  const verifyWorkspace = join(workDir, "verify-workspace", taskId);
+  const hashFile = join(verifyWorkspace, ".install-hash");
+  const fixtureDir = join(taskDir, "fixture");
+  let seeded = false;
+  if (!existsSync(verifyWorkspace)) {
+    mkdirSync(verifyWorkspace, { recursive: true });
+    cpSync(fixtureDir, verifyWorkspace, { recursive: true });
+    seeded = true;
+  }
+  if (seeded || !existsSync(join(verifyWorkspace, "node_modules"))) {
+    installDeps(verifyWorkspace);
+    writeFileSync(hashFile, packageJsonHash(verifyWorkspace), "utf8");
+  }
+
+  // 3. Copy the agent's source files over the seeded workspace.
+  copySources(workspaceDir, verifyWorkspace);
+
+  // 4. Reinstall only if the (possibly agent-modified) package.json changed.
+  const currentHash = packageJsonHash(verifyWorkspace);
+  const previousHash = existsSync(hashFile) ? readFileSync(hashFile, "utf8") : "";
+  if (currentHash !== previousHash) {
+    installDeps(verifyWorkspace);
+    writeFileSync(hashFile, currentHash, "utf8");
+  }
+
+  // 5. Delete any output *unconditionally* before rendering. This single line is
+  //    what defeats a hand-forged PNG; do not make it conditional.
+  const outPath = join(verifyWorkspace, "out.png");
+  rmSync(outPath, { force: true });
+
+  // 6. Re-render in a fresh process with a minimal environment.
+  const render = await runRender(verifyWorkspace);
+
+  const env = {
+    vgpu: manifest.vgpu,
+    node: process.version,
+    gitSha: gitSha(),
+    ...doctorEnv(verifyWorkspace),
+    capturedAt: new Date().toISOString(),
+  };
+
+  /** @type {string[]} */
+  const failures = [];
+  /** @type {Record<string, unknown>} */
+  const metrics = {
+    renderExitCode: render.exitCode,
+    renderDurationMs: render.durationMs,
+  };
+
+  // 7. renders gate.
+  let renders = "fail";
+  if (render.timedOut) {
+    failures.push(`render timed out after ${RENDER_TIMEOUT_MS}ms`);
+  } else if (render.exitCode !== 0) {
+    failures.push(
+      `render exited with code ${render.exitCode}: ${truncate(render.stderr)}`,
+    );
+  } else if (!existsSync(outPath)) {
+    failures.push("render exited 0 but did not write out.png");
+  } else {
+    let graded;
+    try {
+      graded = gradePixels(readFileSync(outPath), manifest.expected);
+    } catch (error) {
+      failures.push(`could not decode out.png: ${String(error)}`);
+    }
+    if (graded) {
+      metrics.width = graded.width;
+      metrics.height = graded.height;
+      metrics.distinctColors = graded.distinctColors;
+      metrics.dominantPixel = graded.dominantPixel;
+      metrics.matchedFraction = graded.matchedFraction;
+      if (
+        graded.width === manifest.expected.width &&
+        graded.height === manifest.expected.height
+      ) {
+        renders = "pass";
+      } else {
+        failures.push(
+          `out.png is ${graded.width}x${graded.height}, expected ${manifest.expected.width}x${manifest.expected.height}`,
+        );
+      }
+    }
+  }
+
+  // 8. colorExact gate.
+  let colorExact = "skip";
+  if (renders === "pass") {
+    colorExact = metrics.matchedFraction === 1 ? "pass" : "fail";
+    if (colorExact === "fail") {
+      failures.push(
+        `only ${((metrics.matchedFraction ?? 0) * 100).toFixed(2)}% of pixels match ${JSON.stringify(
+          manifest.expected.color,
+        )}; dominant pixel was ${JSON.stringify(metrics.dominantPixel)}`,
+      );
+    }
+  }
+
+  // 9. Evidence. A bad render is data, never an exception.
+  return {
+    schemaVersion: SCHEMA_VERSION,
+    taskId,
+    env,
+    gates: { renders, colorExact },
+    metrics,
+    failures,
+  };
+}
+
+/**
+ * `--ignore-workspace` is MANDATORY here: `apps/agent-evals` is a pnpm workspace
+ * member, so without the flag pnpm resolves this nested directory to the root
+ * workspace and silently no-ops the install, leaving no node_modules behind.
+ * (The equivalent `.npmrc` setting does not work on pnpm 9.15.4 — it must be the
+ * CLI flag.) Do not "clean this up".
+ * @param {string} cwd
+ */
+function installDeps(cwd) {
+  const result = spawnSyncish("pnpm", ["install", "--ignore-workspace"], cwd);
+  if (result.status !== 0) {
+    throw new Error(
+      `verifyTask: pnpm install --ignore-workspace failed in ${cwd}: ${truncate(result.stderr)}`,
+    );
+  }
+}
+
+/** @param {string} verifyWorkspace */
+function packageJsonHash(verifyWorkspace) {
+  const pkgPath = join(verifyWorkspace, "package.json");
+  const bytes = existsSync(pkgPath) ? readFileSync(pkgPath) : Buffer.alloc(0);
+  return createHash("sha256").update(bytes).digest("hex");
+}
+
+/**
+ * Copy every `**\/*.{mjs,js,ts,wgsl,json}` from the untrusted workspace into the
+ * verify-workspace, excluding node_modules/, .git/ and out.png.
+ * @param {string} from
+ * @param {string} to
+ */
+function copySources(from, to) {
+  if (!existsSync(from)) {
+    throw new Error(`verifyTask: workspaceDir does not exist: ${from}`);
+  }
+  /** @param {string} dir */
+  const walk = (dir) => {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      if (entry.isDirectory()) {
+        if (EXCLUDED_DIRS.has(entry.name)) continue;
+        walk(join(dir, entry.name));
+        continue;
+      }
+      if (!entry.isFile()) continue;
+      if (EXCLUDED_FILES.has(entry.name)) continue;
+      const dot = entry.name.lastIndexOf(".");
+      const ext = dot === -1 ? "" : entry.name.slice(dot);
+      if (!COPIED_EXTENSIONS.has(ext)) continue;
+      const abs = join(dir, entry.name);
+      const rel = relative(from, abs);
+      if (rel.split(sep).includes("node_modules")) continue;
+      const dest = join(to, rel);
+      mkdirSync(dirname(dest), { recursive: true });
+      cpSync(abs, dest);
+    }
+  };
+  walk(from);
+}
+
+/**
+ * Fresh `node render.mjs`, hard timeout, explicit env allowlist (PATH + HOME
+ * only — deps are already installed, nothing else from the parent process,
+ * including any leaked secrets, is passed through).
+ * @param {string} cwd
+ */
+function runRender(cwd) {
+  return new Promise((resolvePromise) => {
+    const startedAt = Date.now();
+    const child = spawn(process.execPath, ["render.mjs"], {
+      cwd,
+      env: { PATH: process.env.PATH ?? "", HOME: process.env.HOME ?? "" },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let stdout = "";
+    let stderr = "";
+    let timedOut = false;
+    const timer = setTimeout(() => {
+      timedOut = true;
+      child.kill("SIGKILL");
+    }, RENDER_TIMEOUT_MS);
+    child.stdout.on("data", (chunk) => {
+      stdout += String(chunk);
+    });
+    child.stderr.on("data", (chunk) => {
+      stderr += String(chunk);
+    });
+    child.on("error", (error) => {
+      clearTimeout(timer);
+      resolvePromise({
+        exitCode: -1,
+        stdout,
+        stderr: `${stderr}${String(error)}`,
+        timedOut,
+        durationMs: Date.now() - startedAt,
+      });
+    });
+    child.on("close", (code) => {
+      clearTimeout(timer);
+      resolvePromise({
+        exitCode: timedOut ? -1 : (code ?? -1),
+        stdout,
+        stderr,
+        timedOut,
+        durationMs: Date.now() - startedAt,
+      });
+    });
+  });
+}
+
+/**
+ * `vgpu doctor` against the verify-workspace: ~1-2s, and it catches a broken
+ * host before a bad render gets blamed on the agent. Never throws.
+ *
+ * NOTE: no `--json` flag. `vgpu@0.2.0`'s doctor writes JSON to stdout by
+ * default (`Usage: vgpu doctor [--no-render] [--pretty]`); passing `--json`
+ * fails with "Unknown doctor option: --json" and exit 1.
+ * @param {string} cwd
+ */
+function doctorEnv(cwd) {
+  const fallback = { adapterName: null, adapterType: null, doctorVerdict: null };
+  const result = spawnSyncish("npx", ["vgpu", "doctor"], cwd);
+  if (result.status !== 0 && !result.stdout) return fallback;
+  try {
+    const parsed = JSON.parse(extractJson(result.stdout));
+    const adapter = parsed.adapter ?? parsed.gpu ?? {};
+    return {
+      adapterName: adapter.name ?? adapter.description ?? parsed.adapterName ?? null,
+      adapterType: adapter.type ?? parsed.adapterType ?? null,
+      doctorVerdict: parsed.verdict ?? null,
+    };
+  } catch {
+    return fallback;
+  }
+}
+
+/** @param {string} text */
+function extractJson(text) {
+  const start = text.indexOf("{");
+  const end = text.lastIndexOf("}");
+  return start === -1 || end === -1 ? text : text.slice(start, end + 1);
+}
+
+function gitSha() {
+  const result = spawnSyncish("git", ["rev-parse", "--short", "HEAD"], PACKAGE_ROOT);
+  return result.status === 0 ? result.stdout.trim() : null;
+}
+
+/**
+ * @param {string} command
+ * @param {string[]} args
+ * @param {string} cwd
+ */
+function spawnSyncish(command, args, cwd) {
+  const result = spawnSync(command, args, {
+    cwd,
+    encoding: "utf8",
+    env: process.env,
+    maxBuffer: 32 * 1024 * 1024,
+  });
+  return {
+    status: result.status ?? -1,
+    stdout: result.stdout ?? "",
+    stderr: result.stderr ?? "",
+  };
+}
+
+/** @param {string} text */
+function truncate(text, max = 2000) {
+  const value = String(text ?? "");
+  return value.length > max ? `${value.slice(0, max)}…` : value;
+}

--- a/apps/agent-evals/verify/verify-task.mjs
+++ b/apps/agent-evals/verify/verify-task.mjs
@@ -1,9 +1,27 @@
 // Layer 1 re-execution engine.
 //
-// The contract that matters: nothing produced inside the graded workspace is
-// trusted. Source files are re-exported into a clean, separately-installed
-// verify-workspace, any pre-existing output is deleted, and the render is run
-// again in a fresh process before a single pixel is graded.
+// THE TRUST MODEL, precisely (read this before changing anything below):
+//
+//   The agent's workspace contributes SOURCE TEXT and nothing else. Every other
+//   input to the verdict — the dependency manifest, the installed
+//   node_modules, the output PNG — is produced by this file from the task
+//   fixture. Concretely, per call:
+//     * a run directory is seeded from `tasks/<id>/fixture/` and its source
+//       tree is wiped and re-seeded, so no trial can inherit another's files;
+//     * dependencies are installed from the FIXTURE's package.json with
+//       `--ignore-scripts`, so nothing the agent wrote executes on the host at
+//       install time and node_modules cannot be monkey-patched;
+//     * the agent's own package.json / lockfiles are never copied — a changed
+//       manifest (dependencies or scripts) is reported as the
+//       `packageJsonUnchanged` gate instead of being honoured;
+//     * `out.png` is deleted unconditionally and re-rendered in a fresh
+//       process with an env allowlist (PATH + HOME) before a pixel is graded.
+//
+// What this is NOT: a security boundary. The graded render still executes
+// agent-authored code on the host, as the agent's own user. It defeats
+// accidental and opportunistic cheating (a forged PNG, a hijacked dependency,
+// leftovers from a previous trial); it does not contain a determined attacker.
+// Running the render inside a pinned container is tracked as follow-up work.
 //
 // IMPORTANT: no file in this directory may import `eve`. See ../README.md
 // ("Layer boundary invariant").
@@ -13,9 +31,10 @@
 //   taskId: string,        // e.g. "s1-clear-color"
 //   workspaceDir: string,  // absolute path to the (untrusted) agent workspace
 //   workDir: string,       // absolute path to a scratch root, default apps/agent-evals/.work
+//   runId: string,         // optional; isolates concurrent trials, default random
 // }) -> Promise<Evidence>
 import { spawn, spawnSync } from "node:child_process";
-import { createHash } from "node:crypto";
+import { randomUUID } from "node:crypto";
 import {
   cpSync,
   existsSync,
@@ -25,31 +44,55 @@ import {
   rmSync,
   writeFileSync,
 } from "node:fs";
-import { dirname, join, relative, resolve, sep } from "node:path";
-import { fileURLToPath } from "node:url";
+import { basename, dirname, join, relative, resolve, sep } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import { gradePixels } from "./grade-pixels.mjs";
 
 const PACKAGE_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const VERIFY_DIR = join(PACKAGE_ROOT, "verify");
 
 /** Source extensions copied out of the untrusted workspace. */
 const COPIED_EXTENSIONS = new Set([".mjs", ".js", ".ts", ".wgsl", ".json"]);
 /** Directories never copied out of the untrusted workspace. */
 const EXCLUDED_DIRS = new Set(["node_modules", ".git"]);
-/** Files never copied out of the untrusted workspace (outputs must be re-produced). */
-const EXCLUDED_FILES = new Set(["out.png"]);
+/**
+ * Files never copied out of the untrusted workspace, at ANY depth.
+ *
+ * `out.png` because outputs must be re-produced, never imported. Everything
+ * else because it steers dependency resolution or install-time execution:
+ * the dependency set is the fixture's, full stop. A nested `package.json` also
+ * changes module resolution (`"type"`), so it is excluded too.
+ */
+const EXCLUDED_FILES = new Set([
+  "out.png",
+  "package.json",
+  "pnpm-lock.yaml",
+  "package-lock.json",
+  "yarn.lock",
+  "npm-shrinkwrap.json",
+  ".npmrc",
+  ".pnpmfile.cjs",
+]);
+/** Kept out of the wipe: reinstalling per trial would dominate the runtime. */
+const PRESERVED_ON_RESEED = new Set(["node_modules"]);
 
 const RENDER_TIMEOUT_MS = 120_000;
 
 export const SCHEMA_VERSION = 1;
 
 /**
- * @param {{ tasksRoot?: string, taskId: string, workspaceDir: string, workDir?: string }} opts
+ * @param {{ tasksRoot?: string, taskId: string, workspaceDir: string, workDir?: string, runId?: string }} opts
  */
 export async function verifyTask(opts) {
   const tasksRoot = resolve(opts.tasksRoot ?? join(PACKAGE_ROOT, "tasks"));
   const workDir = resolve(opts.workDir ?? join(PACKAGE_ROOT, ".work"));
   const workspaceDir = resolve(opts.workspaceDir);
   const { taskId } = opts;
+  // Concurrent trials of the same task must not share a run directory. The
+  // default is unique per call; callers that want a stable, inspectable path
+  // (and know their trials are serialised) can pass their own id — PR2 passes
+  // the eve session id.
+  const runId = opts.runId ?? randomUUID();
 
   const taskDir = join(tasksRoot, taskId);
   const manifestPath = join(taskDir, "manifest.json");
@@ -58,46 +101,46 @@ export async function verifyTask(opts) {
     throw new Error(`verifyTask: manifest not found at ${manifestPath}`);
   }
   const manifest = JSON.parse(readFileSync(manifestPath, "utf8"));
-
-  // 2. Seed / reuse the verify-workspace.
-  const verifyWorkspace = join(workDir, "verify-workspace", taskId);
-  const hashFile = join(verifyWorkspace, ".install-hash");
   const fixtureDir = join(taskDir, "fixture");
-  let seeded = false;
-  if (!existsSync(verifyWorkspace)) {
-    mkdirSync(verifyWorkspace, { recursive: true });
-    cpSync(fixtureDir, verifyWorkspace, { recursive: true });
-    seeded = true;
+
+  // 2. Seed the run directory, or wipe its source tree and re-seed it.
+  //
+  //    The wipe is not an optimisation, it is the fix for cross-trial
+  //    contamination: without it, a trial that writes NOTHING inherits the
+  //    previous trial's render.mjs and scores whatever that one scored.
+  const runDir = join(workDir, "verify-workspace", taskId, runId);
+  if (existsSync(runDir)) {
+    for (const entry of readdirSync(runDir)) {
+      if (PRESERVED_ON_RESEED.has(entry)) continue;
+      rmSync(join(runDir, entry), { force: true, recursive: true });
+    }
+  } else {
+    mkdirSync(runDir, { recursive: true });
   }
-  if (seeded || !existsSync(join(verifyWorkspace, "node_modules"))) {
-    installDeps(verifyWorkspace);
-    writeFileSync(hashFile, packageJsonHash(verifyWorkspace), "utf8");
+  cpSync(fixtureDir, runDir, { recursive: true });
+
+  // 3. Install the FIXTURE's dependencies. Never the agent's.
+  if (!existsSync(join(runDir, "node_modules"))) {
+    installDeps(runDir);
   }
 
-  // 3. Copy the agent's source files over the seeded workspace.
-  copySources(workspaceDir, verifyWorkspace);
+  // 4. Overlay the agent's source files (no package.json, no lockfiles).
+  copySources(workspaceDir, runDir);
 
-  // 4. Reinstall only if the (possibly agent-modified) package.json changed.
-  const currentHash = packageJsonHash(verifyWorkspace);
-  const previousHash = existsSync(hashFile) ? readFileSync(hashFile, "utf8") : "";
-  if (currentHash !== previousHash) {
-    installDeps(verifyWorkspace);
-    writeFileSync(hashFile, currentHash, "utf8");
-  }
-
-  // 5. Delete any output *unconditionally* before rendering. This single line is
-  //    what defeats a hand-forged PNG; do not make it conditional.
-  const outPath = join(verifyWorkspace, "out.png");
+  // 5. Delete any output *unconditionally* before rendering.
+  const outPath = join(runDir, "out.png");
   rmSync(outPath, { force: true });
 
   // 6. Re-render in a fresh process with a minimal environment.
-  const render = await runRender(verifyWorkspace);
+  const probeLog = join(workDir, "probes", `${runId}.log`);
+  mkdirSync(dirname(probeLog), { recursive: true });
+  const render = await runRender(runDir, probeLog);
 
   const env = {
     vgpu: manifest.vgpu,
     node: process.version,
     gitSha: gitSha(),
-    ...doctorEnv(verifyWorkspace),
+    ...doctorEnv(runDir),
     capturedAt: new Date().toISOString(),
   };
 
@@ -107,16 +150,30 @@ export async function verifyTask(opts) {
   const metrics = {
     renderExitCode: render.exitCode,
     renderDurationMs: render.durationMs,
+    runId,
+    // Soft signal, never a gate: did the graded render actually load vgpu?
+    // `s1-clear-color` is passable with pngjs alone, so a `false` here means
+    // "solved without the library under test" — worth seeing in the evidence,
+    // not worth failing a run over. `null` = the probe could not report.
+    vgpuLoaded: readVgpuLoaded(probeLog),
   };
 
-  // 7. renders gate.
+  // 7. packageJsonUnchanged gate. Declared, reported, and never honoured: the
+  //    install above already used the fixture's manifest, so this only tells a
+  //    reader that the agent's answer assumed a different dependency set — or
+  //    that it tried to get code executed at install time.
+  const manifestCheck = compareManifests(fixtureDir, workspaceDir);
+  metrics.agentPackageScripts = manifestCheck.agentScripts;
+  if (!manifestCheck.unchanged) {
+    failures.push(manifestCheck.reason ?? "agent changed package.json");
+  }
+
+  // 8. renders gate.
   let renders = "fail";
   if (render.timedOut) {
     failures.push(`render timed out after ${RENDER_TIMEOUT_MS}ms`);
   } else if (render.exitCode !== 0) {
-    failures.push(
-      `render exited with code ${render.exitCode}: ${truncate(render.stderr)}`,
-    );
+    failures.push(`render exited with code ${render.exitCode}: ${truncate(render.stderr)}`);
   } else if (!existsSync(outPath)) {
     failures.push("render exited 0 but did not write out.png");
   } else {
@@ -132,10 +189,7 @@ export async function verifyTask(opts) {
       metrics.distinctColors = graded.distinctColors;
       metrics.dominantPixel = graded.dominantPixel;
       metrics.matchedFraction = graded.matchedFraction;
-      if (
-        graded.width === manifest.expected.width &&
-        graded.height === manifest.expected.height
-      ) {
+      if (graded.width === manifest.expected.width && graded.height === manifest.expected.height) {
         renders = "pass";
       } else {
         failures.push(
@@ -145,7 +199,7 @@ export async function verifyTask(opts) {
     }
   }
 
-  // 8. colorExact gate.
+  // 9. colorExact gate.
   let colorExact = "skip";
   if (renders === "pass") {
     colorExact = metrics.matchedFraction === 1 ? "pass" : "fail";
@@ -158,12 +212,16 @@ export async function verifyTask(opts) {
     }
   }
 
-  // 9. Evidence. A bad render is data, never an exception.
+  // 10. Evidence. A bad render is data, never an exception.
   return {
     schemaVersion: SCHEMA_VERSION,
     taskId,
     env,
-    gates: { renders, colorExact },
+    gates: {
+      renders,
+      colorExact,
+      packageJsonUnchanged: manifestCheck.unchanged ? "pass" : "fail",
+    },
     metrics,
     failures,
   };
@@ -175,27 +233,113 @@ export async function verifyTask(opts) {
  * workspace and silently no-ops the install, leaving no node_modules behind.
  * (The equivalent `.npmrc` setting does not work on pnpm 9.15.4 — it must be the
  * CLI flag.) Do not "clean this up".
+ *
+ * `--ignore-scripts` is equally mandatory and is a correctness fix, not
+ * hardening theatre: without it, a `postinstall` reachable from the graded
+ * workspace runs on the host with the verify-workspace as cwd and can rewrite
+ * `node_modules/pngjs` so that every render emits the expected colour. That
+ * exact payload scored a false pass before this flag existed; it is a
+ * regression test now.
  * @param {string} cwd
  */
 function installDeps(cwd) {
-  const result = spawnSyncish("pnpm", ["install", "--ignore-workspace"], cwd);
+  const result = spawnSyncish("pnpm", ["install", "--ignore-workspace", "--ignore-scripts"], cwd);
   if (result.status !== 0) {
     throw new Error(
-      `verifyTask: pnpm install --ignore-workspace failed in ${cwd}: ${truncate(result.stderr)}`,
+      `verifyTask: pnpm install --ignore-workspace --ignore-scripts failed in ${cwd}: ${truncate(result.stderr)}`,
     );
   }
 }
 
-/** @param {string} verifyWorkspace */
-function packageJsonHash(verifyWorkspace) {
-  const pkgPath = join(verifyWorkspace, "package.json");
-  const bytes = existsSync(pkgPath) ? readFileSync(pkgPath) : Buffer.alloc(0);
-  return createHash("sha256").update(bytes).digest("hex");
+/**
+ * Compare the agent's manifest against the fixture's — dependencies AND
+ * scripts. Reported as the `packageJsonUnchanged` gate; the agent's manifest is
+ * never installed and its scripts are never executed.
+ *
+ * `scripts` is part of the comparison because the payload this gate exists to
+ * make visible did not touch dependencies at all: it kept them byte-identical
+ * and added a `postinstall`.
+ * @param {string} fixtureDir
+ * @param {string} workspaceDir
+ */
+function compareManifests(fixtureDir, workspaceDir) {
+  const fixture = readPackageJson(join(fixtureDir, "package.json"));
+  const agentPath = join(workspaceDir, "package.json");
+  if (!existsSync(agentPath)) {
+    return {
+      unchanged: false,
+      reason: "agent workspace has no package.json (the fixture's was used)",
+      agentScripts: {},
+    };
+  }
+  const agent = readPackageJson(agentPath);
+  if (agent === null) {
+    return { unchanged: false, reason: "agent package.json is not valid JSON", agentScripts: {} };
+  }
+
+  const agentScripts = isRecord(agent.scripts) ? agent.scripts : {};
+  const expectedDeps = normaliseDeps(fixture);
+  const actualDeps = normaliseDeps(agent);
+  const expectedScripts = JSON.stringify(normaliseScripts(fixture));
+  const actualScripts = JSON.stringify(normaliseScripts(agent));
+
+  if (expectedDeps !== actualDeps) {
+    return {
+      unchanged: false,
+      reason: `agent changed the dependency set: expected ${expectedDeps}, workspace declares ${actualDeps} (the fixture's dependencies were installed instead)`,
+      agentScripts,
+    };
+  }
+  if (expectedScripts !== actualScripts) {
+    return {
+      unchanged: false,
+      reason: `agent declared package.json scripts ${actualScripts}, expected ${expectedScripts} (they were NOT executed: the verify install runs with --ignore-scripts)`,
+      agentScripts,
+    };
+  }
+  return { unchanged: true, reason: null, agentScripts };
+}
+
+/** @param {string} path */
+function readPackageJson(path) {
+  try {
+    const parsed = JSON.parse(readFileSync(path, "utf8"));
+    return isRecord(parsed) ? parsed : {};
+  } catch {
+    return null;
+  }
+}
+
+/** Stable, whitespace/ordering-insensitive view of a manifest's dependencies. */
+function normaliseDeps(pkg) {
+  const pick = (key) => {
+    const value = pkg?.[key];
+    if (!isRecord(value)) return [];
+    return Object.keys(value)
+      .sort()
+      .map((name) => `${name}@${String(value[name])}`);
+  };
+  return JSON.stringify({ dependencies: pick("dependencies"), devDependencies: pick("devDependencies") });
+}
+
+/** Sorted view of a manifest's `scripts`, so ordering is not a difference. */
+function normaliseScripts(pkg) {
+  const scripts = pkg?.scripts;
+  if (!isRecord(scripts)) return [];
+  return Object.keys(scripts)
+    .sort()
+    .map((name) => `${name}=${String(scripts[name])}`);
+}
+
+/** @param {unknown} value */
+function isRecord(value) {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
 /**
  * Copy every `**\/*.{mjs,js,ts,wgsl,json}` from the untrusted workspace into the
- * verify-workspace, excluding node_modules/, .git/ and out.png.
+ * run directory, excluding node_modules/, .git/, outputs and anything that
+ * steers dependency resolution (see EXCLUDED_FILES).
  * @param {string} from
  * @param {string} to
  */
@@ -228,17 +372,40 @@ function copySources(from, to) {
 }
 
 /**
+ * `--import` (and `module.register`) landed in Node 20.6. Older runtimes still
+ * render; they just report `vgpuLoaded: null`.
+ */
+function supportsModuleProbe() {
+  const [major, minor] = process.versions.node.split(".").map((part) => Number.parseInt(part, 10));
+  return major > 20 || (major === 20 && minor >= 6);
+}
+
+/**
  * Fresh `node render.mjs`, hard timeout, explicit env allowlist (PATH + HOME
  * only — deps are already installed, nothing else from the parent process,
  * including any leaked secrets, is passed through).
+ *
+ * The extra `--import` registers a resolve-hook that logs which specifiers the
+ * render actually loaded. It is observational: the probe writes to a file
+ * outside the run directory and never influences resolution.
  * @param {string} cwd
+ * @param {string} probeLog
  */
-function runRender(cwd) {
+function runRender(cwd, probeLog) {
   return new Promise((resolvePromise) => {
     const startedAt = Date.now();
-    const child = spawn(process.execPath, ["render.mjs"], {
+    const args = [];
+    if (supportsModuleProbe()) {
+      args.push("--import", pathToFileURL(join(VERIFY_DIR, "probe-register.mjs")).href);
+    }
+    args.push("render.mjs");
+    const child = spawn(process.execPath, args, {
       cwd,
-      env: { PATH: process.env.PATH ?? "", HOME: process.env.HOME ?? "" },
+      env: {
+        PATH: process.env.PATH ?? "",
+        HOME: process.env.HOME ?? "",
+        VGPU_VERIFY_PROBE_OUT: probeLog,
+      },
       stdio: ["ignore", "pipe", "pipe"],
     });
     let stdout = "";
@@ -278,8 +445,29 @@ function runRender(cwd) {
 }
 
 /**
- * `vgpu doctor` against the verify-workspace: ~1-2s, and it catches a broken
- * host before a bad render gets blamed on the agent. Never throws.
+ * Did the graded render load the library under test? `null` when the probe did
+ * not run (old Node, or the render died before importing anything).
+ * @param {string} probeLog
+ */
+function readVgpuLoaded(probeLog) {
+  if (!supportsModuleProbe() || !existsSync(probeLog)) return null;
+  try {
+    const text = readFileSync(probeLog, "utf8");
+    if (text.trim() === "") return null;
+    return /(^|[\t/])vgpu(\/|"|$)/mu.test(text) || text.includes("/node_modules/vgpu/");
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * `vgpu doctor` against the run directory: ~1-2s, and it catches a broken host
+ * before a bad render gets blamed on the agent. Never throws.
+ *
+ * Runs under the SAME env allowlist as the render (PATH + HOME): this spawns
+ * `npx` in a directory the agent's sources were copied into, so the parent
+ * environment — including any model/gateway credentials held by the eval
+ * runner — must not be inherited.
  *
  * NOTE: no `--json` flag. `vgpu@0.2.0`'s doctor writes JSON to stdout by
  * default (`Usage: vgpu doctor [--no-render] [--pretty]`); passing `--json`
@@ -288,7 +476,10 @@ function runRender(cwd) {
  */
 function doctorEnv(cwd) {
   const fallback = { adapterName: null, adapterType: null, doctorVerdict: null };
-  const result = spawnSyncish("npx", ["vgpu", "doctor"], cwd);
+  const result = spawnSyncish("npx", ["vgpu", "doctor"], cwd, {
+    PATH: process.env.PATH ?? "",
+    HOME: process.env.HOME ?? "",
+  });
   if (result.status !== 0 && !result.stdout) return fallback;
   try {
     const parsed = JSON.parse(extractJson(result.stdout));
@@ -303,8 +494,12 @@ function doctorEnv(cwd) {
   }
 }
 
-/** @param {string} text */
-function extractJson(text) {
+/**
+ * Pull the JSON object out of a stream that may also carry warnings. Shared
+ * with PR2's sandbox bootstrap, which parses the same command's output.
+ * @param {string} text
+ */
+export function extractJson(text) {
   const start = text.indexOf("{");
   const end = text.lastIndexOf("}");
   return start === -1 || end === -1 ? text : text.slice(start, end + 1);
@@ -319,12 +514,14 @@ function gitSha() {
  * @param {string} command
  * @param {string[]} args
  * @param {string} cwd
+ * @param {NodeJS.ProcessEnv} [env] defaults to the parent environment; pass an
+ *   allowlist for anything that runs against agent-authored files.
  */
-function spawnSyncish(command, args, cwd) {
+function spawnSyncish(command, args, cwd, env) {
   const result = spawnSync(command, args, {
     cwd,
     encoding: "utf8",
-    env: process.env,
+    env: env ?? process.env,
     maxBuffer: 32 * 1024 * 1024,
   });
   return {
@@ -339,3 +536,7 @@ function truncate(text, max = 2000) {
   const value = String(text ?? "");
   return value.length > max ? `${value.slice(0, max)}…` : value;
 }
+
+// Referenced by the JSDoc above; kept exported for tooling that inspects the
+// verifier's layout without importing the whole module.
+export const VERIFY_WORKSPACE_BASENAME = basename(VERIFY_DIR);

--- a/apps/agent-evals/verify/verify-task.test.ts
+++ b/apps/agent-evals/verify/verify-task.test.ts
@@ -1,0 +1,122 @@
+import { cpSync, existsSync, mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { PNG } from "pngjs";
+import { describe, expect, it } from "vitest";
+import { verifyTask } from "./verify-task.mjs";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const PACKAGE_ROOT = join(HERE, "..");
+const TASKS_ROOT = join(PACKAGE_ROOT, "tasks");
+const FIXTURE_DIR = join(TASKS_ROOT, "s1-clear-color", "fixture");
+const CASES = join(HERE, "__fixtures__");
+
+// Each case gets its own workspaceDir and workDir: `.work/` is mutable state
+// (an installed node_modules plus the last render's output) and sharing it
+// between cases would let one case's leftovers decide another case's verdict.
+function tempPair(name: string) {
+  const root = mkdtempSync(join(tmpdir(), `agent-evals-${name}-`));
+  const workspaceDir = join(root, "workspace");
+  const workDir = join(root, "work");
+  mkdirSync(workspaceDir, { recursive: true });
+  mkdirSync(workDir, { recursive: true });
+  // Every graded workspace starts from the task fixture's package.json, exactly
+  // like a real agent session would.
+  cpSync(join(FIXTURE_DIR, "package.json"), join(workspaceDir, "package.json"));
+  return { workspaceDir, workDir };
+}
+
+function solidRedPng(width: number, height: number): Buffer {
+  const png = new PNG({ width, height });
+  for (let i = 0; i < png.data.length; i += 4) {
+    png.data[i] = 255;
+    png.data[i + 1] = 0;
+    png.data[i + 2] = 0;
+    png.data[i + 3] = 255;
+  }
+  return PNG.sync.write(png);
+}
+
+describe("verifyTask(s1-clear-color)", () => {
+  it("passes both gates for a correct solution", { timeout: 300_000 }, async () => {
+    const { workspaceDir, workDir } = tempPair("correct");
+    cpSync(join(CASES, "correct", "render.mjs"), join(workspaceDir, "render.mjs"));
+
+    const evidence = await verifyTask({
+      tasksRoot: TASKS_ROOT,
+      taskId: "s1-clear-color",
+      workspaceDir,
+      workDir,
+    });
+
+    expect(evidence.gates.renders).toBe("pass");
+    expect(evidence.gates.colorExact).toBe("pass");
+    expect(evidence.metrics.matchedFraction).toBe(1);
+    expect(evidence.metrics.dominantPixel).toEqual([255, 0, 0, 255]);
+    expect(evidence.metrics.width).toBe(64);
+    expect(evidence.metrics.height).toBe(64);
+    expect(evidence.failures).toEqual([]);
+  });
+
+  it("renders but fails the color gate for the untouched fixture", { timeout: 300_000 }, async () => {
+    const { workspaceDir, workDir } = tempPair("unchanged");
+    cpSync(join(CASES, "unchanged", "render.mjs"), join(workspaceDir, "render.mjs"));
+
+    const evidence = await verifyTask({
+      tasksRoot: TASKS_ROOT,
+      taskId: "s1-clear-color",
+      workspaceDir,
+      workDir,
+    });
+
+    // "It rendered, it just rendered the wrong thing" must be legible in the
+    // evidence without re-running anything: renders passes, colorExact fails,
+    // and dominantPixel carries the diagnostic non-red colour.
+    expect(evidence.gates.renders).toBe("pass");
+    expect(evidence.gates.colorExact).toBe("fail");
+    expect(evidence.metrics.matchedFraction).toBe(0);
+    // vec4f(0.25, 0.5, 0.75, 1.0) quantised to bytes by this renderer.
+    expect(evidence.metrics.dominantPixel).toEqual([64, 128, 191, 255]);
+    expect(evidence.metrics.distinctColors).toBe(1);
+  });
+
+  it("does not grade a forged out.png (delete-before-render)", { timeout: 300_000 }, async () => {
+    // THIS IS THE EVAL'S CORE ANTI-CHEAT PROPERTY, not incidental coverage.
+    // An agent can trivially write a solid-red PNG by hand instead of fixing the
+    // shader. Step 5 of verifyTask deletes any pre-existing out.png before
+    // re-rendering, so the only PNG that can ever be graded is one this process
+    // just produced from the agent's *source*. If someone deletes that line, or
+    // makes it conditional, this test must go red.
+    const { workspaceDir, workDir } = tempPair("forgery");
+    cpSync(join(CASES, "forgery", "render.mjs"), join(workspaceDir, "render.mjs"));
+    // (a) the forged artefact, hand-written straight to disk, never rendered.
+    writeFileSync(join(workspaceDir, "out.png"), solidRedPng(64, 64));
+
+    // (b) the same forgery planted directly in the verify-workspace, which is
+    // where a stale output from a previous run would live. This is the copy that
+    // only step 5's unconditional delete can defeat.
+    const verifyWorkspace = join(workDir, "verify-workspace", "s1-clear-color");
+    mkdirSync(verifyWorkspace, { recursive: true });
+    cpSync(FIXTURE_DIR, verifyWorkspace, { recursive: true });
+    const plantedOutput = join(verifyWorkspace, "out.png");
+    writeFileSync(plantedOutput, solidRedPng(64, 64));
+
+    const evidence = await verifyTask({
+      tasksRoot: TASKS_ROOT,
+      taskId: "s1-clear-color",
+      workspaceDir,
+      workDir,
+    });
+
+    expect(evidence.gates.renders).toBe("fail");
+    expect(evidence.gates.colorExact).not.toBe("pass");
+    // Explicitly: the forgery must not produce the all-green verdict.
+    expect([evidence.gates.renders, evidence.gates.colorExact]).not.toEqual(["pass", "pass"]);
+    // The planted red PNG is gone: it was deleted and the no-op renderer never
+    // wrote a replacement.
+    expect(existsSync(plantedOutput)).toBe(false);
+    expect(evidence.metrics.matchedFraction).toBeUndefined();
+    expect(evidence.failures.join("\n")).toContain("out.png");
+  });
+});

--- a/apps/agent-evals/verify/verify-task.test.ts
+++ b/apps/agent-evals/verify/verify-task.test.ts
@@ -1,4 +1,4 @@
-import { cpSync, existsSync, mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { cpSync, existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -52,6 +52,9 @@ describe("verifyTask(s1-clear-color)", () => {
 
     expect(evidence.gates.renders).toBe("pass");
     expect(evidence.gates.colorExact).toBe("pass");
+    expect(evidence.gates.packageJsonUnchanged).toBe("pass");
+    // Soft signal (never a gate): this solution really did import vgpu.
+    expect(evidence.metrics.vgpuLoaded).toBe(true);
     expect(evidence.metrics.matchedFraction).toBe(1);
     expect(evidence.metrics.dominantPixel).toEqual([255, 0, 0, 255]);
     expect(evidence.metrics.width).toBe(64);
@@ -96,7 +99,8 @@ describe("verifyTask(s1-clear-color)", () => {
     // (b) the same forgery planted directly in the verify-workspace, which is
     // where a stale output from a previous run would live. This is the copy that
     // only step 5's unconditional delete can defeat.
-    const verifyWorkspace = join(workDir, "verify-workspace", "s1-clear-color");
+    const runId = "forgery-run";
+    const verifyWorkspace = join(workDir, "verify-workspace", "s1-clear-color", runId);
     mkdirSync(verifyWorkspace, { recursive: true });
     cpSync(FIXTURE_DIR, verifyWorkspace, { recursive: true });
     const plantedOutput = join(verifyWorkspace, "out.png");
@@ -107,6 +111,7 @@ describe("verifyTask(s1-clear-color)", () => {
       taskId: "s1-clear-color",
       workspaceDir,
       workDir,
+      runId,
     });
 
     expect(evidence.gates.renders).toBe("fail");
@@ -118,5 +123,105 @@ describe("verifyTask(s1-clear-color)", () => {
     expect(existsSync(plantedOutput)).toBe(false);
     expect(evidence.metrics.matchedFraction).toBeUndefined();
     expect(evidence.failures.join("\n")).toContain("out.png");
+  });
+  it(
+    "does not run install scripts from the graded workspace",
+    { timeout: 300_000 },
+    async () => {
+      // REGRESSION (P0, was exploitable): the agent's package.json used to be
+      // copied into the verify-workspace and installed there, so `pnpm install`
+      // executed its `postinstall` ON THE HOST, with the verify-workspace as
+      // cwd. The payload below is the one that actually defeated the verifier:
+      // it leaves the WRONG shader in place and instead monkey-patches
+      // node_modules/pngjs so every write() paints the expected colour. It
+      // scored renders=pass + colorExact=pass.
+      //
+      // Two independent fixes must keep this red-flagged: the install ignores
+      // scripts, and the agent's package.json is never copied at all.
+      const { workspaceDir, workDir } = tempPair("install-script");
+      cpSync(join(CASES, "unchanged", "render.mjs"), join(workspaceDir, "render.mjs"));
+      writeFileSync(
+        join(workspaceDir, "patch.js"),
+        [
+          'import { appendFileSync } from "node:fs";',
+          'appendFileSync("node_modules/pngjs/lib/png.js", `',
+          ";(function () {",
+          "  const _w = exports.PNG.sync.write;",
+          "  exports.PNG.sync.write = function (png, opts) {",
+          "    for (let i = 0; i < png.data.length; i += 4) {",
+          "      png.data[i] = 255; png.data[i+1] = 0; png.data[i+2] = 0; png.data[i+3] = 255;",
+          "    }",
+          "    return _w.call(this, png, opts);",
+          "  };",
+          "})();",
+          "`);",
+        ].join("\n"),
+      );
+      writeFileSync(
+        join(workspaceDir, "package.json"),
+        JSON.stringify({
+          private: true,
+          type: "module",
+          scripts: { postinstall: "node patch.js" },
+          dependencies: { vgpu: "0.2.0", pngjs: "7.0.0" },
+        }),
+      );
+
+      const evidence = await verifyTask({
+        tasksRoot: TASKS_ROOT,
+        taskId: "s1-clear-color",
+        workspaceDir,
+        workDir,
+      });
+
+      // The wrong shader must score as wrong.
+      expect(evidence.gates.colorExact).toBe("fail");
+      expect(evidence.metrics.dominantPixel).toEqual([64, 128, 191, 255]);
+      // The hijack never ran: pngjs in the run directory is untouched.
+      const pngjs = readFileSync(
+        join(workDir, "verify-workspace", "s1-clear-color", String(evidence.metrics.runId), "node_modules", "pngjs", "lib", "png.js"),
+        "utf8",
+      );
+      expect(pngjs).not.toContain("exports.PNG.sync.write = function");
+      // And the attempt is legible in the evidence rather than silently ignored.
+      expect(evidence.gates.packageJsonUnchanged).toBe("fail");
+      expect(evidence.failures.join("\n")).toContain("--ignore-scripts");
+      expect(evidence.metrics.agentPackageScripts).toEqual({ postinstall: "node patch.js" });
+    },
+  );
+
+  it("does not inherit sources from a previous trial", { timeout: 300_000 }, async () => {
+    // REGRESSION (P0, was exploitable): the verify-workspace was seeded once
+    // and only ever overlaid, so a second trial sharing the same workDir
+    // inherited the first trial's render.mjs. An agent that wrote NOTHING
+    // scored whatever the previous agent scored. PR2 reuses one workDir for
+    // every trial, so this was reachable in normal operation.
+    const { workspaceDir: solvedWorkspace, workDir } = tempPair("trial-a");
+    cpSync(join(CASES, "correct", "render.mjs"), join(solvedWorkspace, "render.mjs"));
+
+    const trialA = await verifyTask({
+      tasksRoot: TASKS_ROOT,
+      taskId: "s1-clear-color",
+      workspaceDir: solvedWorkspace,
+      workDir,
+    });
+    expect(trialA.gates.colorExact).toBe("pass");
+
+    // Trial B: same workDir, same task, and an agent that produced nothing.
+    const emptyWorkspace = join(workDir, "..", "empty-workspace");
+    mkdirSync(emptyWorkspace, { recursive: true });
+
+    const trialB = await verifyTask({
+      tasksRoot: TASKS_ROOT,
+      taskId: "s1-clear-color",
+      workspaceDir: emptyWorkspace,
+      workDir,
+    });
+
+    // B must be graded against the FIXTURE, not against A's solution.
+    expect(trialB.gates.renders).toBe("pass");
+    expect(trialB.gates.colorExact).toBe("fail");
+    expect(trialB.metrics.dominantPixel).toEqual([64, 128, 191, 255]);
+    expect(trialB.metrics.runId).not.toBe(trialA.metrics.runId);
   });
 });

--- a/apps/agent-evals/vitest.config.ts
+++ b/apps/agent-evals/vitest.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from "vitest/config";
+
+// Local config on purpose: this package is intentionally absent from the root
+// `vitest.config.ts` include list (see README.md). Without a config of its own,
+// `vitest run` here would walk up and pick the repo root's config, which does
+// not match any file in this package.
+//
+// The verifier's tests install a real node_modules and spawn a renderer, so the
+// timeouts are generous compared to the library's unit tests.
+export default defineConfig({
+  test: {
+    include: ["verify/**/*.test.ts"],
+    pool: "forks",
+    testTimeout: 300_000,
+    hookTimeout: 300_000,
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -52,6 +52,21 @@ importers:
         specifier: 0.4.0
         version: 0.4.0
 
+  apps/agent-evals:
+    devDependencies:
+      '@types/node':
+        specifier: ^22.10.7
+        version: 22.19.17
+      pngjs:
+        specifier: ^7.0.0
+        version: 7.0.0
+      typescript:
+        specifier: ^5.7.3
+        version: 5.9.3
+      vitest:
+        specifier: ^3.2.7
+        version: 3.2.7(@types/debug@4.1.13)(@types/node@22.19.17)(jiti@1.21.7)(terser@5.47.1)
+
   apps/docs:
     dependencies:
       '@mdx-js/loader':


### PR DESCRIPTION
## What

Adds `apps/agent-evals/`, a new private pnpm workspace member (`@vgpu/agent-evals`), containing:

- `tasks/s1-clear-color/`: a minimal task fixture (render a WGSL fragment shader to a 64×64 PNG via `vgpu/node`, task = make it solid red) — the first task in an agent-evals suite for vgpu.
- `verify/`: a deterministic, agent-agnostic grader. It never trusts the PNG or the reply produced inside the graded workspace — it re-exports source files, deletes any existing output, reinstalls into a clean `node_modules` (`pnpm install --ignore-workspace`), and re-renders in a fresh `node` process before grading pixels.

This is Layer 1 of a two-layer design: task + grader are agnostic to whatever drives the agent (this PR has **no `eve` dependency at all**). Layer 2 (the eve-based driver, evals, sandbox) is the next PR, stacked on top of this one.

## Why this order

The stack was originally scoped agent-first, then command; it's inverted here because the grader is the only part verifiable in most dev environments (no GPU/Docker/model credentials needed — `vgpu@0.2.0`'s software-render fallback via `llvmpipe` handles that), and because Layer 1 is the part that is expensive to get wrong later.

## The anti-cheat property (the point of the whole PR)

`verifyTask()` grades **only** a PNG that it produced itself, in this order:

1. seed/reuse a verify-workspace from `tasks/<id>/fixture/` and `pnpm install --ignore-workspace` into it,
2. copy the agent's `**/*.{mjs,js,ts,wgsl,json}` over it (never `out.png`, never `node_modules/`),
3. reinstall iff the agent's `package.json` hash changed,
4. **`rm -f out.png` unconditionally**,
5. spawn `node render.mjs` in a fresh process (120 s timeout, env allowlist of `PATH`+`HOME` only),
6. grade the resulting pixels against `manifest.json`'s `expected`.

Step 4 is what a hand-forged red PNG cannot survive, and `verify/verify-task.test.ts`'s third case exists to keep it that way.

Grading failures are **data, not exceptions**: gates are the strings `pass|fail|skip` and `verifyTask` only throws on genuine harness bugs (missing manifest, failed install).

## How to review

1. Read `apps/agent-evals/verify/verify-task.mjs`'s numbered steps against `apps/agent-evals/verify/verify-task.test.ts`'s three cases — the delete-before-render step maps directly to the third test.
2. Run: `pnpm --filter @vgpu/agent-evals test` and `node apps/agent-evals/verify/run-verify.mjs --workspace apps/agent-evals/tasks/s1-clear-color/fixture --task s1-clear-color`.
3. Confirm `apps/agent-evals` is absent from `vitest.config.ts` include and `tsconfig.json` references (intentional — see `apps/agent-evals/README.md`). The only tracked file outside `apps/agent-evals/` in this diff is `pnpm-lock.yaml` (+15 lines, the new workspace member).

## Verification run locally (Node 20.20.0, arm64, llvmpipe software renderer)

```
$ pnpm --filter @vgpu/agent-evals test
 ✓ verify/verify-task.test.ts (3 tests) 5968ms
   ✓ verifyTask(s1-clear-color) > passes both gates for a correct solution  2664ms
   ✓ verifyTask(s1-clear-color) > renders but fails the color gate for the untouched fixture  1973ms
   ✓ verifyTask(s1-clear-color) > does not grade a forged out.png (delete-before-render)  1330ms
 Test Files  1 passed (1)
      Tests  3 passed (3)

$ pnpm install --frozen-lockfile      # Done in 714ms
$ pnpm -w typecheck                   # exit 0
$ pnpm exec vitest run                # Test Files 228 passed | 23 skipped (251) — unchanged by this PR
$ pnpm check:filenames                # All filenames are kebab-case
$ pnpm bundle-check                   # all budgets green, no publishable package touched
$ pnpm --filter @vgpu/agent-evals exec tsc --noEmit    # exit 0
$ grep -rn '"eve"' apps/agent-evals/tasks apps/agent-evals/verify   # empty
```

CLI, unmodified fixture (expected: renders pass, colorExact fail, exit 1):

```json
{ "gates": { "renders": "pass", "colorExact": "fail" },
  "metrics": { "width": 64, "height": 64, "distinctColors": 1,
               "dominantPixel": [64, 128, 191, 255], "matchedFraction": 0 },
  "failures": ["only 0.00% of pixels match [255,0,0,255]; dominant pixel was [64,128,191,255]"] }
```

CLI, same fixture with the shader literal changed to `vec4f(1.0, 0.0, 0.0, 1.0)` (expected: both gates pass, exit 0):

```json
{ "gates": { "renders": "pass", "colorExact": "pass" },
  "metrics": { "width": 64, "height": 64, "distinctColors": 1,
               "dominantPixel": [255, 0, 0, 255], "matchedFraction": 1 },
  "failures": [] }
```

`env` in both runs: `{"vgpu":"0.2.0","node":"v20.20.0","gitSha":"b562408d","adapterName":"llvmpipe: Mesa 25.0.7 (LLVM 19.1.7) 0.0.1","adapterType":"cpu","doctorVerdict":"healthy"}`.

## Notes for the reviewer

- **`vgpu doctor` is called without `--json`.** `vgpu@0.2.0` writes JSON to stdout by default (`Usage: vgpu doctor [--no-render] [--pretty]`); passing `--json` fails with `Unknown doctor option: --json` and exit 1. Worth knowing for anything else that shells out to doctor.
- **`pnpm install --ignore-workspace` is mandatory** inside the verify-workspace: it lives under a workspace member, so without the flag pnpm resolves it to the root workspace and silently installs nothing. The `.npmrc` equivalent does **not** work on pnpm 9.15.4 — it has to be the CLI flag. There's a comment on the call site saying so.
- **`apps/agent-evals/vitest.config.ts` is intentional**: without a local config, `vitest run` inside the package walks up and picks the repo root's config, whose `include` matches nothing here ("No test files found"). This config does not touch the root one.
- `apps/agent-evals/tsconfig.json` sets `allowJs: true, checkJs: false` so the TS test can import the plain-`.mjs` verifier (which must stay runnable with bare `node`, no build step) and pick up its JSDoc types instead of `TS7016`.
- The untouched fixture's dominant pixel is `[64,128,191,255]` (this renderer's byte quantisation of `vec4f(0.25, 0.5, 0.75, 1.0)`), which is what the second test asserts.

## Context / links

- Design doc: `vgpu-agent-evals-design.md` (parent suite design, not affected by this PR).
- Architecture decision for this skeleton: Layer 1 (this PR) is agnostic to the driver; Layer 2 (next PR) is eve-specific and swappable.
- Follow-ups (not in this PR): PR2 adds the eve agent/driver and the `h0`/`s1` evals; PR3 adds the `pnpm agent-evals` command and an optional manual CI workflow.
