### PR TITLE
feat(agent-evals): eve driver (h0-harness-export, s1-clear-color)

### DIFF
--- a/apps/agent-evals/README.md
+++ b/apps/agent-evals/README.md
@@ -6,10 +6,82 @@ package.
 
 The package has two layers:
 
-- **Layer 1 — `tasks/` + `verify/` (this PR).** Task fixtures plus a
-  deterministic, driver-agnostic grader. No knowledge of any agent framework.
-- **Layer 2 — `agent/` + `evals/` (next PR).** The `eve`-based driver that runs
-  an agent against a task and hands the resulting workspace to Layer 1.
+- **Layer 1 — `tasks/` + `verify/`.** Task fixtures plus a deterministic,
+  driver-agnostic grader. No knowledge of any agent framework.
+- **Layer 2 — `agent/` + `evals/`.** The `eve`-based driver that runs an agent
+  against a task and hands the resulting workspace to Layer 1.
+
+## Running the evals (Layer 2)
+
+```bash
+pnpm agent-evals                       # from the repo root (preflights Node >= 24)
+pnpm --filter @vgpu/agent-evals exec eve eval evals/h0-harness-export.eval.ts
+```
+
+Environment:
+
+| Variable | Default | Meaning |
+| --- | --- | --- |
+| `AI_GATEWAY_API_KEY` / `VERCEL_OIDC_TOKEN` | — | required; without either, every eval **skips** (never fails) |
+| `VGPU_EVALS_MODEL` | `anthropic/claude-sonnet-5` | model under test |
+| `VGPU_EVALS_SANDBOX` | `docker` | `docker` or `vercel`; anything else throws at startup |
+| `VGPU_EVALS_WORK_DIR` | `<package>/.work` | where snapshots and evidence land |
+
+Run `h0-harness-export` first: it is the infra self-test for the workspace
+export. An `s1` result recorded while `h0` is red is not trustworthy.
+
+### Credentials
+
+Local development — one token covers both the sandbox and the model gateway:
+
+```bash
+npx vercel link --yes --scope vercel-labs --project vgpu
+npx vercel env pull                 # writes .env.local with VERCEL_OIDC_TOKEN
+node --env-file .env.local ../../scripts/agent-evals.mjs
+```
+
+`VERCEL_OIDC_TOKEN` authenticates `@vercel/sandbox` **and** the AI Gateway (eve
+accepts it in place of `AI_GATEWAY_API_KEY`). It expires after 12 hours; re-run
+`vercel env pull`.
+
+> **Footgun:** `vercel env pull` writes the value **wrapped in double quotes**.
+> Extracting it with `grep`/`cut` keeps the quotes and the gateway answers
+> `403 invalidToken`, which looks exactly like a permissions problem. Always
+> load the file with a real dotenv reader (`node --env-file .env.local`), never
+> with hand-rolled shell parsing.
+
+CI / non-interactive: a 12-hour OIDC token is useless for a scheduled run. Use
+`VERCEL_TOKEN` + `VERCEL_TEAM_ID` + `VERCEL_PROJECT_ID` for the sandbox and a
+separate `AI_GATEWAY_API_KEY` for the gateway — a Vercel access token does
+**not** work as a Gateway bearer token.
+
+### Sandbox backend selection
+
+`agent/sandbox/backend.ts` is the only file in the repo allowed to construct a
+`SandboxBackend`, and nothing may call `defaultBackend()` (its cascade can
+silently degrade to `just-bash`, which has no real binaries — an infra problem
+would then look like an agent failure).
+
+The Vercel Sandbox backend is already selectable (`VGPU_EVALS_SANDBOX=vercel`);
+wiring its concrete `vercel({...})` options is pending the sandbox spike — see
+`backend.ts`. The spike verified the golden path: **x86_64 only**, runtime
+`node22`/`node24`, one `sudo dnf install -y mesa-vulkan-drivers vulkan-loader`,
+after which `vgpu doctor` reports healthy in ~22-30 s. That dnf step is already
+in `bootstrap` as a backend-agnostic, no-op-if-absent shell step, so only the
+runtime/resource options remain to be filled in.
+
+### How the workspace gets out of the sandbox
+
+`agent/hooks/export-workspace.ts` tars `/workspace` out of the sandbox on every
+`turn.completed` and writes it to `.work/snapshots/<sessionId>/workspace.tar` on
+the host. The evals grade that tar; nothing the agent *says* is ever evidence.
+
+This is a hook rather than the originally-planned `GET /export` channel route
+because a channel route handler's context (`RouteHandlerArgs`) has **no**
+`getSandbox()` — verified against `eve@0.29.2` (local checkout) and `eve@0.29.5`
+(the pinned build). `getSandbox()` lives on `SessionContext`, which
+`HookContext` extends. The hook stays backend-agnostic (plain `tar` over
+`sandbox.run`), so it is explicitly *not* the retired `docker cp` fallback.
 
 ## Intentionally outside the root test/typecheck configs
 
@@ -30,7 +102,7 @@ pnpm --filter @vgpu/agent-evals exec tsc --noEmit
 
 Layer 1 (`tasks/`, `verify/`) runs on this repo's own Node (22).
 
-Running the eve-driven evals (Layer 2, added in the next PR) requires
+Running the eve-driven evals (Layer 2) requires
 **Node.js >= 24** and an AI Gateway credential (`AI_GATEWAY_API_KEY` or
 `VERCEL_OIDC_TOKEN`). This repo pins Node 22 (`.nvmrc`, root `engines`) and that
 does not change — so this host may well have neither Node 24 nor a credential,

--- a/apps/agent-evals/agent/agent.ts
+++ b/apps/agent-evals/agent/agent.ts
@@ -1,0 +1,9 @@
+import { defineAgent } from "eve";
+
+// No `tools:` field on purpose. eve's defaults (bash, read_file, write_file,
+// glob, grep) are exactly the representative coding-agent proxy this suite
+// measures; adding a vgpu-aware tool here would hand the agent part of the
+// answer and silently invalidate every discoverability metric. Do not add one.
+export default defineAgent({
+  model: process.env.VGPU_EVALS_MODEL ?? "anthropic/claude-sonnet-5",
+});

--- a/apps/agent-evals/agent/hooks/export-workspace.ts
+++ b/apps/agent-evals/agent/hooks/export-workspace.ts
@@ -1,0 +1,53 @@
+import { mkdirSync, writeFileSync } from "node:fs";
+import { dirname } from "node:path";
+import { defineHook } from "eve/hooks";
+import { snapshotTarPath } from "./snapshot-path.ts";
+
+/**
+ * Out-of-band workspace export.
+ *
+ * Every completed turn, this hook tars `/workspace` (minus `node_modules/` and
+ * `.git/`) straight out of the sandbox and writes it to the HOST at
+ * `.work/snapshots/<sessionId>/workspace.tar`. The evals then grade that tar
+ * with Layer 1's verifier. Nothing the agent *says* is ever used as evidence —
+ * only bytes we extracted ourselves.
+ *
+ * WHY A HOOK AND NOT A CHANNEL: the plan for this PR specified an
+ * `agent/channels/harness.ts` with a `GET /export` route calling
+ * `ctx.getSandbox()`. That API does not exist: a channel route handler's
+ * second argument is `RouteHandlerArgs` (`send`, `resolveActiveSession`,
+ * `cancel`, `reset`, `getSession`, `receive`, `params`, `waitUntil`,
+ * `requestIp`) — verified against both the local eve checkout (0.29.2) and the
+ * pinned registry build (0.29.5, `dist/src/channel/routes.d.ts`). `getSandbox()`
+ * lives on `SessionContext`, which `HookContext` extends
+ * (`dist/src/public/definitions/callback-context.d.ts`), so an authored hook is
+ * the supported way to reach the sandbox out of band. This is NOT the retired
+ * `docker cp` fallback: it is backend-agnostic (plain `tar` over
+ * `sandbox.run`), so `VGPU_EVALS_SANDBOX=vercel` keeps working unchanged.
+ *
+ * Assumption that `h0-harness-export.eval.ts` exists to prove or disprove on a
+ * real run: the hook executes in the eve runtime process, i.e. on the same host
+ * (and same filesystem) as the eval that reads the tar. That holds for a local
+ * `eve eval`; it would not hold against a remotely deployed target.
+ */
+export default defineHook({
+  events: {
+    "turn.completed": async (_event, ctx) => {
+      const sandbox = await ctx.getSandbox();
+
+      // base64 because `run()` hands back stdout as a string: raw tar bytes
+      // would not survive UTF-8 decoding. `-w0` keeps it on one line.
+      const exported = await sandbox.run({
+        command:
+          "tar -cf - --exclude=./node_modules --exclude=./.git -C /workspace . | base64 -w0",
+      });
+      if (exported.exitCode !== 0) {
+        throw new Error(`export-workspace: tar failed (${exported.exitCode}): ${exported.stderr}`);
+      }
+
+      const tarPath = snapshotTarPath(ctx.session.id);
+      mkdirSync(dirname(tarPath), { recursive: true });
+      writeFileSync(tarPath, Buffer.from(exported.stdout.trim(), "base64"));
+    },
+  },
+});

--- a/apps/agent-evals/agent/hooks/snapshot-path.ts
+++ b/apps/agent-evals/agent/hooks/snapshot-path.ts
@@ -1,0 +1,32 @@
+import { join, resolve } from "node:path";
+
+/**
+ * Where the workspace export for a session lands on the HOST.
+ *
+ * Shared by the export hook (writer) and the evals (readers) so the two can
+ * never drift. `eve eval` runs with the package root as cwd; override with
+ * `VGPU_EVALS_WORK_DIR` if you drive the evals from somewhere else.
+ */
+export function workDir(): string {
+  return resolve(process.env.VGPU_EVALS_WORK_DIR ?? join(process.cwd(), ".work"));
+}
+
+/** Directory holding everything captured for one session. */
+export function snapshotDir(sessionId: string): string {
+  return join(workDir(), "snapshots", sessionId);
+}
+
+/** The tar produced by the export hook for one session. */
+export function snapshotTarPath(sessionId: string): string {
+  return join(snapshotDir(sessionId), "workspace.tar");
+}
+
+/** Where a snapshot tar is extracted for grading. */
+export function snapshotWorkspaceDir(sessionId: string): string {
+  return join(snapshotDir(sessionId), "workspace");
+}
+
+/** Final evidence artifact for one session. */
+export function evidencePath(sessionId: string): string {
+  return join(workDir(), "evidence", `${sessionId}.json`);
+}

--- a/apps/agent-evals/agent/instructions.md
+++ b/apps/agent-evals/agent/instructions.md
@@ -1,0 +1,8 @@
+<!--
+  Keep this file strictly neutral. Do NOT mention vgpu, doctor, docs, check,
+  shaders, WebGPU or any skill here. This suite measures whether an agent can
+  discover those on its own from the package it is handed; any hint in this
+  file invalidates every discoverability metric the evals report.
+-->
+
+You are a coding agent working in `/workspace`. Complete the user's task.

--- a/apps/agent-evals/agent/sandbox/backend.ts
+++ b/apps/agent-evals/agent/sandbox/backend.ts
@@ -1,0 +1,41 @@
+import type { SandboxBackend } from "eve/sandbox";
+import { docker } from "eve/sandbox/docker";
+import { vercel } from "eve/sandbox/vercel";
+
+/**
+ * The ONLY place in this repo allowed to construct a sandbox backend.
+ *
+ * Rules (enforced in review, not just by this comment):
+ * 1. No other file may import `eve/sandbox/docker`, `eve/sandbox/vercel` or
+ *    `eve/sandbox/microsandbox`.
+ * 2. Nothing may use `defaultBackend()` from `eve/sandbox`. Its fallback
+ *    cascade can silently degrade to `just-bash`, which has no real binaries —
+ *    that turns an infra problem into a fake "the agent failed" result.
+ * 3. An unknown `VGPU_EVALS_SANDBOX` value throws loudly at startup. Never
+ *    fall back silently.
+ */
+export function evalSandboxBackend(): SandboxBackend {
+  const kind = process.env.VGPU_EVALS_SANDBOX ?? "docker"; // provisional default
+
+  if (kind === "vercel") {
+    // Landing spot for the Vercel Sandbox spike's output. The spike
+    // (see the runbook linked from README.md) established the golden path:
+    // runtime `node22`/`node24`, 1-2 vCPUs, and one
+    // `sudo dnf install -y mesa-vulkan-drivers vulkan-loader` before
+    // `vgpu doctor` reports healthy — that dnf step belongs in `bootstrap`
+    // (sandbox.ts), not here, so it stays backend-agnostic. Only the
+    // resource/runtime options belong in this object, and they are
+    // deliberately not guessed here: fill them in when the spike lands.
+    return vercel({
+      /* pending the Vercel Sandbox spike — see README.md */
+    });
+  }
+
+  if (kind === "docker") {
+    // Image intentionally unpinned for the walking skeleton; pin by digest in
+    // a later PR once the suite grows past s1.
+    return docker({});
+  }
+
+  throw new Error(`VGPU_EVALS_SANDBOX invalid: ${kind} (docker|vercel)`);
+}

--- a/apps/agent-evals/agent/sandbox/sandbox.ts
+++ b/apps/agent-evals/agent/sandbox/sandbox.ts
@@ -1,0 +1,61 @@
+import { defineSandbox } from "eve/sandbox";
+import { evalSandboxBackend } from "./backend.ts";
+
+/**
+ * Sandbox for the agent-evals suite.
+ *
+ * `agent/sandbox/workspace/` is seeded into `/workspace` by eve. Its contents
+ * are a materialised copy of `tasks/s1-clear-color/fixture/` — that directory
+ * is the source of truth; re-sync this copy whenever it changes (eve's
+ * `workspace/` is a static tree, not a build step, so it cannot be a symlink).
+ *
+ * `bootstrap` deliberately fails loudly when `vgpu doctor` is not healthy.
+ * Whether a GPU/software renderer works inside the sandbox image is exactly
+ * the kind of thing that would otherwise show up as a per-trial "the model
+ * couldn't do it" flake. Gating it here turns it into one cached, obvious
+ * infra failure instead — and the pixel verdict itself is still computed on
+ * the host by Layer 1, so a broken sandbox can block a run but never corrupt
+ * a result.
+ *
+ * Keep every command here backend-agnostic (plain shell, no docker flags, no
+ * host paths) so switching to `VGPU_EVALS_SANDBOX=vercel` stays a one-line
+ * env change.
+ */
+export default defineSandbox({
+  backend: evalSandboxBackend(),
+  // Bump on any bootstrap change so the cached template is rebuilt.
+  revalidationKey: () => "agent-evals-s1-bootstrap-v1",
+  async bootstrap({ use }) {
+    const sandbox = await use();
+
+    // The Vercel Sandbox spike found that the AL2023 runtimes need Mesa's
+    // Vulkan driver before vgpu can fall back to the CPU renderer. This is a
+    // no-op on images that already have it, and `|| true` keeps images without
+    // dnf (e.g. the Debian-based eve default) working — the doctor gate below
+    // is what actually decides whether the environment is usable.
+    await sandbox.run({
+      command: "command -v dnf >/dev/null && sudo dnf install -y mesa-vulkan-drivers vulkan-loader || true",
+    });
+
+    const install = await sandbox.run({ command: "pnpm install" });
+    if (install.exitCode !== 0) {
+      throw new Error(`bootstrap: pnpm install failed: ${install.stderr}`);
+    }
+
+    // No `--json`: vgpu@0.2.0's doctor already writes JSON to stdout
+    // (`Usage: vgpu doctor [--no-render] [--pretty]`), and `--json` exits 1
+    // with "Unknown doctor option".
+    const doctor = await sandbox.run({ command: "npx vgpu doctor" });
+    let verdict: unknown;
+    try {
+      verdict = (JSON.parse(doctor.stdout) as { verdict?: unknown }).verdict;
+    } catch {
+      throw new Error(`bootstrap: could not parse vgpu doctor output: ${doctor.stdout}`);
+    }
+    if (verdict !== "healthy") {
+      throw new Error(
+        `bootstrap: vgpu doctor verdict is "${String(verdict)}", expected "healthy": ${doctor.stdout}`,
+      );
+    }
+  },
+});

--- a/apps/agent-evals/agent/sandbox/workspace/package.json
+++ b/apps/agent-evals/agent/sandbox/workspace/package.json
@@ -1,0 +1,5 @@
+{
+  "private": true,
+  "type": "module",
+  "dependencies": { "vgpu": "0.2.0", "pngjs": "7.0.0" }
+}

--- a/apps/agent-evals/agent/sandbox/workspace/render.mjs
+++ b/apps/agent-evals/agent/sandbox/workspace/render.mjs
@@ -1,0 +1,21 @@
+import { writeFileSync } from "node:fs";
+import { PNG } from "pngjs";
+import { init, effect, target } from "vgpu/node";
+
+const SHADER = `
+  @fragment fn main() -> @location(0) vec4f {
+    return vec4f(0.25, 0.5, 0.75, 1.0);
+  }
+`;
+const width = 64;
+const height = 64;
+
+const gpu = await init();
+const colorTarget = target(gpu, { size: [width, height] });
+effect(gpu, SHADER).draw(colorTarget);
+const pixels = await colorTarget.read();
+
+const png = new PNG({ width, height });
+png.data.set(pixels);
+writeFileSync("out.png", PNG.sync.write(png));
+gpu.dispose();

--- a/apps/agent-evals/evals/evals.config.ts
+++ b/apps/agent-evals/evals/evals.config.ts
@@ -1,0 +1,9 @@
+import { defineEvalConfig } from "eve/evals";
+
+// No `judge`: nothing in this skeleton uses `t.judge.*` (the whole point is
+// that the verdict comes from pixels, not from prose). No `reporters` either —
+// wiring Braintrust/JUnit can wait until there is more than one eval worth
+// aggregating.
+export default defineEvalConfig({
+  timeoutMs: 180_000,
+});

--- a/apps/agent-evals/evals/h0-harness-export.eval.ts
+++ b/apps/agent-evals/evals/h0-harness-export.eval.ts
@@ -1,0 +1,53 @@
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdirSync, readFileSync, rmSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { defineEval } from "eve/evals";
+import { equals, satisfies } from "eve/evals/expect";
+import { snapshotDir, snapshotTarPath } from "../agent/hooks/snapshot-path.ts";
+import { requireCredentials } from "./lib/credentials-guard.ts";
+
+const PACKAGE_ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
+const SEED_DIR = join(PACKAGE_ROOT, "agent", "sandbox", "workspace");
+
+/**
+ * Infra self-test. No rendering, no GPU, no vgpu vocabulary: it only proves
+ * that the harness can pull the sandbox's `/workspace` back to the host
+ * byte-for-byte. This is the first eval that must go green on a real run —
+ * if it fails, every `s1` result after it is meaningless.
+ *
+ * It is also the runtime check on the one assumption this PR could not verify
+ * statically: that the export hook (which reaches the sandbox via
+ * `ctx.getSandbox()`, the only supported way — channel route handlers have no
+ * such accessor) runs on the same host filesystem as this eval.
+ */
+export default defineEval({
+  description: "h0: the harness can export the sandbox workspace to the host, byte-exact.",
+
+  async test(t) {
+    requireCredentials(t);
+
+    // A deliberately trivial turn: it provisions the sandbox and produces the
+    // `turn.completed` the export hook listens for. Nothing vgpu-specific.
+    const turn = await t.send("Reply with the single word: ready.");
+    t.succeeded();
+
+    const sessionId = turn.sessionId;
+    const tarPath = snapshotTarPath(sessionId);
+    await t.require(
+      existsSync(tarPath),
+      satisfies((value: unknown) => value === true, `export hook wrote ${tarPath}`),
+    );
+
+    const extracted = join(snapshotDir(sessionId), "h0-extract");
+    rmSync(extracted, { force: true, recursive: true });
+    mkdirSync(extracted, { recursive: true });
+    execFileSync("tar", ["-xf", tarPath, "-C", extracted]);
+
+    for (const name of ["package.json", "render.mjs"]) {
+      const exported = readFileSync(join(extracted, name));
+      const seeded = readFileSync(join(SEED_DIR, name));
+      t.check(exported.equals(seeded), equals(true)).gate().label(`${name} round-trips byte-exact`);
+    }
+  },
+});

--- a/apps/agent-evals/evals/lib/credentials-guard.ts
+++ b/apps/agent-evals/evals/lib/credentials-guard.ts
@@ -1,0 +1,21 @@
+import type { EveEvalContext } from "eve/evals";
+
+/**
+ * MUST be the first statement inside every `test(t)` in this package, `h0`
+ * included. Without it a credential-less run does not skip cleanly: it fails
+ * with a gateway auth error that reads like a harness bug and sends whoever
+ * runs it debugging the wrong thing.
+ *
+ * `t.skip()` returns `never` — it aborts the test body before any model call
+ * or sandbox provisioning happens.
+ */
+export function requireCredentials(t: EveEvalContext): void {
+  const backend = process.env.VGPU_EVALS_SANDBOX ?? "docker";
+
+  if (!process.env.AI_GATEWAY_API_KEY && !process.env.VERCEL_OIDC_TOKEN) {
+    t.skip("no AI Gateway credentials (AI_GATEWAY_API_KEY | VERCEL_OIDC_TOKEN)");
+  }
+  if (backend === "vercel" && !process.env.VERCEL_OIDC_TOKEN && !process.env.VERCEL_TOKEN) {
+    t.skip("VGPU_EVALS_SANDBOX=vercel requires Vercel credentials");
+  }
+}

--- a/apps/agent-evals/evals/lib/journey-milestones.ts
+++ b/apps/agent-evals/evals/lib/journey-milestones.ts
@@ -1,0 +1,71 @@
+import type { EveEvalToolCall } from "eve/evals";
+
+/**
+ * Soft, non-gating journey adapter: it turns raw tool calls into "did the agent
+ * ever run `vgpu doctor`?"-style counters.
+ *
+ * Gate the outcome, score the journey, never gate the ritual — nothing derived
+ * from this module may end up inside a `.gate()`. It is recorded in the
+ * evidence artifact and read by humans, that is all.
+ *
+ * Layer boundary: this module belongs to Layer 2. Nothing under `verify/` or
+ * `tasks/` may import it (Layer 2 -> Layer 1 is fine; the reverse is not).
+ */
+export interface MilestoneSpec {
+  readonly id: string;
+  readonly tool: string;
+  readonly commandPattern?: string;
+  readonly pathPattern?: string;
+}
+
+export interface Journey {
+  readonly milestones: Record<string, number>;
+  readonly order: string[];
+  readonly turnsToFirstRender: number | null;
+  readonly toolCalls: number;
+}
+
+export function deriveJourney(
+  toolCalls: readonly EveEvalToolCall[],
+  milestones: readonly MilestoneSpec[],
+): Journey {
+  const counts: Record<string, number> = {};
+  for (const milestone of milestones) counts[milestone.id] = 0;
+
+  const order: string[] = [];
+  let turnsToFirstRender: number | null = null;
+
+  for (const call of toolCalls) {
+    for (const milestone of milestones) {
+      if (call.name !== milestone.tool) continue;
+
+      const subject =
+        milestone.commandPattern !== undefined
+          ? stringField(call.input, "command")
+          : stringField(call.input, "path");
+      const pattern = milestone.commandPattern ?? milestone.pathPattern;
+      if (subject === null || pattern === undefined) continue;
+
+      if (!new RegExp(pattern, "u").test(subject)) continue;
+
+      counts[milestone.id] = (counts[milestone.id] ?? 0) + 1;
+      order.push(milestone.id);
+      if (milestone.id === "ranRender" && turnsToFirstRender === null) {
+        turnsToFirstRender = call.turnIndex;
+      }
+    }
+  }
+
+  return {
+    milestones: counts,
+    order,
+    turnsToFirstRender,
+    toolCalls: toolCalls.length,
+  };
+}
+
+function stringField(input: unknown, key: string): string | null {
+  if (typeof input !== "object" || input === null) return null;
+  const value = (input as Record<string, unknown>)[key];
+  return typeof value === "string" ? value : null;
+}

--- a/apps/agent-evals/evals/s1-clear-color.eval.ts
+++ b/apps/agent-evals/evals/s1-clear-color.eval.ts
@@ -1,0 +1,101 @@
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { defineEval } from "eve/evals";
+import { equals, satisfies } from "eve/evals/expect";
+import {
+  evidencePath,
+  snapshotTarPath,
+  snapshotWorkspaceDir,
+  workDir,
+} from "../agent/hooks/snapshot-path.ts";
+// Layer 2 -> Layer 1: the grader is imported verbatim, never re-implemented.
+import { verifyTask } from "../verify/verify-task.mjs";
+import { requireCredentials } from "./lib/credentials-guard.ts";
+import { deriveJourney, type MilestoneSpec } from "./lib/journey-milestones.ts";
+
+const PACKAGE_ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
+const TASK_ID = "s1-clear-color";
+const TASKS_ROOT = join(PACKAGE_ROOT, "tasks");
+const TASK_DIR = join(TASKS_ROOT, TASK_ID);
+
+/**
+ * Layer 1's Evidence, plus the Layer-2-only fields this eval adds. Layer 2
+ * extends the schema, it never redefines it.
+ */
+interface Evidence {
+  schemaVersion: number;
+  taskId: string;
+  env: Record<string, unknown>;
+  gates: Record<string, string>;
+  metrics: Record<string, unknown>;
+  failures: string[];
+  journey?: unknown;
+}
+
+interface TaskManifest {
+  readonly taskId: string;
+  readonly journeyMilestones: readonly MilestoneSpec[];
+}
+
+/**
+ * The end-to-end walking skeleton: hand a neutral coding agent a neutral task,
+ * export the workspace it leaves behind, and grade it with Layer 1's verifier.
+ *
+ * What is gated: `renders` and `colorExact`, both computed on the host from a
+ * PNG this process re-rendered itself. What is NOT gated: the agent's reply,
+ * and the whole journey (which tools it reached for, whether it ever ran
+ * `vgpu doctor`). Gate the outcome, score the journey, never gate the ritual.
+ */
+export default defineEval({
+  description: "s1: agent makes the rendered image solid red; graded by pixels, not by prose.",
+
+  async test(t) {
+    requireCredentials(t);
+
+    const manifest = JSON.parse(
+      readFileSync(join(TASK_DIR, "manifest.json"), "utf8"),
+    ) as TaskManifest;
+
+    // The prompt file is owned by Layer 1 and read, never duplicated.
+    const turn = await t.send(readFileSync(join(TASK_DIR, "prompt.md"), "utf8"));
+
+    // Harness-level success only: the run completed. This is not the pixel gate.
+    t.succeeded();
+
+    const sessionId = turn.sessionId;
+    const tarPath = snapshotTarPath(sessionId);
+    await t.require(
+      existsSync(tarPath),
+      satisfies((value: unknown) => value === true, `export hook wrote ${tarPath}`),
+    );
+
+    const extracted = snapshotWorkspaceDir(sessionId);
+    rmSync(extracted, { force: true, recursive: true });
+    mkdirSync(extracted, { recursive: true });
+    execFileSync("tar", ["-xf", tarPath, "-C", extracted]);
+
+    const evidence: Evidence = await verifyTask({
+      tasksRoot: TASKS_ROOT,
+      taskId: TASK_ID,
+      workspaceDir: extracted,
+      workDir: workDir(),
+    });
+
+    // Soft, report-only enrichment. Nothing below is gated on.
+    evidence.journey = deriveJourney(turn.toolCalls, manifest.journeyMilestones);
+    evidence.env.model = process.env.VGPU_EVALS_MODEL ?? "anthropic/claude-sonnet-5";
+    evidence.env.sandboxBackend = process.env.VGPU_EVALS_SANDBOX ?? "docker";
+    evidence.env.sessionId = sessionId;
+
+    const artifact = evidencePath(sessionId);
+    mkdirSync(dirname(artifact), { recursive: true });
+    writeFileSync(artifact, `${JSON.stringify(evidence, null, 2)}\n`, "utf8");
+    t.log(`evidence written to ${artifact}`);
+
+    // The only two gates in this file.
+    t.check(evidence.gates.renders, equals("pass")).gate();
+    t.check(evidence.gates.colorExact, equals("pass")).gate();
+  },
+});

--- a/apps/agent-evals/package.json
+++ b/apps/agent-evals/package.json
@@ -3,9 +3,18 @@
   "version": "0.0.0",
   "private": true,
   "type": "module",
+  "engines": {
+    "node": ">=24"
+  },
   "scripts": {
     "test": "vitest run",
-    "verify": "node verify/run-verify.mjs"
+    "verify": "node verify/run-verify.mjs",
+    "evals": "eve eval"
+  },
+  "dependencies": {
+    "ai": "^7.0.38",
+    "eve": "0.29.5",
+    "zod": "^4.1.8"
   },
   "devDependencies": {
     "@types/node": "^22.10.7",

--- a/apps/agent-evals/tsconfig.json
+++ b/apps/agent-evals/tsconfig.json
@@ -4,13 +4,16 @@
     "module": "ES2022",
     "moduleResolution": "Bundler",
     "strict": true,
+    "skipLibCheck": true,
+    "types": ["node"],
     // The verifier itself is plain `.mjs` (it must stay runnable with bare
     // `node`, with no build step); `allowJs` lets the TypeScript test file
     // import it and pick up its JSDoc types instead of erroring with TS7016.
     "allowJs": true,
     "checkJs": false,
-    "skipLibCheck": true,
-    "types": ["node"]
+    // eve authors import sibling modules with an explicit `.ts` extension.
+    "allowImportingTsExtensions": true,
+    "noEmit": true
   },
-  "include": ["verify/**/*.ts"]
+  "include": ["verify/**/*.ts", "agent/**/*.ts", "evals/**/*.ts"]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,6 +53,16 @@ importers:
         version: 0.4.0
 
   apps/agent-evals:
+    dependencies:
+      ai:
+        specifier: ^7.0.38
+        version: 7.0.48(zod@4.1.11)
+      eve:
+        specifier: 0.29.5
+        version: 0.29.5(@vercel/blob@2.6.1)(ai@7.0.48(zod@4.1.11))(jiti@1.21.7)(vite@6.4.3(@types/node@22.19.17)(jiti@1.21.7)(terser@5.47.1))
+      zod:
+        specifier: ^4.1.8
+        version: 4.1.11
     devDependencies:
       '@types/node':
         specifier: ^22.10.7
@@ -401,6 +411,22 @@ importers:
   packages/wgsl-std: {}
 
 packages:
+
+  '@ai-sdk/gateway@4.0.37':
+    resolution: {integrity: sha512-YBCTsSlX0ETVsjo0ihfBOeJ3p3y1wXKXDzF9Ygp9dscUY06dzOGmyWJSGsKg+khKVArzBWUW4UCSAKms20ZDmg==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/provider-utils@5.0.18':
+    resolution: {integrity: sha512-UBNCrkxS5llgN2/RXLBRkjCFTIuL6YB1Goq5c+yRecnznhtX4XPjTwLHz2hrsTltTVZ0rqVegtnwFXdPBkjDHA==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/provider@4.0.4':
+    resolution: {integrity: sha512-tbHKNLirllUNF3ZlkCsXnwab2ZV1Sl4b1H/Cp9ruCce15IBmskE8Gwkk0yo9xDWY+jho2of7lVXtwSsyrq7cwQ==}
+    engines: {node: '>=22'}
 
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
@@ -1090,6 +1116,9 @@ packages:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
 
+  '@oxc-project/types@0.142.0':
+    resolution: {integrity: sha512-7W+2q5AKQVU36fkaryontrHn3YDt1RyUYXatw9i5H8ocYe2sPKSFB6eS8WNPeRKiN1qAWWZUPm7gwFzJGrccqQ==}
+
   '@protobufjs/aspromise@1.1.2':
     resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
 
@@ -1116,6 +1145,93 @@ packages:
 
   '@protobufjs/utf8@1.1.2':
     resolution: {integrity: sha512-b1UQwcEZ4yCnMCD8DAL1VlbvBJE9/IX4FTIp7BG1xYpf29SLazLSrqUkj4w7Y5y7cCVP6E5tcqqcI0xemPkHug==}
+
+  '@rolldown/binding-android-arm64@1.2.2':
+    resolution: {integrity: sha512-l7x215OGvo1s52JWmR8U/DAVzEDWBCIbTm28aeJV/WDTSHgcKXaZTuBT0hJMs5NggilfJTW3clZVvd24yfKJxA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@rolldown/binding-darwin-arm64@1.2.2':
+    resolution: {integrity: sha512-9u9Xv6c1AJZT0FfwH5vrMG5Jjcwhc1MlyrPu0XfTqkzsmqfks2M6W/o5XwAJgVVN/jHpqqngC1WevHKKTIUtIA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rolldown/binding-darwin-x64@1.2.2':
+    resolution: {integrity: sha512-9W1mbGZAfW3oqd85bhBkmpyHCCzL1TeG/zFFP3vg7b0rlly8cxOcre5nXwz+LHazCwac2MNWgPdPCHndABjpWQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rolldown/binding-freebsd-x64@1.2.2':
+    resolution: {integrity: sha512-0p1lhiCSCyaerFwtrdZQUx7NqGk6LQnaRKWX7tFQqwQgvX0rjM15cIkm3pax1UpEakK14C4mOxx/jSqCBdBRqQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.2.2':
+    resolution: {integrity: sha512-e+cOJXrJ2L3zx6YzqPg+f6Wbk3V1cKB8bOhbaYdVYN3DdquzNdRAmrbETz1qnt5yp/c7JNlNjmITiA2cVneQ7w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-gnu@1.2.2':
+    resolution: {integrity: sha512-JsSMsj6sNat/MuhG5fnBD7QgbtpHKVe30x5/bAVirDHdhoQRXJkF6xc0Jqk8O4fiCUQAzMOoH9wZi3m60c8wtg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-musl@1.2.2':
+    resolution: {integrity: sha512-B5G/zJdHaoJn9vD50eGHWkiWfmq8Uhi3IiLPJTzmZTrAalk1bztUikSXo0qga18ibE0IXboyeMUnhPjhAJ45wQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rolldown/binding-linux-ppc64-gnu@1.2.2':
+    resolution: {integrity: sha512-6mC/awzKka8W6EoekjegpfGkjz8jXWDX63pqu/HYVpyKtZfu65Jsh4QAH3Kej3CAv/c1oGX7psTmFEbr0mDxLA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rolldown/binding-linux-s390x-gnu@1.2.2':
+    resolution: {integrity: sha512-412MX9fJLdA1IK28EZnc8jYv2HRTleOZgfLQumJ5zy7OeJLZlg/CETwFaXjNmGVxG51cFHpKLqb5LKvBC+HsHA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+
+  '@rolldown/binding-linux-x64-gnu@1.2.2':
+    resolution: {integrity: sha512-Q/+HI/ToJafZ1iCqGgVQXUEkIjufHCTF0gBQ2a5o3cg7GJ2h0qyq3nvvSmU+bGda2/7ygXpTY4TM6gO9OhQ0ZA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@rolldown/binding-linux-x64-musl@1.2.2':
+    resolution: {integrity: sha512-ZKp/w41n6wCvxzxQHtQSbuphfX3Y4cCvbjkKHusrLx4lh+JWLTU7StSltO/DKARISzbj368d+qUaCjI8K2wzXw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@rolldown/binding-openharmony-arm64@1.2.2':
+    resolution: {integrity: sha512-pxE6xD4KS3eAROkKK5yrhB9/3+vhlhVGMvlQLbdpzrBGDbKrnzx3RLwPaHvasLo6jgaiBLn7e04Df9C4tYhjmA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rolldown/binding-win32-arm64-msvc@1.2.2':
+    resolution: {integrity: sha512-4MqEue5re+xIZzAWsB8sj0P1kqZySWqIuN4t6QaIO/YA6SFwySOLruvWQFzfmqk8LBK2P30KCSJwf6mJCZZ5/A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rolldown/binding-win32-x64-msvc@1.2.2':
+    resolution: {integrity: sha512-NweNxxD0Nf9t8v7kodun45Ijp3EIwYY+uydPP6qBEYvfBqhIjN6dZMzlQja3tqX/aLs3F3Uz+AxDpKgRhpOZQg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@rolldown/pluginutils@1.0.1':
+    resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
 
   '@rollup/rollup-android-arm-eabi@4.60.3':
     resolution: {integrity: sha512-x35CNW/ANXG3hE/EZpRU8MXX1JDN86hBb2wMGAtltkz7pc6cxgjpy1OMMfDosOQ+2hWqIkag/fGok1Yady9nGw==}
@@ -1263,6 +1379,9 @@ packages:
   '@shikijs/vscode-textmate@10.0.2':
     resolution: {integrity: sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==}
 
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
   '@swc/helpers@0.5.15':
     resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
 
@@ -1335,6 +1454,10 @@ packages:
   '@vercel/cli-exec@1.0.0':
     resolution: {integrity: sha512-kQF8LGie/Hbdq9/psJxLE7owRTcqMQMhgybU04gCeR7cbQAr5t8OrjefDNColJv1QSSucFt4pLwRiARVmlOnug==}
     engines: {node: '>= 18'}
+
+  '@vercel/oidc@3.2.0':
+    resolution: {integrity: sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==}
+    engines: {node: '>= 20'}
 
   '@vercel/oidc@3.8.0':
     resolution: {integrity: sha512-r00laGW6Pv778RoR6M2NxX91ycSj+PBwVo+fOb9Bif+F0IyUKt25zrvBzfEzQpeAzbqOgPZyQibEWDdDFApd+A==}
@@ -1417,6 +1540,9 @@ packages:
   '@webgpu/types@0.1.69':
     resolution: {integrity: sha512-RPmm6kgRbI8e98zSD3RVACvnuktIja5+yLgDAkTmxLr90BEwdTXRQWNLF3ETTTyH/8mKhznZuN5AveXYFEsMGQ==}
 
+  '@workflow/serde@4.1.0':
+    resolution: {integrity: sha512-pav4F2BoirECWR7Nf1TKt+2eETcBj7jj4cBefQ8VXQCA6NPkaKeLfj/zMgi+3zYV5ZIBT4GuUiphsj0/b9hPQQ==}
+
   '@xtuc/ieee754@1.2.0':
     resolution: {integrity: sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==}
 
@@ -1443,6 +1569,12 @@ packages:
         optional: true
       react-dom:
         optional: true
+
+  ai@7.0.48:
+    resolution: {integrity: sha512-QmqshWFEDdkFFqSgdJ4cogaoDIYaedqbv73q/NXEYNkSIocJCzXnGFVyM9lrtAGTSBfm+5hq3/292ooXJ1jDSw==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
 
   ajv-formats@2.1.1:
     resolution: {integrity: sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==}
@@ -1595,9 +1727,21 @@ packages:
     resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
     engines: {node: '>= 6'}
 
+  consola@3.4.2:
+    resolution: {integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==}
+    engines: {node: ^14.18.0 || >=16.10.0}
+
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
+
+  crossws@0.4.10:
+    resolution: {integrity: sha512-pz3oubH/dt12KjqsUB0IuXW4nwRDQ583iDsP4555Cpdqx0NoU7pGlWBcayyFI8f/l/idRpgjMEfwuOxSWJYlIA==}
+    peerDependencies:
+      srvx: '>=0.11.5'
+    peerDependenciesMeta:
+      srvx:
+        optional: true
 
   cssesc@3.0.0:
     resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
@@ -1606,6 +1750,29 @@ packages:
 
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
+  db0@0.3.4:
+    resolution: {integrity: sha512-RiXXi4WaNzPTHEOu8UPQKMooIbqOEyqA1t7Z6MsdxSCeb8iUC9ko3LcmsLmeUt2SM5bctfArZKkRQggKZz7JNw==}
+    peerDependencies:
+      '@electric-sql/pglite': '*'
+      '@libsql/client': '*'
+      better-sqlite3: '*'
+      drizzle-orm: '*'
+      mysql2: '*'
+      sqlite3: '*'
+    peerDependenciesMeta:
+      '@electric-sql/pglite':
+        optional: true
+      '@libsql/client':
+        optional: true
+      better-sqlite3:
+        optional: true
+      drizzle-orm:
+        optional: true
+      mysql2:
+        optional: true
+      sqlite3:
+        optional: true
 
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
@@ -1658,6 +1825,24 @@ packages:
   enquirer@2.4.1:
     resolution: {integrity: sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==}
     engines: {node: '>=8.6'}
+
+  env-runner@0.1.16:
+    resolution: {integrity: sha512-2LRJM4P2KLX6J83QZZrMqvgCDt/D5ea7wPcI3yYiy5cG/9rX5QwdwZFx0D7ktWnjdRyZxYjttGGorb5nFqb1CA==}
+    hasBin: true
+    peerDependencies:
+      '@netlify/runtime': ^4.1.23
+      '@vercel/queue': '>=0.2.0'
+      miniflare: ^4.20260515.0
+      wrangler: ^4.0.0
+    peerDependenciesMeta:
+      '@netlify/runtime':
+        optional: true
+      '@vercel/queue':
+        optional: true
+      miniflare:
+        optional: true
+      wrangler:
+        optional: true
 
   es-errors@1.3.0:
     resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
@@ -1735,9 +1920,33 @@ packages:
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
 
+  eve@0.29.5:
+    resolution: {integrity: sha512-XiIJHANIgT7LQAZ3e2MyQG4N+B9dPYwdFk0rAzSGYSBjgavCbCtX/tXDlqasjIfEH726uxFdYrLGnlGvIZ38vg==}
+    engines: {node: '>=24'}
+    hasBin: true
+    peerDependencies:
+      '@opentelemetry/api': ^1.0.0
+      ai: ^7.0.38
+      braintrust: ^3.0.0
+      just-bash: ^3.0.0
+      microsandbox: ^0.5.0
+    peerDependenciesMeta:
+      '@opentelemetry/api':
+        optional: true
+      braintrust:
+        optional: true
+      just-bash:
+        optional: true
+      microsandbox:
+        optional: true
+
   events@3.3.0:
     resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
     engines: {node: '>=0.8.x'}
+
+  eventsource-parser@3.1.0:
+    resolution: {integrity: sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==}
+    engines: {node: '>=18.0.0'}
 
   execa@5.1.1:
     resolution: {integrity: sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==}
@@ -1746,6 +1955,9 @@ packages:
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
+
+  exsolve@1.1.1:
+    resolution: {integrity: sha512-9U/jZUgjnSGyntRr6y5Muu1MJcwFl6kPu7k8qLF0IMNfLqvw0NZ4nnVDq0RVoZ0RvCyumib4Ez3KYrVfilrw+g==}
 
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
@@ -1832,6 +2044,16 @@ packages:
   guid-typescript@1.0.9:
     resolution: {integrity: sha512-Y8T4vYhEfwJOTbouREvG+3XDsjr8E3kIr7uf+JZ0BYloFsttiHU0WfvANVsR7TxNUJa/WpCnw/Ino/p+DeBhBQ==}
 
+  h3@2.0.1-rc.22:
+    resolution: {integrity: sha512-Esv0DMIuPkCTSWCA0vO73vcTqwzH1wjSrAO1TXNu/K3up1sZHa9EKMapbmxCDYBeymC3fVTk4qxp7ogQWQ+KgA==}
+    engines: {node: '>=20.11.1'}
+    hasBin: true
+    peerDependencies:
+      crossws: ^0.4.1
+    peerDependenciesMeta:
+      crossws:
+        optional: true
+
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
@@ -1852,11 +2074,17 @@ packages:
   hast-util-whitespace@3.0.0:
     resolution: {integrity: sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==}
 
+  hookable@6.1.1:
+    resolution: {integrity: sha512-U9LYDy1CwhMCnprUfeAZWZGByVbhd54hwepegYTK7Pi5NvqEj63ifz5z+xukznehT7i6NIZRu89Ay1AZmRsLEQ==}
+
   html-url-attributes@3.0.1:
     resolution: {integrity: sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==}
 
   html-void-elements@3.0.0:
     resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
+
+  httpxy@0.5.5:
+    resolution: {integrity: sha512-uDjmnPyp1q4Sgzf3w+J/Fc6UqcCEj0x4Wjp7OqK5dGhNeDgpyrAmnS6ey8QWrX3SWDon2DMKf9sBa5X9+CVyMA==}
 
   human-id@4.2.0:
     resolution: {integrity: sha512-K3GbkIWqyvvlpfhBPlbEvD97TtqBpAYA4kt+cn2lD2x2HuohzZCibcA2nOlnJT6exqvJLggoB5nv2dNf192nEA==}
@@ -1962,6 +2190,9 @@ packages:
 
   json-schema-traverse@1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+
+  json-schema@0.4.0:
+    resolution: {integrity: sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==}
 
   jsonfile@4.0.0:
     resolution: {integrity: sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==}
@@ -2291,6 +2522,40 @@ packages:
       sass:
         optional: true
 
+  nf3@0.3.23:
+    resolution: {integrity: sha512-RWVLAWozmVD3AaDmaU3qMGB3v+yNlH5d9qqStI4e/WLlNQVnJ4YErGDbYCIrGFyrHdbF6I6Baf0Ae6c7tFYmSg==}
+
+  nitro@3.0.260610-beta:
+    resolution: {integrity: sha512-KPb4L5yaF/Rx/xoGMpgHRJvZhbhGiqbRKOwwPLCH9jKTKTsEUHLjnJas85AeCzaswqa8Wi52eQBtRsODC4PS0Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@vercel/queue': ^0.3.0
+      dotenv: '*'
+      giget: '*'
+      jiti: ^2.7.0
+      rollup: ^4.61.1
+      vite: ^6.4.3
+      xml2js: ^0.6.2
+      zephyr-agent: ^0.2.0
+    peerDependenciesMeta:
+      '@vercel/queue':
+        optional: true
+      dotenv:
+        optional: true
+      giget:
+        optional: true
+      jiti:
+        optional: true
+      rollup:
+        optional: true
+      vite:
+        optional: true
+      xml2js:
+        optional: true
+      zephyr-agent:
+        optional: true
+
   node-releases@2.0.51:
     resolution: {integrity: sha512-wRNIrw4DmVLKQlbgOMdkMx27Wrpzes2hh5Jtbi2bjPd+4wJstWIqP5A+lscnqbm0xxmT5Bpg8Lec5ItEBwx6BQ==}
     engines: {node: '>=18'}
@@ -2310,6 +2575,15 @@ packages:
   object-hash@3.0.0:
     resolution: {integrity: sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==}
     engines: {node: '>= 6'}
+
+  ocache@0.1.5:
+    resolution: {integrity: sha512-kNNnkkVQup/QDvmTz8Q84wc2ntiyoVHDxa6eHWKt5qdGAmFRBIxy83rxgCYEjW0x06UJ9E3P6VgM2yY4rOBH4w==}
+
+  ofetch@2.0.0-alpha.3:
+    resolution: {integrity: sha512-zpYTCs2byOuft65vI3z43Dd6iSdFbOZZLb9/d21aCpx2rGastVU9dOCv0lu4ykc1Ur1anAYjDi3SUvR0vq50JA==}
+
+  ohash@2.0.11:
+    resolution: {integrity: sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==}
 
   onetime@5.1.2:
     resolution: {integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==}
@@ -2573,10 +2847,18 @@ packages:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
 
+  rolldown@1.2.2:
+    resolution: {integrity: sha512-opwpo1tQBAcpSUJDt94B7hhLNGOKjCdE//XXjeLrnx9b83bjnw45tXdg1b09yEw/VLFBJGZpwRULMmOZo7ol+A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+
   rollup@4.60.3:
     resolution: {integrity: sha512-pAQK9HalE84QSm4Po3EmWIZPd3FnjkShVkiMlz1iligWYkWQ7wHYd1PF/T7QZ5TVSD6uSTon5gBVMSM4JfBV+A==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
+
+  rou3@0.8.1:
+    resolution: {integrity: sha512-ePa+XGk00/3HuCqrEnK3LxJW7I0SdNg6EFzKUJG73hMAdDcOUC/i/aSz7LSDwLrGr33kal/rqOGydzwl6U7zBA==}
 
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
@@ -2648,6 +2930,11 @@ packages:
 
   sprintf-js@1.0.3:
     resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
+
+  srvx@0.11.22:
+    resolution: {integrity: sha512-LqZxxBDMKuMAZzFzJnDCkFOrs9MZQZr0LvHiO/SuSZVdQaXD7xQ5UWTUxheJrQPve1qk9MG2B/yttUvJxw8egQ==}
+    engines: {node: '>=20.16.0'}
+    hasBin: true
 
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
@@ -2784,6 +3071,17 @@ packages:
     resolution: {integrity: sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==}
     engines: {node: '>=18.17'}
 
+  undici@7.29.0:
+    resolution: {integrity: sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==}
+    engines: {node: '>=20.18.1'}
+
+  undici@8.9.0:
+    resolution: {integrity: sha512-aWZpUj7XoGonMClx4gdDRfgBjqeA+F473aDmROQQbM9n6PRfK/u1q/a0X4wMTgcHfT8H6fpbt98PFuDUwFg2YA==}
+    engines: {node: '>=22.19.0'}
+
+  unenv@2.0.0-rc.24:
+    resolution: {integrity: sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==}
+
   unified@11.0.5:
     resolution: {integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==}
 
@@ -2808,6 +3106,80 @@ packages:
   universalify@0.1.2:
     resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==}
     engines: {node: '>= 4.0.0'}
+
+  unstorage@2.0.0-alpha.7:
+    resolution: {integrity: sha512-ELPztchk2zgFJnakyodVY3vJWGW9jy//keJ32IOJVGUMyaPydwcA1FtVvWqT0TNRch9H+cMNEGllfVFfScImog==}
+    peerDependencies:
+      '@azure/app-configuration': ^1.11.0
+      '@azure/cosmos': ^4.9.1
+      '@azure/data-tables': ^13.3.2
+      '@azure/identity': ^4.13.0
+      '@azure/keyvault-secrets': ^4.10.0
+      '@azure/storage-blob': ^12.31.0
+      '@capacitor/preferences': ^6 || ^7 || ^8
+      '@deno/kv': '>=0.13.0'
+      '@netlify/blobs': ^6.5.0 || ^7.0.0 || ^8.1.0 || ^9.0.0 || ^10.0.0
+      '@planetscale/database': ^1.19.0
+      '@upstash/redis': ^1.36.2
+      '@vercel/blob': '>=0.27.3'
+      '@vercel/functions': ^2.2.12 || ^3.0.0
+      '@vercel/kv': ^1.0.1
+      aws4fetch: ^1.0.20
+      chokidar: ^4 || ^5
+      db0: '>=0.3.4'
+      idb-keyval: ^6.2.2
+      ioredis: ^5.9.3
+      lru-cache: ^11.2.6
+      mongodb: ^6 || ^7
+      ofetch: '*'
+      uploadthing: ^7.7.4
+    peerDependenciesMeta:
+      '@azure/app-configuration':
+        optional: true
+      '@azure/cosmos':
+        optional: true
+      '@azure/data-tables':
+        optional: true
+      '@azure/identity':
+        optional: true
+      '@azure/keyvault-secrets':
+        optional: true
+      '@azure/storage-blob':
+        optional: true
+      '@capacitor/preferences':
+        optional: true
+      '@deno/kv':
+        optional: true
+      '@netlify/blobs':
+        optional: true
+      '@planetscale/database':
+        optional: true
+      '@upstash/redis':
+        optional: true
+      '@vercel/blob':
+        optional: true
+      '@vercel/functions':
+        optional: true
+      '@vercel/kv':
+        optional: true
+      aws4fetch:
+        optional: true
+      chokidar:
+        optional: true
+      db0:
+        optional: true
+      idb-keyval:
+        optional: true
+      ioredis:
+        optional: true
+      lru-cache:
+        optional: true
+      mongodb:
+        optional: true
+      ofetch:
+        optional: true
+      uploadthing:
+        optional: true
 
   update-browserslist-db@1.2.3:
     resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
@@ -2946,6 +3318,26 @@ packages:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
 snapshots:
+
+  '@ai-sdk/gateway@4.0.37(zod@4.1.11)':
+    dependencies:
+      '@ai-sdk/provider': 4.0.4
+      '@ai-sdk/provider-utils': 5.0.18(zod@4.1.11)
+      '@vercel/oidc': 3.2.0
+      zod: 4.1.11
+
+  '@ai-sdk/provider-utils@5.0.18(zod@4.1.11)':
+    dependencies:
+      '@ai-sdk/provider': 4.0.4
+      '@standard-schema/spec': 1.1.0
+      '@workflow/serde': 4.1.0
+      eventsource-parser: 3.1.0
+      undici: 7.29.0
+      zod: 4.1.11
+
+  '@ai-sdk/provider@4.0.4':
+    dependencies:
+      json-schema: 0.4.0
 
   '@alloc/quick-lru@5.2.0': {}
 
@@ -3510,6 +3902,8 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.20.1
 
+  '@oxc-project/types@0.142.0': {}
+
   '@protobufjs/aspromise@1.1.2': {}
 
   '@protobufjs/base64@1.1.2': {}
@@ -3529,6 +3923,50 @@ snapshots:
   '@protobufjs/pool@1.1.0': {}
 
   '@protobufjs/utf8@1.1.2': {}
+
+  '@rolldown/binding-android-arm64@1.2.2':
+    optional: true
+
+  '@rolldown/binding-darwin-arm64@1.2.2':
+    optional: true
+
+  '@rolldown/binding-darwin-x64@1.2.2':
+    optional: true
+
+  '@rolldown/binding-freebsd-x64@1.2.2':
+    optional: true
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.2.2':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-gnu@1.2.2':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-musl@1.2.2':
+    optional: true
+
+  '@rolldown/binding-linux-ppc64-gnu@1.2.2':
+    optional: true
+
+  '@rolldown/binding-linux-s390x-gnu@1.2.2':
+    optional: true
+
+  '@rolldown/binding-linux-x64-gnu@1.2.2':
+    optional: true
+
+  '@rolldown/binding-linux-x64-musl@1.2.2':
+    optional: true
+
+  '@rolldown/binding-openharmony-arm64@1.2.2':
+    optional: true
+
+  '@rolldown/binding-win32-arm64-msvc@1.2.2':
+    optional: true
+
+  '@rolldown/binding-win32-x64-msvc@1.2.2':
+    optional: true
+
+  '@rolldown/pluginutils@1.0.1': {}
 
   '@rollup/rollup-android-arm-eabi@4.60.3':
     optional: true
@@ -3638,6 +4076,8 @@ snapshots:
 
   '@shikijs/vscode-textmate@10.0.2': {}
 
+  '@standard-schema/spec@1.1.0': {}
+
   '@swc/helpers@0.5.15':
     dependencies:
       tslib: 2.8.1
@@ -3717,6 +4157,8 @@ snapshots:
   '@vercel/cli-exec@1.0.0':
     dependencies:
       execa: 5.1.1
+
+  '@vercel/oidc@3.2.0': {}
 
   '@vercel/oidc@3.8.0':
     dependencies:
@@ -3844,6 +4286,8 @@ snapshots:
 
   '@webgpu/types@0.1.69': {}
 
+  '@workflow/serde@4.1.0': {}
+
   '@xtuc/ieee754@1.2.0': {}
 
   '@xtuc/long@4.2.2': {}
@@ -3858,6 +4302,13 @@ snapshots:
     optionalDependencies:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
+
+  ai@7.0.48(zod@4.1.11):
+    dependencies:
+      '@ai-sdk/gateway': 4.0.37(zod@4.1.11)
+      '@ai-sdk/provider': 4.0.4
+      '@ai-sdk/provider-utils': 5.0.18(zod@4.1.11)
+      zod: 4.1.11
 
   ajv-formats@2.1.1(ajv@8.20.0):
     optionalDependencies:
@@ -3989,15 +4440,23 @@ snapshots:
 
   commander@4.1.1: {}
 
+  consola@3.4.2: {}
+
   cross-spawn@7.0.6:
     dependencies:
       path-key: 3.1.1
       shebang-command: 2.0.0
       which: 2.0.2
 
+  crossws@0.4.10(srvx@0.11.22):
+    optionalDependencies:
+      srvx: 0.11.22
+
   cssesc@3.0.0: {}
 
   csstype@3.2.3: {}
+
+  db0@0.3.4: {}
 
   debug@4.4.3:
     dependencies:
@@ -4039,6 +4498,13 @@ snapshots:
     dependencies:
       ansi-colors: 4.1.3
       strip-ansi: 6.0.1
+
+  env-runner@0.1.16:
+    dependencies:
+      crossws: 0.4.10(srvx@0.11.22)
+      exsolve: 1.1.1
+      httpxy: 0.5.5
+      srvx: 0.11.22
 
   es-errors@1.3.0: {}
 
@@ -4170,7 +4636,54 @@ snapshots:
     dependencies:
       '@types/estree': 1.0.8
 
+  eve@0.29.5(@vercel/blob@2.6.1)(ai@7.0.48(zod@4.1.11))(jiti@1.21.7)(vite@6.4.3(@types/node@22.19.17)(jiti@1.21.7)(terser@5.47.1)):
+    dependencies:
+      ai: 7.0.48(zod@4.1.11)
+      nitro: 3.0.260610-beta(@vercel/blob@2.6.1)(jiti@1.21.7)(vite@6.4.3(@types/node@22.19.17)(jiti@1.21.7)(terser@5.47.1))
+      undici: 8.9.0
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@electric-sql/pglite'
+      - '@libsql/client'
+      - '@netlify/blobs'
+      - '@netlify/runtime'
+      - '@planetscale/database'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/functions'
+      - '@vercel/kv'
+      - '@vercel/queue'
+      - aws4fetch
+      - better-sqlite3
+      - chokidar
+      - dotenv
+      - drizzle-orm
+      - giget
+      - idb-keyval
+      - ioredis
+      - jiti
+      - lru-cache
+      - miniflare
+      - mongodb
+      - mysql2
+      - rollup
+      - sqlite3
+      - uploadthing
+      - vite
+      - wrangler
+      - xml2js
+      - zephyr-agent
+
   events@3.3.0: {}
+
+  eventsource-parser@3.1.0: {}
 
   execa@5.1.1:
     dependencies:
@@ -4185,6 +4698,8 @@ snapshots:
       strip-final-newline: 2.0.0
 
   expect-type@1.3.0: {}
+
+  exsolve@1.1.1: {}
 
   extend@3.0.2: {}
 
@@ -4267,6 +4782,13 @@ snapshots:
 
   guid-typescript@1.0.9: {}
 
+  h3@2.0.1-rc.22(crossws@0.4.10(srvx@0.11.22)):
+    dependencies:
+      rou3: 0.8.1
+      srvx: 0.11.22
+    optionalDependencies:
+      crossws: 0.4.10(srvx@0.11.22)
+
   has-flag@4.0.0: {}
 
   hasown@2.0.4:
@@ -4332,9 +4854,13 @@ snapshots:
     dependencies:
       '@types/hast': 3.0.5
 
+  hookable@6.1.1: {}
+
   html-url-attributes@3.0.1: {}
 
   html-void-elements@3.0.0: {}
+
+  httpxy@0.5.5: {}
 
   human-id@4.2.0: {}
 
@@ -4415,6 +4941,8 @@ snapshots:
       argparse: 2.0.1
 
   json-schema-traverse@1.0.0: {}
+
+  json-schema@0.4.0: {}
 
   jsonfile@4.0.0:
     optionalDependencies:
@@ -4979,6 +5507,59 @@ snapshots:
       - '@babel/core'
       - babel-plugin-macros
 
+  nf3@0.3.23: {}
+
+  nitro@3.0.260610-beta(@vercel/blob@2.6.1)(jiti@1.21.7)(vite@6.4.3(@types/node@22.19.17)(jiti@1.21.7)(terser@5.47.1)):
+    dependencies:
+      consola: 3.4.2
+      crossws: 0.4.10(srvx@0.11.22)
+      db0: 0.3.4
+      env-runner: 0.1.16
+      h3: 2.0.1-rc.22(crossws@0.4.10(srvx@0.11.22))
+      hookable: 6.1.1
+      nf3: 0.3.23
+      ocache: 0.1.5
+      ofetch: 2.0.0-alpha.3
+      ohash: 2.0.11
+      rolldown: 1.2.2
+      srvx: 0.11.22
+      unenv: 2.0.0-rc.24
+      unstorage: 2.0.0-alpha.7(@vercel/blob@2.6.1)(db0@0.3.4)(ofetch@2.0.0-alpha.3)
+    optionalDependencies:
+      jiti: 1.21.7
+      vite: 6.4.3(@types/node@22.19.17)(jiti@1.21.7)(terser@5.47.1)
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@electric-sql/pglite'
+      - '@libsql/client'
+      - '@netlify/blobs'
+      - '@netlify/runtime'
+      - '@planetscale/database'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/functions'
+      - '@vercel/kv'
+      - aws4fetch
+      - better-sqlite3
+      - chokidar
+      - drizzle-orm
+      - idb-keyval
+      - ioredis
+      - lru-cache
+      - miniflare
+      - mongodb
+      - mysql2
+      - sqlite3
+      - uploadthing
+      - wrangler
+
   node-releases@2.0.51: {}
 
   normalize-path@3.0.0: {}
@@ -4990,6 +5571,14 @@ snapshots:
   object-assign@4.1.1: {}
 
   object-hash@3.0.0: {}
+
+  ocache@0.1.5:
+    dependencies:
+      ohash: 2.0.11
+
+  ofetch@2.0.0-alpha.3: {}
+
+  ohash@2.0.11: {}
 
   onetime@5.1.2:
     dependencies:
@@ -5291,6 +5880,26 @@ snapshots:
 
   reusify@1.1.0: {}
 
+  rolldown@1.2.2:
+    dependencies:
+      '@oxc-project/types': 0.142.0
+      '@rolldown/pluginutils': 1.0.1
+    optionalDependencies:
+      '@rolldown/binding-android-arm64': 1.2.2
+      '@rolldown/binding-darwin-arm64': 1.2.2
+      '@rolldown/binding-darwin-x64': 1.2.2
+      '@rolldown/binding-freebsd-x64': 1.2.2
+      '@rolldown/binding-linux-arm-gnueabihf': 1.2.2
+      '@rolldown/binding-linux-arm64-gnu': 1.2.2
+      '@rolldown/binding-linux-arm64-musl': 1.2.2
+      '@rolldown/binding-linux-ppc64-gnu': 1.2.2
+      '@rolldown/binding-linux-s390x-gnu': 1.2.2
+      '@rolldown/binding-linux-x64-gnu': 1.2.2
+      '@rolldown/binding-linux-x64-musl': 1.2.2
+      '@rolldown/binding-openharmony-arm64': 1.2.2
+      '@rolldown/binding-win32-arm64-msvc': 1.2.2
+      '@rolldown/binding-win32-x64-msvc': 1.2.2
+
   rollup@4.60.3:
     dependencies:
       '@types/estree': 1.0.8
@@ -5321,6 +5930,8 @@ snapshots:
       '@rollup/rollup-win32-x64-gnu': 4.60.3
       '@rollup/rollup-win32-x64-msvc': 4.60.3
       fsevents: 2.3.3
+
+  rou3@0.8.1: {}
 
   run-parallel@1.2.0:
     dependencies:
@@ -5417,6 +6028,8 @@ snapshots:
       signal-exit: 4.1.0
 
   sprintf-js@1.0.3: {}
+
+  srvx@0.11.22: {}
 
   stackback@0.0.2: {}
 
@@ -5550,6 +6163,14 @@ snapshots:
 
   undici@6.27.0: {}
 
+  undici@7.29.0: {}
+
+  undici@8.9.0: {}
+
+  unenv@2.0.0-rc.24:
+    dependencies:
+      pathe: 2.0.3
+
   unified@11.0.5:
     dependencies:
       '@types/unist': 3.0.3
@@ -5588,6 +6209,12 @@ snapshots:
       unist-util-visit-parents: 6.0.2
 
   universalify@0.1.2: {}
+
+  unstorage@2.0.0-alpha.7(@vercel/blob@2.6.1)(db0@0.3.4)(ofetch@2.0.0-alpha.3):
+    optionalDependencies:
+      '@vercel/blob': 2.6.1
+      db0: 0.3.4
+      ofetch: 2.0.0-alpha.3
 
   update-browserslist-db@1.2.3(browserslist@4.28.5):
     dependencies:


### PR DESCRIPTION
## What

Adds the eve-based driver for `apps/agent-evals` (Layer 2, stacked on #248):

- `agent/agent.ts` — a neutral coding agent, eve's default tools only, model from `VGPU_EVALS_MODEL`.
- `agent/instructions.md` — strictly neutral; zero vgpu vocabulary (that neutrality is load-bearing for every discoverability metric).
- `agent/sandbox/` — the single backend selector (`VGPU_EVALS_SANDBOX=docker|vercel`, throws on anything else, never `defaultBackend()`) plus a bootstrap gated on `vgpu doctor` reporting `healthy`.
- `agent/hooks/export-workspace.ts` — out-of-band workspace export (see below).
- `evals/h0-harness-export.eval.ts` — infra self-test for the export.
- `evals/s1-clear-color.eval.ts` — drives the agent through PR1's task and grades it with **PR1's verifier**, never trusting the agent's PNG or its reply.

`eve` is pinned exact: **`eve@0.29.5`** (peer-compatible `ai@^7.0.38`, `zod@^4.1.8`, taken from `eve@0.29.5`'s own `peerDependencies` / `ai@7`'s zod range, not guessed).

## ⚠️ Deviation from the plan: the export is a hook, not a channel

The plan specified `agent/channels/harness.ts` with a `GET /export` route calling `ctx.getSandbox()`, and flagged that call as the one unverified API in the design. **It does not exist.** A channel route handler's second argument is `RouteHandlerArgs`:

```ts
interface RouteHandlerArgs<TState = undefined> {
  send; resolveActiveSession; cancel; reset; getSession; receive; params; waitUntil; requestIp;
}
```

No `getSandbox()`. Verified in both the local eve checkout (`0.29.2`, `src/channel/routes.ts`) and the pinned registry build (`0.29.5`, `dist/src/channel/routes.d.ts`).

`getSandbox(): Promise<SandboxSession>` lives on `SessionContext` (`dist/src/public/definitions/callback-context.d.ts`), which **`HookContext` extends** — so an authored hook is the supported way to reach the sandbox out of band. `agent/hooks/export-workspace.ts` therefore subscribes to `turn.completed`, runs `tar -cf - --exclude=./node_modules --exclude=./.git -C /workspace . | base64 -w0` through `sandbox.run()`, and writes the bytes to `.work/snapshots/<sessionId>/workspace.tar` on the host.

This is explicitly **not** the retired `docker cp` fallback: it is plain shell over the backend-agnostic `sandbox.run()`, so `VGPU_EVALS_SANDBOX=vercel` keeps working unchanged and backend-swappability is preserved.

**Reviewer decision needed.** `h0` now also carries the new assumption this swap introduces: that the hook runs in the eve runtime process on the same host filesystem as the eval reading the tar (true for a local `eve eval`; false against a remotely deployed target). If you'd rather have a channel-shaped API for this, that needs an eve-side feature (sandbox access from a route handler), not a workaround here.

## Why this PR is not verified by CI in this repo

`eve` requires Node.js >= 24; this repo pins Node 22 (`.nvmrc`, root `engines`) and this PR does **not** change that — `apps/agent-evals` declares its own `engines: {"node": ">=24"}` (documentary; pnpm does not enforce nested engines). Running the evals also needs a model-gateway credential CI does not provision today.

## What I did verify locally (Node 20.20.0 host)

Everything except actually running the evals:

```
$ pnpm --filter @vgpu/agent-evals exec tsc --noEmit    # exit 0 — the eval/agent/hook code
                                                        # typechecks against real eve@0.29.5 types
$ pnpm install --frozen-lockfile   # green (one pre-existing peer warning: nitro wants jiti ^2.7.0,
                                   #  root has 1.21.7 — unrelated to correctness here)
$ pnpm -w typecheck                # exit 0
$ pnpm exec vitest run             # 228 passed | 23 skipped (251) — identical to main
$ pnpm check:filenames             # kebab-case OK
$ pnpm --filter @vgpu/agent-evals test   # PR1's 3 verifier tests still pass
$ grep -n "vgpu\|doctor\|docs\|check" agent/instructions.md   # only the "do not mention" HTML comment
```

Type-checking against the pinned eve is worth more than it sounds: it is what caught `t.sessionId` being `string | undefined` (the code now takes `sessionId`/`toolCalls` off the `EveEvalTurn` returned by `t.send()`, where `sessionId` is non-optional) and that `EveEvalContext` has no `toolCalls`.

**Not verified:** any actual eval run (`eve eval`), the bootstrap doctor gate inside a real sandbox image, and the export hook's host-filesystem assumption. That is `h0`'s job on the first credentialed Node 24 run.

## Manual verification recipe (needs Node >= 24 + Docker + a credential)

```bash
git clone https://github.com/vercel-labs/vgpu.git && cd vgpu
git checkout feat/agent-evals-eve-driver
corepack enable && pnpm install --frozen-lockfile
cd apps/agent-evals

# credentials — one OIDC token covers both the sandbox and the AI Gateway:
npx vercel link --yes --scope vercel-labs --project vgpu
npx vercel env pull                     # writes .env.local with VERCEL_OIDC_TOKEN (12 h TTL)

node --env-file .env.local ./node_modules/.bin/eve eval evals/h0-harness-export.eval.ts
node --env-file .env.local ./node_modules/.bin/eve eval evals/s1-clear-color.eval.ts
cat .work/evidence/*.json               # expect gates.renders=pass, gates.colorExact=pass
```

Run `h0` first; an `s1` result recorded while `h0` is red is meaningless.

> **Credential footgun (documented in the README too):** `vercel env pull` writes the token **wrapped in double quotes**. Extracting it with `grep`/`cut` keeps the quotes and the gateway returns `403 invalidToken`, which is indistinguishable from a permissions problem. Load the file with a real dotenv reader (`node --env-file .env.local`), never with hand-rolled shell parsing.

Without credentials the run should exit 0 with both evals reported **skipped** (that's `requireCredentials(t)`, the first statement of every `test(t)`), not failed.

## Review checklist

- [ ] `agent/instructions.md` has zero vgpu-specific vocabulary
- [ ] `agent/sandbox/backend.ts` is the sole place a `SandboxBackend` is constructed; no `defaultBackend()` anywhere
- [ ] No gate reads `t.reply` or `evidence.journey` — the only `.gate()`s in `s1` are `gates.renders` and `gates.colorExact`
- [ ] `s1-clear-color.eval.ts` imports `verifyTask` from Layer 1 rather than re-implementing it
- [ ] `requireCredentials(t)` short-circuits **before** any model/sandbox call (trace it, don't just grep)
- [ ] `revalidationKey()` is a hardcoded, manually-bumped string
- [ ] **Judgement call:** the hook-instead-of-channel swap above
- [ ] The manual recipe has been run once, with `h0` green before `s1` was attempted

## Follow-ups (out of scope)

- Concrete `vercel({...})` options once the sandbox spike lands. The spike's golden path is already documented in the README and its `dnf install -y mesa-vulkan-drivers vulkan-loader` step is already in `bootstrap` (x86_64, runtime `node22`/`node24`, doctor healthy in ~22-30 s).
- PR3: `pnpm agent-evals` with a Node preflight, docs, and a manual-dispatch-only CI workflow.
