### PR TITLE
chore(agent-evals): pnpm agent-evals command + docs + manual CI

### DIFF
--- a/.github/workflows/agent-evals.yml
+++ b/.github/workflows/agent-evals.yml
@@ -1,0 +1,36 @@
+name: Agent Evals (manual)
+
+# Manual dispatch only, on purpose. These evals need Node 24 (the rest of the
+# repo is Node 22), a model-gateway credential, and real model spend, so they
+# must never run on push/pull_request.
+on:
+  workflow_dispatch:
+    inputs:
+      model:
+        description: "Override VGPU_EVALS_MODEL (optional)"
+        required: false
+
+jobs:
+  run:
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9.15.4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm agent-evals
+        env:
+          # The Gateway needs its own key: a Vercel access token does NOT work
+          # as a Gateway bearer token, and the 12h OIDC token from
+          # `vercel env pull` is useless for a non-interactive run.
+          AI_GATEWAY_API_KEY: ${{ secrets.AGENT_EVALS_AI_GATEWAY_API_KEY }}
+          # Only used when VGPU_EVALS_SANDBOX=vercel (default is docker).
+          VERCEL_TOKEN: ${{ secrets.AGENT_EVALS_VERCEL_TOKEN }}
+          VERCEL_TEAM_ID: ${{ secrets.AGENT_EVALS_VERCEL_TEAM_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.AGENT_EVALS_VERCEL_PROJECT_ID }}
+          VGPU_EVALS_MODEL: ${{ inputs.model }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,6 +5,22 @@
 - Node.js 22 (the workspace engine is `>=22 <23`)
 - pnpm
 
+## Agent evals
+
+`apps/agent-evals/` measures how well a coding agent uses the `vgpu` package,
+driven by [`eve`](https://eve.dev/). It requires Node.js >= 24 and an AI Gateway
+credential (`AI_GATEWAY_API_KEY` or `VERCEL_OIDC_TOKEN`), independent of this
+repo's own Node 22 requirement. Run it with:
+
+```bash
+pnpm agent-evals
+```
+
+The command preflights the Node version and exits with code `2` and an
+actionable message if it is too old. Without a credential the evals skip (exit
+0) rather than fail. See `apps/agent-evals/README.md` for details, the
+credential recipe and current limitations.
+
 ## Making changes
 
 If your PR changes published package behavior, add a changeset before opening it:

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "bundle-check": "node scripts/check-bundle-size.mjs --experiences",
     "check-bundle-size": "node scripts/check-bundle-size.mjs --experiences",
     "check:filenames": "bash scripts/check-filenames.sh",
+    "agent-evals": "node scripts/agent-evals.mjs",
     "bump:patch": "pnpm -r exec npm version patch --no-git-tag-version",
     "bump:minor": "pnpm -r exec npm version minor --no-git-tag-version",
     "bump:major": "pnpm -r exec npm version major --no-git-tag-version"

--- a/scripts/agent-evals.mjs
+++ b/scripts/agent-evals.mjs
@@ -1,0 +1,58 @@
+#!/usr/bin/env node
+// Entry point for `pnpm agent-evals`.
+//
+// Dependency-free on purpose (only node: builtins): its entire job is to run
+// correctly *before* anything workspace-specific is guaranteed to be installed
+// for the current Node version.
+//
+// `apps/agent-evals` is driven by `eve`, which requires Node.js >= 24, while
+// this repo itself pins Node 22 (.nvmrc, root engines). Without this preflight
+// the failure surfaces as an opaque syntax/engine error from deep inside eve's
+// bin; with it you get one actionable line.
+import { spawn } from "node:child_process";
+import process from "node:process";
+
+const REQUIRED_MAJOR = 24;
+// Exit 2, not 1, so CI logs and scripts can tell "wrong Node" apart from
+// "the evals ran and failed" (which `eve eval` reports as exit 1).
+const EXIT_WRONG_NODE = 2;
+
+const major = Number.parseInt(process.versions.node.split(".")[0], 10);
+
+if (!Number.isInteger(major) || major < REQUIRED_MAJOR) {
+  process.stderr.write(
+    [
+      `pnpm agent-evals: Node.js >= ${REQUIRED_MAJOR} is required, but this is v${process.versions.node}.`,
+      "",
+      "  apps/agent-evals is driven by `eve`, which requires Node 24+. The rest of",
+      "  this repo pins Node 22 on purpose, so switch Node just for this command:",
+      "",
+      `      nvm install ${REQUIRED_MAJOR} && nvm use ${REQUIRED_MAJOR} && pnpm agent-evals`,
+      "",
+      "  You also need an AI Gateway credential (AI_GATEWAY_API_KEY or",
+      "  VERCEL_OIDC_TOKEN); without one the evals skip instead of failing.",
+      "  See apps/agent-evals/README.md.",
+      "",
+    ].join("\n"),
+  );
+  process.exit(EXIT_WRONG_NODE);
+}
+
+const child = spawn(
+  "pnpm",
+  ["--filter", "@vgpu/agent-evals", "exec", "eve", "eval", ...process.argv.slice(2)],
+  { stdio: "inherit" },
+);
+
+child.on("error", (error) => {
+  process.stderr.write(`pnpm agent-evals: failed to start pnpm: ${error.message}\n`);
+  process.exit(1);
+});
+
+child.on("close", (code, signal) => {
+  if (signal) {
+    process.stderr.write(`pnpm agent-evals: terminated by signal ${signal}\n`);
+    process.exit(1);
+  }
+  process.exit(code ?? 1);
+});


### PR DESCRIPTION
## What

Adds the root `pnpm agent-evals` command (`scripts/agent-evals.mjs`) with a Node-version preflight, a short `CONTRIBUTING.md` section pointing at `apps/agent-evals/`, and a `workflow_dispatch`-only GitHub Actions workflow to run the suite on demand.

Stacked on #249 (eve driver) and #248 (task + verifier).

The preflight fails fast (exit code **2**, not 1, so it is distinguishable in CI logs from an actual eval failure, which `eve eval` reports as exit 1) when run under this repo's own Node 22 instead of the Node 24 `eve` requires. It is dependency-free (`node:` builtins only) because its whole job is to run correctly *before* anything workspace-specific is guaranteed to be installed for the current Node version.

## Why manual-dispatch only, and why no credential gate on the job

The suite needs Node 24 + an AI Gateway credential this repo's CI does not provision to every job, plus real model spend. Rather than teaching `ci.yml` about a second Node version and a new secret for every PR, this workflow is entirely separate and triggers **only** via `workflow_dispatch`.

There is deliberately **no** job-level `if:` gating on secret presence: `apps/agent-evals`'s `requireCredentials()` guard (previous PR) makes a credential-less run exit 0 with the evals reported *skipped*, which is a better signal than a conditionally-skipped job — the run still shows up in Actions history either way.

## Credentials the workflow expects

- `AGENT_EVALS_AI_GATEWAY_API_KEY` → `AI_GATEWAY_API_KEY`. The Gateway needs its own key: a Vercel access token does **not** work as a Gateway bearer token, and the 12-hour OIDC token from `vercel env pull` is useless for a non-interactive scheduled run.
- `AGENT_EVALS_VERCEL_TOKEN` / `AGENT_EVALS_VERCEL_TEAM_ID` / `AGENT_EVALS_VERCEL_PROJECT_ID` → only used when `VGPU_EVALS_SANDBOX=vercel` (the default is `docker`). Harmless when unset.

Local development is different and simpler: `npx vercel link && npx vercel env pull` gives a single `VERCEL_OIDC_TOKEN` that authenticates both the sandbox and the Gateway. See `apps/agent-evals/README.md`, including the `vercel env pull` quoting footgun.

These secret **names are placeholders** — confirm them against whatever convention the org already uses before merging. `grep -rn AGENT_EVALS_ .github` shows no existing collisions.

## Verification (this host, Node 20.20.0)

```
$ pnpm agent-evals; echo "exit=$?"
pnpm agent-evals: Node.js >= 24 is required, but this is v20.20.0.

  apps/agent-evals is driven by `eve`, which requires Node 24+. The rest of
  this repo pins Node 22 on purpose, so switch Node just for this command:

      nvm install 24 && nvm use 24 && pnpm agent-evals

  You also need an AI Gateway credential (AI_GATEWAY_API_KEY or
  VERCEL_OIDC_TOKEN); without one the evals skip instead of failing.
  See apps/agent-evals/README.md.
exit=2
real    0m0.276s          # fails before attempting any install/spawn

$ pnpm install --frozen-lockfile   # green
$ pnpm -w typecheck                # exit 0
$ pnpm exec vitest run             # 228 passed | 23 skipped (251) — unchanged
$ pnpm check:filenames             # kebab-case OK
$ python3 -c "...yaml.safe_load..."
ok: {'workflow_dispatch': {'inputs': {'model': {...}}}}      # no push/pull_request/schedule
$ git diff --name-only origin/main -- .github/workflows/ci.yml   # empty: ci.yml untouched
```

The actual `eve eval` happy path is **not** verified here — same Node 24 + credential constraint as the previous PR.

## Diff shape

- Root `package.json`: exactly one new script line.
- `CONTRIBUTING.md`: one new additive section, no existing text altered.
- `scripts/agent-evals.mjs`, `.github/workflows/agent-evals.yml`: new.

## Open question for the reviewer

Should the workflow's job be gated on secret presence via an `if:`, trading a slightly noisier "always runs, sometimes all-skipped" Actions history for an explicit "didn't even attempt" signal? Left as always-runs; it is a one-line change either way and a legitimate judgement call, not a correctness bug.
