### PR TITLE
fix(wgsl): make ./runtime importable from CommonJS consumers

### DIFF
--- a/.changeset/wgsl-runtime-works-from-cjs.md
+++ b/.changeset/wgsl-runtime-works-from-cjs.md
@@ -1,0 +1,5 @@
+---
+"@vgpu/wgsl": patch
+---
+
+`@vgpu/wgsl/runtime` is now reachable from CommonJS. The subpath declared only `types` and `import` conditions, so any consumer that resolved it through `require` — a plain `require("@vgpu/wgsl/runtime")`, a `.cts` file, or a `tsx`/ts-node script in a project without `"type": "module"` — failed with `ERR_PACKAGE_PATH_NOT_EXPORTED: Package subpath './runtime' is not defined by "exports"`, even though the sibling subpaths (`./loader-webpack`, `./loader-vite`, `./reflect-source`) all already exposed `require`/`default`. `./runtime` now mirrors them and points every condition at the same ESM file, which Node 22 loads through `require(esm)`: the runtime entry has no top-level await and its only ESM-specific constructs are `createRequire(import.meta.url)` calls, both of which are fine under synchronous `require(esm)`.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - run: pnpm build
-      - run: pnpm test packages/wgsl/tests/webpack-real.test.ts packages/wgsl/tests/vite-real.test.ts
+      - run: pnpm test packages/wgsl/tests/webpack-real.test.ts packages/wgsl/tests/vite-real.test.ts packages/wgsl/tests/runtime-cjs-require.test.ts
 
   docker-gpu:
     runs-on: ubuntu-latest

--- a/packages/wgsl/package.json
+++ b/packages/wgsl/package.json
@@ -35,7 +35,9 @@
     },
     "./runtime": {
       "types": "./dist/runtime/resolve-shader.d.ts",
-      "import": "./dist/runtime/resolve-shader.js"
+      "import": "./dist/runtime/resolve-shader.js",
+      "require": "./dist/runtime/resolve-shader.js",
+      "default": "./dist/runtime/resolve-shader.js"
     },
     "./loader-webpack": {
       "types": "./dist/loader-webpack/index.d.ts",

--- a/packages/wgsl/tests/runtime-cjs-require.test.ts
+++ b/packages/wgsl/tests/runtime-cjs-require.test.ts
@@ -1,0 +1,45 @@
+import { mkdir, mkdtemp, symlink, writeFile } from "node:fs/promises";
+import { createRequire } from "node:module";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+/**
+ * Regression test for https://github.com/vercel-labs/vgpu/issues/241.
+ *
+ * `@vgpu/wgsl/runtime` used to declare only `types` + `import` conditions, so any
+ * CommonJS consumer (`require("@vgpu/wgsl/runtime")`, plain `tsx`/ts-node projects
+ * without `"type": "module"`) failed with ERR_PACKAGE_PATH_NOT_EXPORTED.
+ *
+ * The root vitest config aliases `@vgpu/wgsl/runtime` straight to `src/`, which
+ * bypasses the exports map entirely, so a normal `import` test cannot catch this.
+ * This test installs the real package (real `package.json` + built `dist/`) into a
+ * temp project WITHOUT `"type": "module"` and resolves/requires the bare specifier
+ * through Node's real CJS resolver. It therefore needs `pnpm build` to have run.
+ */
+describe("@vgpu/wgsl/runtime (CommonJS consumers)", () => {
+  it("resolves and requires the bare './runtime' subpath from a CJS project", async () => {
+    const dir = await createCjsProject();
+    const requireFromProject = createRequire(join(dir, "index.cjs"));
+
+    expect(() => requireFromProject.resolve("@vgpu/wgsl/runtime")).not.toThrow();
+
+    const runtime = requireFromProject("@vgpu/wgsl/runtime");
+    expect(typeof runtime.resolveShader).toBe("function");
+  });
+});
+
+async function createCjsProject(): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), "vgsl-cjs-require-"));
+  // Deliberately no "type": "module" here: this is a CommonJS consumer.
+  await writeFile(join(dir, "package.json"), JSON.stringify({ name: "vgsl-cjs-consumer", version: "0.0.0" }, null, 2));
+  await writeFile(join(dir, "index.cjs"), 'require("@vgpu/wgsl/runtime");\n');
+  await installWorkspacePackage(dir);
+  return dir;
+}
+
+async function installWorkspacePackage(dir: string): Promise<void> {
+  const scopeDir = join(dir, "node_modules", "@vgpu");
+  await mkdir(scopeDir, { recursive: true });
+  await symlink(resolve("packages/wgsl"), join(scopeDir, "wgsl"), "dir");
+}


### PR DESCRIPTION
Fixes #241

## Diagnosis

`@vgpu/wgsl`'s `./runtime` subpath declared only `types` and `import` conditions:

```json
"./runtime": {
  "types": "./dist/runtime/resolve-shader.d.ts",
  "import": "./dist/runtime/resolve-shader.js"
}
```

With no `require` (and no `default`) condition, Node's resolver refuses the subpath outright for any CJS-flavored resolution — `require("@vgpu/wgsl/runtime")`, a `.cts` file, or the issue's `tsx` script in a project without `"type": "module"` — and reports `ERR_PACKAGE_PATH_NOT_EXPORTED`.

This is an oversight rather than a deliberate ESM-only restriction: **every sibling subpath already exposes `require`/`default`** (`./loader-webpack`, `./loader-vite`, `./reflect-source`), and they all point at the *same* ESM `.js` file. There is no dual ESM+CJS build in this repo — the package builds with a plain `tsc -b` and emits ESM only — so `./runtime` was simply missing the conditions its neighbors already had.

## Fix

`./runtime` now mirrors `./loader-webpack` exactly (same key order, all conditions pointing at the one ESM artifact):

```json
"./runtime": {
  "types": "./dist/runtime/resolve-shader.d.ts",
  "import": "./dist/runtime/resolve-shader.js",
  "require": "./dist/runtime/resolve-shader.js",
  "default": "./dist/runtime/resolve-shader.js"
}
```

### Why pointing `require` at the ESM file is safe here

Node 22 (this repo's engine floor: `"node": ">=22 <23"`) loads ESM from `require()` synchronously via `require(esm)`. That has two constraints, and the runtime graph satisfies both:

- **No top-level await** anywhere in `src/runtime/resolve-shader.ts` or its transitive imports. `require(esm)` throws `ERR_REQUIRE_ASYNC_MODULE` on a TLA graph; this graph has none.
- **`import.meta` usage is limited to `createRequire(import.meta.url)`** (`src/runtime/package-resolution.ts:149`, `src/runtime/validation.ts:10`). `import.meta` is fully populated under `require(esm)`, so both calls behave identically to the ESM path.

This is also exactly what the loader subpaths have been doing in production already.

## Evidence (before / after)

Temp project **without** `"type": "module"`, real built package symlinked into `node_modules/@vgpu/wgsl`, Node v22.14.0:

**Before**

```
$ node -e 'require("@vgpu/wgsl/runtime")'
Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: Package subpath './runtime' is not defined by "exports" in /tmp/repro-241/node_modules/@vgpu/wgsl/package.json
    at exportsNotFound (node:internal/modules/esm/resolve:314:10)
    at packageExportsResolve (node:internal/modules/esm/resolve:604:13)
    at resolveExports (node:internal/modules/cjs/loader:639:36)
    ...
  code: 'ERR_PACKAGE_PATH_NOT_EXPORTED'
}
```

**After**

```
$ node repro.js
OK typeof resolveShader = function
```

## Test strategy

New regression test `packages/wgsl/tests/runtime-cjs-require.test.ts`, modeled on the `installWorkspacePackage` pattern in `webpack-real.test.ts`: it creates a temp project **without** `"type": "module"`, symlinks the real package (real `package.json` + built `dist/`), then uses `createRequire` rooted in that project to both `.resolve()` and `require()` the bare specifier `"@vgpu/wgsl/runtime"`, asserting `resolveShader` comes back.

Going through the bare specifier is the whole point: the root `vitest.config.ts` aliases `@vgpu/wgsl/runtime` directly to `src/`, which bypasses the exports map entirely, so a plain `import` test could never have caught this. Verified red/green — with the `package.json` change reverted the new test fails with the exact `ERR_PACKAGE_PATH_NOT_EXPORTED` above; with the fix it passes.

Because it needs `dist/`, the test is wired into the CI job that runs `pnpm build` first (`wgsl-loader-bundler-tests`), alongside the webpack/vite real-bundler tests, rather than the no-build default vitest job.

## Gates run (Node 22.14.0)

| Gate | Result |
| --- | --- |
| `pnpm build` | ✅ |
| `pnpm typecheck` | ✅ |
| `pnpm exec vitest run packages/wgsl` | ✅ 43 passed / 3 skipped (344 tests) |
| `pnpm test <webpack-real, vite-real, runtime-cjs-require>` (CI job command) | ✅ 3 files / 9 tests |
| `pnpm bundle-check` | ✅ |
| `pnpm docs:verify-snippets` | ✅ `snippets=591 tsc=OK` |
| `pnpm check:filenames` | ✅ |

**Budget-neutral:** `bundle-check` measures the `import` target, which is unchanged. `@vgpu/wgsl/runtime [tooling]: 22161 B gzip / 22528 B budget (headroom 367 B)` — no re-baseline.

## Notes

No docs changes: the fix removes the ESM-only restriction rather than documenting it, so there is nothing to note (and this avoids docs-regen conflicts with other in-flight PRs). A patch changeset for `@vgpu/wgsl` is included.
