### PR TITLE
fix(wgsl): make entry-point reflection lossless under JSON serialization

### DIFF
--- a/.changeset/lossless-entry-point-reflection.md
+++ b/.changeset/lossless-entry-point-reflection.md
@@ -1,0 +1,7 @@
+---
+"@vgpu/wgsl": patch
+"@vgpu/cli": patch
+"vgpu": patch
+---
+
+Serialize entry-point reflection losslessly. `EntryPointInfo` now carries a non-enumerable `toJSON()` (returning the new exported `EntryPointInfoJSON` type), so `JSON.stringify(reflection)` keeps each entry point's `bindings`, `samplingPairs` and `inputs` instead of silently dropping them — `vgpu check` output includes the per-entry metadata its documented JSON promises. `Object.keys`/spread behaviour is unchanged, and `structuredClone` still drops those fields because it ignores `toJSON`. Consumers that build bind group layouts now throw `VGPU-REFLECT-ENTRY-METADATA-MISSING` when an entry point arrives without that metadata, instead of falling back to a silently wrong layout (widened stage visibility, `unfilterable-float` textures, or zero vertex attributes).

--- a/packages/vgpu-api/package.json
+++ b/packages/vgpu-api/package.json
@@ -105,7 +105,7 @@
     "init-only": 1024,
     "effect-only": 25600,
     "triangle-low-level": 28672,
-    "draw-recipe-box": 29696,
+    "draw-recipe-box": 30208,
     "full-root": 38912
   },
   "vgpuSceneBundleBudgetNote": "The scene barrel retains all recipe builders after the geometry redesign; direct primitive imports retain only their selected mesh, as the experience fixtures assert."

--- a/packages/vgpu-api/src/compute.ts
+++ b/packages/vgpu-api/src/compute.ts
@@ -1,7 +1,7 @@
 import type { Device } from "@vgpu/core";
 import type { ShaderSource } from "@vgpu/wgsl";
 import { reflectSource, type BindingInfo, type EntryPointInfo, type Reflection } from "@vgpu/wgsl/reflect-source";
-import { entryBindings } from "./entry-metadata.ts";
+import { entryMetadata } from "./entry-metadata.ts";
 import { createBindGroupCache, identityKey, type BindGroupCache, type BindGroupIdentityPart } from "./bind-cache.ts";
 import { createSetCore, bindGroupLayoutsForReflection, pipelineLayoutFor, type SetBag, type SetCore } from "./set-core.ts";
 import { visibilityForEntries } from "./set-layouts.ts";
@@ -71,7 +71,7 @@ export class ComputePipeline implements Compute {
       compute: { module: this.shaderModule, entryPoint: this.entryPoint, ...(constants ? { constants } : {}) },
     });
     this.setCore = createSetCore({ device, label: this.label, drawId: this.id, reflection: this.reflection, bindGroupLayouts: this.bindGroupLayouts, cache: this.cache });
-    const active = new Set(entryBindings(entry, `${this.label}.compute`).map((binding) => `${binding.group}:${binding.binding}`));
+    const active = new Set(entryMetadata(entry, "bindings", this.label).map((binding) => `${binding.group}:${binding.binding}`));
     this.#storageBindings = this.reflection.bindings.filter((binding) => binding.kind === "buffer" && binding.addressSpace === "storage" && active.has(`${binding.group}:${binding.binding}`));
     if (opts.set) this.set(opts.set);
   }

--- a/packages/vgpu-api/src/compute.ts
+++ b/packages/vgpu-api/src/compute.ts
@@ -1,6 +1,7 @@
 import type { Device } from "@vgpu/core";
 import type { ShaderSource } from "@vgpu/wgsl";
 import { reflectSource, type BindingInfo, type EntryPointInfo, type Reflection } from "@vgpu/wgsl/reflect-source";
+import { entryBindings } from "./entry-metadata.ts";
 import { createBindGroupCache, identityKey, type BindGroupCache, type BindGroupIdentityPart } from "./bind-cache.ts";
 import { createSetCore, bindGroupLayoutsForReflection, pipelineLayoutFor, type SetBag, type SetCore } from "./set-core.ts";
 import { visibilityForEntries } from "./set-layouts.ts";
@@ -70,7 +71,7 @@ export class ComputePipeline implements Compute {
       compute: { module: this.shaderModule, entryPoint: this.entryPoint, ...(constants ? { constants } : {}) },
     });
     this.setCore = createSetCore({ device, label: this.label, drawId: this.id, reflection: this.reflection, bindGroupLayouts: this.bindGroupLayouts, cache: this.cache });
-    const active = new Set((entry.bindings ?? this.reflection.bindings).map((binding) => `${binding.group}:${binding.binding}`));
+    const active = new Set(entryBindings(entry, `${this.label}.compute`).map((binding) => `${binding.group}:${binding.binding}`));
     this.#storageBindings = this.reflection.bindings.filter((binding) => binding.kind === "buffer" && binding.addressSpace === "storage" && active.has(`${binding.group}:${binding.binding}`));
     if (opts.set) this.set(opts.set);
   }

--- a/packages/vgpu-api/src/draw.ts
+++ b/packages/vgpu-api/src/draw.ts
@@ -2,6 +2,7 @@ import type { Device } from "@vgpu/core";
 import type { ShaderSource } from "@vgpu/wgsl";
 import { reflectSource, type BindingInfo, type EntryPointInfo, type Reflection } from "@vgpu/wgsl/reflect-source";
 import { createBindGroupCache, type BindGroupCache } from "./bind-cache.ts";
+import { entryInputs } from "./entry-metadata.ts";
 import { claimedGroupValidationDone, discardClaimedGroupValidationResults, discardClaimedGroupValidationScopes, discardLastClaimedGroupValidationScope, popLastClaimedGroupValidationScope, preferClaimedGroupValidationResult, pushClaimedGroupValidationScope, submittedWorkDone, type ClaimedGroupValidationContext, type ClaimedGroupValidationResult, type ValidationErrorSink } from "./claim-validation.ts";
 import { endRenderPassWithClaimValidation } from "./claim-validation-encode.ts";
 import { createSetCore, type BindingIdentityChange, type BindingState, type SetBag, type SetCore } from "./set-core.ts";
@@ -294,7 +295,7 @@ export class InternalDraw implements Draw {
     const visibility = visibilityForEntries(reflection.bindings, selectedEntries);
     validateStorageStageLimits(device, this.label, reflection.bindings, selectedEntries, visibility);
     const geometry = opts.geometry as (GeometryLike & Partial<GeometryLayoutResolvable>) | undefined;
-    const inputs = vertexEntry?.inputs ?? [];
+    const inputs = vertexEntry ? entryInputs(vertexEntry, `${this.label}.draw`) : [];
     const vertexBufferLayouts = geometry && geometryLayoutResolver in geometry ? geometry[geometryLayoutResolver]!(inputs, `${this.label}.geometry`) : geometry?.vertexBufferLayouts;
     const bindGroupLayouts = new Map(bindGroupLayoutsForReflection(device, this.label, reflection, visibility));
     const pipelineLayout = pipelineLayouts.get(bindGroupLayouts);

--- a/packages/vgpu-api/src/draw.ts
+++ b/packages/vgpu-api/src/draw.ts
@@ -2,7 +2,7 @@ import type { Device } from "@vgpu/core";
 import type { ShaderSource } from "@vgpu/wgsl";
 import { reflectSource, type BindingInfo, type EntryPointInfo, type Reflection } from "@vgpu/wgsl/reflect-source";
 import { createBindGroupCache, type BindGroupCache } from "./bind-cache.ts";
-import { entryInputs } from "./entry-metadata.ts";
+import { entryMetadata } from "./entry-metadata.ts";
 import { claimedGroupValidationDone, discardClaimedGroupValidationResults, discardClaimedGroupValidationScopes, discardLastClaimedGroupValidationScope, popLastClaimedGroupValidationScope, preferClaimedGroupValidationResult, pushClaimedGroupValidationScope, submittedWorkDone, type ClaimedGroupValidationContext, type ClaimedGroupValidationResult, type ValidationErrorSink } from "./claim-validation.ts";
 import { endRenderPassWithClaimValidation } from "./claim-validation-encode.ts";
 import { createSetCore, type BindingIdentityChange, type BindingState, type SetBag, type SetCore } from "./set-core.ts";
@@ -295,7 +295,7 @@ export class InternalDraw implements Draw {
     const visibility = visibilityForEntries(reflection.bindings, selectedEntries);
     validateStorageStageLimits(device, this.label, reflection.bindings, selectedEntries, visibility);
     const geometry = opts.geometry as (GeometryLike & Partial<GeometryLayoutResolvable>) | undefined;
-    const inputs = vertexEntry ? entryInputs(vertexEntry, `${this.label}.draw`) : [];
+    const inputs = vertexEntry ? entryMetadata(vertexEntry, "inputs", this.label) : [];
     const vertexBufferLayouts = geometry && geometryLayoutResolver in geometry ? geometry[geometryLayoutResolver]!(inputs, `${this.label}.geometry`) : geometry?.vertexBufferLayouts;
     const bindGroupLayouts = new Map(bindGroupLayoutsForReflection(device, this.label, reflection, visibility));
     const pipelineLayout = pipelineLayouts.get(bindGroupLayouts);

--- a/packages/vgpu-api/src/entry-metadata.ts
+++ b/packages/vgpu-api/src/entry-metadata.ts
@@ -1,0 +1,26 @@
+import type { EntryPointInfo } from "@vgpu/wgsl/reflect-source";
+import { entryMetadataMissingError } from "./errors.ts";
+
+/**
+ * Required accessors for the per-entry reflection metadata that drives bind group layouts.
+ *
+ * `bindings`, `samplingPairs` and `inputs` are optional on the type (a compute entry has no
+ * `inputs`) but reflection always attaches the two resource fields, and always attaches `inputs` to
+ * a vertex entry. Absence therefore means the reflection was hand-built or lost its non-enumerable
+ * metadata on the way here — the pre-#252 failure mode, where a `??` fallback silently widened
+ * visibility, dropped texture filterability or produced zero vertex attributes. These throw instead.
+ */
+export function entryBindings(entry: EntryPointInfo, where: string): NonNullable<EntryPointInfo["bindings"]> {
+  if (!entry.bindings) throw entryMetadataMissingError(where, entry.name, "bindings");
+  return entry.bindings;
+}
+
+export function entrySamplingPairs(entry: EntryPointInfo, where: string): NonNullable<EntryPointInfo["samplingPairs"]> {
+  if (!entry.samplingPairs) throw entryMetadataMissingError(where, entry.name, "samplingPairs");
+  return entry.samplingPairs;
+}
+
+export function entryInputs(entry: EntryPointInfo, where: string): NonNullable<EntryPointInfo["inputs"]> {
+  if (!entry.inputs) throw entryMetadataMissingError(where, entry.name, "inputs");
+  return entry.inputs;
+}

--- a/packages/vgpu-api/src/entry-metadata.ts
+++ b/packages/vgpu-api/src/entry-metadata.ts
@@ -1,26 +1,27 @@
 import type { EntryPointInfo } from "@vgpu/wgsl/reflect-source";
-import { entryMetadataMissingError } from "./errors.ts";
+import { VGPUError } from "./errors.ts";
 
 /**
- * Required accessors for the per-entry reflection metadata that drives bind group layouts.
+ * Required accessor for the per-entry reflection metadata that drives bind group layouts.
  *
  * `bindings`, `samplingPairs` and `inputs` are optional on the type (a compute entry has no
  * `inputs`) but reflection always attaches the two resource fields, and always attaches `inputs` to
  * a vertex entry. Absence therefore means the reflection was hand-built or lost its non-enumerable
  * metadata on the way here — the pre-#252 failure mode, where a `??` fallback silently widened
- * visibility, dropped texture filterability or produced zero vertex attributes. These throw instead.
+ * visibility, dropped texture filterability or produced zero vertex attributes. This throws instead.
+ *
+ * One generic accessor, throwing inline rather than through an errors.ts factory: this ships in
+ * the client bundle, which is budgeted (`pnpm bundle-check`).
  */
-export function entryBindings(entry: EntryPointInfo, where: string): NonNullable<EntryPointInfo["bindings"]> {
-  if (!entry.bindings) throw entryMetadataMissingError(where, entry.name, "bindings");
-  return entry.bindings;
-}
-
-export function entrySamplingPairs(entry: EntryPointInfo, where: string): NonNullable<EntryPointInfo["samplingPairs"]> {
-  if (!entry.samplingPairs) throw entryMetadataMissingError(where, entry.name, "samplingPairs");
-  return entry.samplingPairs;
-}
-
-export function entryInputs(entry: EntryPointInfo, where: string): NonNullable<EntryPointInfo["inputs"]> {
-  if (!entry.inputs) throw entryMetadataMissingError(where, entry.name, "inputs");
-  return entry.inputs;
+export function entryMetadata<K extends "bindings" | "samplingPairs" | "inputs">(entry: EntryPointInfo, field: K, where: string): NonNullable<EntryPointInfo[K]> {
+  const value = entry[field];
+  if (!value) {
+    throw new VGPUError({
+      code: "VGPU-REFLECT-ENTRY-METADATA-MISSING",
+      message: `Entry point '${entry.name}' has no reflected ${field}.`,
+      fix: "Pass the reflection from reflectSource()/resolveShader().",
+      where,
+    });
+  }
+  return value as NonNullable<EntryPointInfo[K]>;
 }

--- a/packages/vgpu-api/src/errors.ts
+++ b/packages/vgpu-api/src/errors.ts
@@ -18,22 +18,6 @@ export function storageStageLimitError(label: string, stage: "vertex" | "fragmen
   });
 }
 
-/**
- * An entry point reached a layout/binding consumer without the reflection metadata that describes
- * which resources its stage uses. Every fallback here used to be a silent `??`, which produced a
- * subtly wrong GPUBindGroupLayout (widened visibility, lost filterability, zero vertex attributes)
- * and failed much later inside WebGPU validation — or not at all. Failing here names the cause.
- */
-export function entryMetadataMissingError(where: string, entryPoint: string, field: "bindings" | "samplingPairs" | "inputs"): VGPUError {
-  return new VGPUError({
-    code: "VGPU-REFLECT-ENTRY-METADATA-MISSING",
-    message: `Entry point '${entryPoint}' carries no reflected ${field}; the bind group layout for '${where}' would be wrong.`,
-    fix: "Pass the reflection from reflectSource()/resolveShader() — JSON round-trips preserve it via EntryPointInfo.toJSON(). Hand-built or field-stripped entry points are not supported.",
-    where,
-    detail: { entryPoint },
-  });
-}
-
 export function textureFilterabilityError(label: string, binding: BindingInfo, format: string, resourceName: string, sampler?: BindingInfo): VGPUError {
   return new VGPUError({
     code: "VGPU-SET-TEXTURE-FILTERABILITY",

--- a/packages/vgpu-api/src/errors.ts
+++ b/packages/vgpu-api/src/errors.ts
@@ -18,6 +18,22 @@ export function storageStageLimitError(label: string, stage: "vertex" | "fragmen
   });
 }
 
+/**
+ * An entry point reached a layout/binding consumer without the reflection metadata that describes
+ * which resources its stage uses. Every fallback here used to be a silent `??`, which produced a
+ * subtly wrong GPUBindGroupLayout (widened visibility, lost filterability, zero vertex attributes)
+ * and failed much later inside WebGPU validation — or not at all. Failing here names the cause.
+ */
+export function entryMetadataMissingError(where: string, entryPoint: string, field: "bindings" | "samplingPairs" | "inputs"): VGPUError {
+  return new VGPUError({
+    code: "VGPU-REFLECT-ENTRY-METADATA-MISSING",
+    message: `Entry point '${entryPoint}' carries no reflected ${field}; the bind group layout for '${where}' would be wrong.`,
+    fix: "Pass the reflection from reflectSource()/resolveShader() — JSON round-trips preserve it via EntryPointInfo.toJSON(). Hand-built or field-stripped entry points are not supported.",
+    where,
+    detail: { entryPoint },
+  });
+}
+
 export function textureFilterabilityError(label: string, binding: BindingInfo, format: string, resourceName: string, sampler?: BindingInfo): VGPUError {
   return new VGPUError({
     code: "VGPU-SET-TEXTURE-FILTERABILITY",

--- a/packages/vgpu-api/src/set-core.ts
+++ b/packages/vgpu-api/src/set-core.ts
@@ -1,7 +1,7 @@
 import { bindGroupLayoutMetadata, bindGroupMetadataFor, type Buffer, type Device, type UnsubscribeResourceDestroy } from "@vgpu/core";
 import type { BindingInfo, Reflection } from "@vgpu/wgsl/reflect-source";
 import { identityKey, type BindGroupCache, type BindGroupIdentityPart } from "./bind-cache.ts";
-import { entrySamplingPairs } from "./entry-metadata.ts";
+import { entryMetadata } from "./entry-metadata.ts";
 import { claimedGroupIncompatibleError, claimedGroupSetError, neverSetError, ownershipFlipError, unsupportedError } from "./errors.ts";
 import { bindGroupLayoutEntriesForGroup, bindGroupLayoutsForReflection, pipelineLayoutFor } from "./set-layouts.ts";
 import { isPlainObject, isPlainValue, normalizeResource } from "./set-resources.ts";
@@ -116,7 +116,7 @@ export function createSetCore(options: SetCoreOptions): SetCore {
 
   function resourceContext(binding: BindingInfo) {
     const entry = bindGroupLayoutMetadata(options.bindGroupLayouts.get(binding.group)!)?.entries.find((item) => item.binding === binding.binding);
-    const pair = options.reflection.entryPoints.flatMap((item) => entrySamplingPairs(item, `${options.label}.set`)).find((item) => item.mode === "filtering" && item.texture.group === binding.group && item.texture.binding === binding.binding);
+    const pair = options.reflection.entryPoints.flatMap((item) => entryMetadata(item, "samplingPairs", options.label)).find((item) => item.mode === "filtering" && item.texture.group === binding.group && item.texture.binding === binding.binding);
     const pairedSampler = pair && options.reflection.bindings.find((item) => item.group === pair.sampler.group && item.binding === pair.sampler.binding);
     return { sourceHint: options.label, filterableTexture: entry?.texture?.sampleType === "float", float32Filterable: options.device.features.has("float32-filterable"), pairedSampler };
   }

--- a/packages/vgpu-api/src/set-core.ts
+++ b/packages/vgpu-api/src/set-core.ts
@@ -1,6 +1,7 @@
 import { bindGroupLayoutMetadata, bindGroupMetadataFor, type Buffer, type Device, type UnsubscribeResourceDestroy } from "@vgpu/core";
 import type { BindingInfo, Reflection } from "@vgpu/wgsl/reflect-source";
 import { identityKey, type BindGroupCache, type BindGroupIdentityPart } from "./bind-cache.ts";
+import { entrySamplingPairs } from "./entry-metadata.ts";
 import { claimedGroupIncompatibleError, claimedGroupSetError, neverSetError, ownershipFlipError, unsupportedError } from "./errors.ts";
 import { bindGroupLayoutEntriesForGroup, bindGroupLayoutsForReflection, pipelineLayoutFor } from "./set-layouts.ts";
 import { isPlainObject, isPlainValue, normalizeResource } from "./set-resources.ts";
@@ -115,7 +116,7 @@ export function createSetCore(options: SetCoreOptions): SetCore {
 
   function resourceContext(binding: BindingInfo) {
     const entry = bindGroupLayoutMetadata(options.bindGroupLayouts.get(binding.group)!)?.entries.find((item) => item.binding === binding.binding);
-    const pair = options.reflection.entryPoints.flatMap((item) => item.samplingPairs ?? []).find((item) => item.mode === "filtering" && item.texture.group === binding.group && item.texture.binding === binding.binding);
+    const pair = options.reflection.entryPoints.flatMap((item) => entrySamplingPairs(item, `${options.label}.set`)).find((item) => item.mode === "filtering" && item.texture.group === binding.group && item.texture.binding === binding.binding);
     const pairedSampler = pair && options.reflection.bindings.find((item) => item.group === pair.sampler.group && item.binding === pair.sampler.binding);
     return { sourceHint: options.label, filterableTexture: entry?.texture?.sampleType === "float", float32Filterable: options.device.features.has("float32-filterable"), pairedSampler };
   }

--- a/packages/vgpu-api/src/set-layouts.ts
+++ b/packages/vgpu-api/src/set-layouts.ts
@@ -1,6 +1,6 @@
 import { attachBindGroupLayoutMetadata, type Device } from "@vgpu/core";
 import type { BindingInfo, EntryPointInfo, ReflectedBindingLayout, Reflection } from "@vgpu/wgsl/reflect-source";
-import { entryBindings, entrySamplingPairs } from "./entry-metadata.ts";
+import { entryMetadata } from "./entry-metadata.ts";
 import { unsupportedError } from "./errors.ts";
 
 /** Builds explicit WebGPU BGL entries from the frozen ReflectionFacade bindingLayout metadata. */
@@ -21,11 +21,11 @@ export function visibilityForEntries(_bindings: readonly BindingInfo[], entries:
   const filterable = new Set<string>();
   for (const entry of entries) {
     const stage = entry.stage === "vertex" ? 1 : entry.stage === "fragment" ? 2 : 4;
-    for (const binding of entryBindings(entry, "visibilityForEntries")) {
+    for (const binding of entryMetadata(entry, "bindings", "visibility")) {
       const key = `${binding.group}:${binding.binding}`;
       masks.set(key, (masks.get(key) ?? 0) | stage);
     }
-    for (const pair of entrySamplingPairs(entry, "visibilityForEntries")) if (pair.mode === "filtering") filterable.add(`${pair.texture.group}:${pair.texture.binding}`);
+    for (const pair of entryMetadata(entry, "samplingPairs", "visibility")) if (pair.mode === "filtering") filterable.add(`${pair.texture.group}:${pair.texture.binding}`);
   }
   const policy: BindingVisibilityFn = (binding) => masks.get(`${binding.group}:${binding.binding}`) ?? 0;
   Object.defineProperty(policy, "filterable", { value: filterable });

--- a/packages/vgpu-api/src/set-layouts.ts
+++ b/packages/vgpu-api/src/set-layouts.ts
@@ -1,5 +1,6 @@
 import { attachBindGroupLayoutMetadata, type Device } from "@vgpu/core";
 import type { BindingInfo, EntryPointInfo, ReflectedBindingLayout, Reflection } from "@vgpu/wgsl/reflect-source";
+import { entryBindings, entrySamplingPairs } from "./entry-metadata.ts";
 import { unsupportedError } from "./errors.ts";
 
 /** Builds explicit WebGPU BGL entries from the frozen ReflectionFacade bindingLayout metadata. */
@@ -7,16 +8,24 @@ export type BindingVisibilityFn = ((binding: BindingInfo) => GPUShaderStageFlags
 
 const bindGroupLayoutCaches = new WeakMap<GPUDevice, Map<string, GPUBindGroupLayout>>();
 
-export function visibilityForEntries(bindings: readonly BindingInfo[], entries: readonly EntryPointInfo[]): BindingVisibilityFn {
+/**
+ * Stage visibility mask (plus the filtering-texture set) for the selected entry points.
+ *
+ * Driven strictly by each entry's reflected `bindings`/`samplingPairs`: a missing field throws
+ * rather than falling back to `bindings` (which widened visibility to every declared resource) or
+ * to `[]` (which downgraded filterable textures to `unfilterable-float`). `bindings` stays in the
+ * signature as the module-wide binding list callers already hold; it is no longer a fallback.
+ */
+export function visibilityForEntries(_bindings: readonly BindingInfo[], entries: readonly EntryPointInfo[]): BindingVisibilityFn {
   const masks = new Map<string, number>();
   const filterable = new Set<string>();
   for (const entry of entries) {
     const stage = entry.stage === "vertex" ? 1 : entry.stage === "fragment" ? 2 : 4;
-    for (const binding of entry.bindings ?? bindings) {
+    for (const binding of entryBindings(entry, "visibilityForEntries")) {
       const key = `${binding.group}:${binding.binding}`;
       masks.set(key, (masks.get(key) ?? 0) | stage);
     }
-    for (const pair of entry.samplingPairs ?? []) if (pair.mode === "filtering") filterable.add(`${pair.texture.group}:${pair.texture.binding}`);
+    for (const pair of entrySamplingPairs(entry, "visibilityForEntries")) if (pair.mode === "filtering") filterable.add(`${pair.texture.group}:${pair.texture.binding}`);
   }
   const policy: BindingVisibilityFn = (binding) => masks.get(`${binding.group}:${binding.binding}`) ?? 0;
   Object.defineProperty(policy, "filterable", { value: filterable });

--- a/packages/vgpu-api/tests/reflection-serialization.test.ts
+++ b/packages/vgpu-api/tests/reflection-serialization.test.ts
@@ -37,7 +37,7 @@ test("visibilityForEntries fails loudly when an entry point has no reflected bin
   const stripped = { name: entry!.name, mangledName: entry!.mangledName, stage: entry!.stage } as EntryPointInfo;
 
   expect(() => visibilityForEntries([], [stripped])).toThrowError(VGPUError);
-  expect(() => visibilityForEntries([], [stripped])).toThrowError(/carries no reflected bindings/);
+  expect(() => visibilityForEntries([], [stripped])).toThrowError(/has no reflected bindings/);
   try {
     visibilityForEntries([], [stripped]);
   } catch (error) {
@@ -49,5 +49,5 @@ test("visibilityForEntries fails loudly when an entry point has no reflected sam
   const [entry] = reflectSource(SHADER, "issue-252.wgsl").entryPoints;
   const stripped = { name: entry!.name, mangledName: entry!.mangledName, stage: entry!.stage, bindings: entry!.bindings } as EntryPointInfo;
 
-  expect(() => visibilityForEntries([], [stripped])).toThrowError(/carries no reflected samplingPairs/);
+  expect(() => visibilityForEntries([], [stripped])).toThrowError(/has no reflected samplingPairs/);
 });

--- a/packages/vgpu-api/tests/reflection-serialization.test.ts
+++ b/packages/vgpu-api/tests/reflection-serialization.test.ts
@@ -1,0 +1,53 @@
+import { expect, test } from "vitest";
+import { reflectSource, type EntryPointInfo, type Reflection } from "@vgpu/wgsl/reflect-source";
+import { VGPUError } from "../src/errors.ts";
+import { bindGroupLayoutEntriesForGroup, visibilityForEntries } from "../src/set-layouts.ts";
+
+// #252's shader, with `params` actually used so all three bindings are live.
+const SHADER = `struct Params { time: f32, }
+@group(0) @binding(0) var<uniform> params: Params;
+@group(0) @binding(1) var tex: texture_2d<f32>;
+@group(0) @binding(2) var samp: sampler;
+
+fn sample_it(uv: vec2f) -> vec4f { return textureSample(tex, samp, uv); }
+
+@fragment fn fs_main(@location(0) uv: vec2f) -> @location(0) vec4f { return sample_it(uv) * params.time; }
+`;
+
+const roundTrip = <T>(value: T): T => JSON.parse(JSON.stringify(value)) as T;
+
+test("a JSON round-tripped reflection produces byte-identical bind group layout entries", () => {
+  const reflection = reflectSource(SHADER, "issue-252.wgsl");
+  const live = reflection.entryPoints;
+  const serialized = roundTrip(reflection) as Reflection;
+
+  const liveEntries = bindGroupLayoutEntriesForGroup(reflection.bindings, 0, visibilityForEntries(reflection.bindings, live));
+  const serializedEntries = bindGroupLayoutEntriesForGroup(serialized.bindings, 0, visibilityForEntries(serialized.bindings, serialized.entryPoints));
+
+  expect(serializedEntries).toEqual(liveEntries);
+  // The filtering pair must survive: losing it downgrades the texture to "unfilterable-float",
+  // which WebGPU then rejects when a filtering sampler is bound against this layout.
+  expect(serializedEntries.find((entry) => entry.binding === 1)?.texture?.sampleType).toBe("float");
+  // Visibility must stay fragment-only (2) rather than widening to every declared binding.
+  expect(serializedEntries.map((entry) => [entry.binding, entry.visibility])).toEqual([[0, 2], [1, 2], [2, 2]]);
+});
+
+test("visibilityForEntries fails loudly when an entry point has no reflected bindings", () => {
+  const [entry] = reflectSource(SHADER, "issue-252.wgsl").entryPoints;
+  const stripped = { name: entry!.name, mangledName: entry!.mangledName, stage: entry!.stage } as EntryPointInfo;
+
+  expect(() => visibilityForEntries([], [stripped])).toThrowError(VGPUError);
+  expect(() => visibilityForEntries([], [stripped])).toThrowError(/carries no reflected bindings/);
+  try {
+    visibilityForEntries([], [stripped]);
+  } catch (error) {
+    expect((error as VGPUError).code).toBe("VGPU-REFLECT-ENTRY-METADATA-MISSING");
+  }
+});
+
+test("visibilityForEntries fails loudly when an entry point has no reflected samplingPairs", () => {
+  const [entry] = reflectSource(SHADER, "issue-252.wgsl").entryPoints;
+  const stripped = { name: entry!.name, mangledName: entry!.mangledName, stage: entry!.stage, bindings: entry!.bindings } as EntryPointInfo;
+
+  expect(() => visibilityForEntries([], [stripped])).toThrowError(/carries no reflected samplingPairs/);
+});

--- a/packages/vgpu-api/tests/tooling/check-cli.test.ts
+++ b/packages/vgpu-api/tests/tooling/check-cli.test.ts
@@ -38,6 +38,25 @@ test("vgpu check emits reflection JSON for WGSL files", async () => {
   );
 });
 
+test("vgpu check JSON carries per-entry bindings, sampling pairs and vertex inputs", async () => {
+  const output = await runCheckSuccess(resolve(fixtureRoot, "sample.wgsl"));
+
+  // schemaVersion 1 documents "the shader's reflection data as JSON"; before #252 the per-entry
+  // metadata was non-enumerable and vanished from this payload without a trace.
+  const entryPoints = output.reflection.entryPoints as { name: string; bindings?: unknown; samplingPairs?: unknown; inputs?: unknown }[];
+  for (const entry of entryPoints) {
+    expect(entry).toHaveProperty("bindings");
+    expect(entry).toHaveProperty("samplingPairs");
+    expect(Array.isArray(entry.bindings)).toBe(true);
+  }
+
+  const vertex = entryPoints.find((entry) => entry.name === "vs_main");
+  expect(vertex?.inputs).toBeDefined();
+  expect(entryPoints.find((entry) => entry.name === "fs_main")?.bindings).toEqual(
+    expect.arrayContaining([expect.objectContaining({ group: 0, binding: 0 })]),
+  );
+});
+
 test("vgpu check surfaces Phase-1 fix-it text verbatim", async () => {
   const result = await runCheck([resolve(fixtureRoot, "bool-uniform.wgsl")]);
   expect(result.code).toBe(1);

--- a/packages/wgsl/src/runtime/reflect-source.ts
+++ b/packages/wgsl/src/runtime/reflect-source.ts
@@ -11,6 +11,7 @@ export type {
   BindingKind,
   BindingRef,
   EntryPointInfo,
+  EntryPointInfoJSON,
   EntryPointInputInfo,
   HostShareableLayout,
   LayoutMember,

--- a/packages/wgsl/src/runtime/reflect-types.ts
+++ b/packages/wgsl/src/runtime/reflect-types.ts
@@ -93,11 +93,12 @@ export interface EntryPointInfoJSON {
  * Non-enumerability must not mean *lossy*, so every entry point also carries a non-enumerable
  * {@link EntryPointInfo.toJSON} that returns the complete {@link EntryPointInfoJSON}. Consequently
  * `JSON.stringify(entry)` / `JSON.parse(JSON.stringify(reflection))` round-trip all metadata, and
- * consumers behind a serialization boundary (the `vgpu check` CLI payload, workers, RSC) see the
- * same bindings the in-process consumers see.
+ * consumers behind a JSON boundary (the `vgpu check` CLI payload, RSC) see the same bindings the
+ * in-process consumers see.
  *
- * `structuredClone` still drops the three properties — it ignores `toJSON`. Use JSON, or copy the
- * fields explicitly.
+ * `structuredClone` still drops the three properties — it ignores `toJSON` — and so does worker
+ * `postMessage`, which clones structurally. Across those boundaries, send
+ * `JSON.parse(JSON.stringify(reflection))` or copy the fields explicitly.
  */
 export interface EntryPointInfo extends EntryPointInfoJSON {
   /**

--- a/packages/wgsl/src/runtime/reflect-types.ts
+++ b/packages/wgsl/src/runtime/reflect-types.ts
@@ -63,7 +63,12 @@ export interface SamplingPair {
   readonly mode: "filtering" | "comparison";
 }
 
-export interface EntryPointInfo {
+/**
+ * Plain, fully enumerable projection of an {@link EntryPointInfo} — what `JSON.stringify` emits and
+ * what `JSON.parse` gives back. Every field an entry point carries is present here, including the
+ * three that live behind non-enumerable properties on the live object.
+ */
+export interface EntryPointInfoJSON {
   readonly name: string;
   readonly mangledName: string;
   readonly stage: "vertex" | "fragment" | "compute";
@@ -73,6 +78,33 @@ export interface EntryPointInfo {
   readonly bindings?: readonly BindingRef[];
   /** Sampler/texture pairs statically sampled by this entry point and transitive callees. */
   readonly samplingPairs?: readonly SamplingPair[];
+}
+
+/**
+ * One `@vertex`/`@fragment`/`@compute` entry point.
+ *
+ * ## Serialization contract
+ *
+ * `bindings`, `samplingPairs` and `inputs` are **non-enumerable** own properties: they are read
+ * through dot access (`entry.bindings`) but stay out of `Object.keys`, `{ ...entry }`,
+ * `Object.assign` and `toEqual`/snapshot comparisons, which keeps reflection snapshots small and
+ * stable. That is deliberate and test-locked.
+ *
+ * Non-enumerability must not mean *lossy*, so every entry point also carries a non-enumerable
+ * {@link EntryPointInfo.toJSON} that returns the complete {@link EntryPointInfoJSON}. Consequently
+ * `JSON.stringify(entry)` / `JSON.parse(JSON.stringify(reflection))` round-trip all metadata, and
+ * consumers behind a serialization boundary (the `vgpu check` CLI payload, workers, RSC) see the
+ * same bindings the in-process consumers see.
+ *
+ * `structuredClone` still drops the three properties — it ignores `toJSON`. Use JSON, or copy the
+ * fields explicitly.
+ */
+export interface EntryPointInfo extends EntryPointInfoJSON {
+  /**
+   * Lossless JSON projection, invoked automatically by `JSON.stringify`. Non-enumerable, so it
+   * never shows up in `Object.keys(entry)` or a spread of the entry point.
+   */
+  readonly toJSON?: () => EntryPointInfoJSON;
 }
 
 /** Pipeline-overridable constant (`override`) declaration. `id` is the `@id(N)` pipeline constant ID when the declaration has one; `defaultValue` is the raw initializer expression, present only when the declaration has a default. */

--- a/packages/wgsl/src/runtime/reflect.ts
+++ b/packages/wgsl/src/runtime/reflect.ts
@@ -4,7 +4,7 @@ import { parseDeclarations } from "./reflect-declarations.ts";
 import { layoutOf } from "./reflect-layout.ts";
 import { entrySamplingPairs } from "./reflect-sampling.ts";
 import { buildModuleSymbols, buildRegistry, resolveType, unwrapAlias, type ImportPathResolver } from "./reflect-symbols.ts";
-import type { Attr, BindingInfo, BindingRef, EntryPointInfo, EntryPointInputInfo, HostShareableLayout, ModuleSymbols, ParsedDecls, ParsedEntryPoint, ParsedStructMember, Reflection, Registry } from "./reflect-types.ts";
+import type { Attr, BindingInfo, BindingRef, EntryPointInfo, EntryPointInfoJSON, EntryPointInputInfo, HostShareableLayout, ModuleSymbols, ParsedDecls, ParsedEntryPoint, ParsedStructMember, Reflection, Registry } from "./reflect-types.ts";
 import { numericAttr } from "./reflect-utils.ts";
 import { analyzeWgslTokens } from "./scope-walker.ts";
 
@@ -18,6 +18,7 @@ export type {
   BindingKind,
   BindingRef,
   EntryPointInfo,
+  EntryPointInfoJSON,
   EntryPointInputInfo,
   HostShareableLayout,
   LayoutMember,
@@ -142,8 +143,22 @@ function publicEntryPoint(entry: ParsedEntryPoint, structs: readonly { readonly 
   const result: EntryPointInfo = { name: entry.name, mangledName: entry.mangledName, stage: entry.stage, workgroupSize: entry.workgroupSize };
   Object.defineProperty(result, "bindings", { value: bindings.map(({ group, binding }) => ({ group, binding })), enumerable: false, configurable: true });
   Object.defineProperty(result, "samplingPairs", { value: samplingPairs, enumerable: false, configurable: true });
-  if (entry.stage === "vertex") Object.defineProperty(result, "inputs", { value: vertexInputs(entry, structs, symbols, registry), enumerable: false });
+  if (entry.stage === "vertex") Object.defineProperty(result, "inputs", { value: vertexInputs(entry, structs, symbols, registry), enumerable: false, configurable: true });
+  Object.defineProperty(result, "toJSON", { value: entryPointToJSON, enumerable: false, configurable: true });
   return result;
+}
+
+/**
+ * `JSON.stringify` hook that keeps entry-point reflection lossless across serialization boundaries.
+ *
+ * `bindings`, `samplingPairs` and `inputs` are non-enumerable on purpose (snapshot ergonomics), which
+ * otherwise makes `JSON.stringify` — and therefore the `vgpu check` payload, workers and any other
+ * structural consumer — silently drop them. Reading through `this` rather than a closure keeps the
+ * projection correct after `resolveShader()` re-defines the properties with whole-program values.
+ */
+function entryPointToJSON(this: EntryPointInfo): EntryPointInfoJSON {
+  const enumerable = { ...this } as Omit<EntryPointInfo, "toJSON">;
+  return { ...enumerable, bindings: this.bindings, samplingPairs: this.samplingPairs, ...(this.inputs ? { inputs: this.inputs } : {}) };
 }
 
 function vertexInputs(entry: ParsedEntryPoint, structs: readonly { readonly path: string; readonly mangledName: string; readonly members: readonly ParsedStructMember[] }[], symbols: ReadonlyMap<string, ModuleSymbols>, registry: Registry): readonly EntryPointInputInfo[] {

--- a/packages/wgsl/src/runtime/resolve-shader.ts
+++ b/packages/wgsl/src/runtime/resolve-shader.ts
@@ -17,7 +17,7 @@ import { scan } from "./scanner.ts";
 import { validateWGSL } from "./validation.ts";
 
 export { reflectSource } from "./reflect-source.ts";
-export type { BindingInfo, BindingKind, BindingRef, EntryPointInfo, EntryPointInputInfo, HostShareableLayout, LayoutMember, ReflectedBindingLayout, Reflection, ReflectionFacade, SamplingPair, WGSLType } from "./reflect.ts";
+export type { BindingInfo, BindingKind, BindingRef, EntryPointInfo, EntryPointInfoJSON, EntryPointInputInfo, HostShareableLayout, LayoutMember, ReflectedBindingLayout, Reflection, ReflectionFacade, SamplingPair, WGSLType } from "./reflect.ts";
 export type { MinifyOption, MinifyOptions, NormalizedMinifyOptions } from "./minify.ts";
 export type { ShaderSource } from "../types.ts";
 export interface ResolveOptions {
@@ -58,8 +58,8 @@ export async function resolveShader(opts: ResolveOptions): Promise<ResolvedShade
   const emittedReflection = reflectSource(emittedWgsl, entry);
   for (const reflectedEntry of reflection.entryPoints) {
     const emittedEntry = emittedReflection.entryPoints.find((item) => item.name === reflectedEntry.mangledName);
-    if (emittedEntry?.bindings) Object.defineProperty(reflectedEntry, "bindings", { value: emittedEntry.bindings, enumerable: false });
-    if (emittedEntry?.samplingPairs) Object.defineProperty(reflectedEntry, "samplingPairs", { value: emittedEntry.samplingPairs, enumerable: false });
+    if (emittedEntry?.bindings) Object.defineProperty(reflectedEntry, "bindings", { value: emittedEntry.bindings, enumerable: false, configurable: true });
+    if (emittedEntry?.samplingPairs) Object.defineProperty(reflectedEntry, "samplingPairs", { value: emittedEntry.samplingPairs, enumerable: false, configurable: true });
   }
   const map = sourceMap(modules);
   const minify = normalizeMinifyOption(opts.minify);

--- a/packages/wgsl/tests/reflect-entry-inputs.test.ts
+++ b/packages/wgsl/tests/reflect-entry-inputs.test.ts
@@ -79,7 +79,10 @@ test("vertex inputs remain snapshot-safe by staying non-enumerable", () => {
 
   expect(entry.inputs?.[0]?.name).toBe("position");
   expect(Object.keys(entry)).toEqual(["name", "mangledName", "stage", "workgroupSize"]);
-  expect(JSON.stringify(entry)).not.toContain("inputs");
+  expect(Object.keys({ ...entry })).not.toContain("inputs");
+  // Non-enumerable is about snapshot/spread ergonomics, not about losing data: `toJSON` keeps
+  // serialization lossless (#252).
+  expect(JSON.stringify(entry)).toContain("inputs");
 });
 
 test("non-vertex entry points do not expose inputs", () => {

--- a/packages/wgsl/tests/reflect-entry-serialization.test.ts
+++ b/packages/wgsl/tests/reflect-entry-serialization.test.ts
@@ -1,0 +1,98 @@
+import { expect, test } from "vitest";
+import { reflectSource, resolveShader } from "@vgpu/wgsl/runtime";
+
+// The shader from issue #252, verbatim. Note `params` is declared but never referenced, so a
+// correct implementation reports only the texture/sampler pair for `fs_main` — the helper-call
+// tracing itself was never broken; the metadata was only invisible to structural consumers.
+const ISSUE_252 = `struct Params { time: f32, }
+@group(0) @binding(0) var<uniform> params: Params;
+@group(0) @binding(1) var tex: texture_2d<f32>;
+@group(0) @binding(2) var samp: sampler;
+
+fn sample_it(uv: vec2f) -> vec4f {
+  return textureSample(tex, samp, uv);
+}
+
+@fragment
+fn fs_main(@location(0) uv: vec2f) -> @location(0) vec4f {
+  return sample_it(uv);
+}
+`;
+
+test("issue #252: entry-point bindings used through a helper survive JSON.stringify", async () => {
+  const { reflection } = await resolveShader({ entry: "/issue-252.wgsl", modules: { "/issue-252.wgsl": ISSUE_252 }, minify: false, validate: false });
+  const live = reflection.entryPoints[0]!;
+
+  // Transitive tracing was always correct; `params` is unused so it is legitimately absent.
+  expect(live.bindings).toEqual([{ group: 0, binding: 1 }, { group: 0, binding: 2 }]);
+
+  const json = JSON.stringify(reflection.entryPoints);
+  expect(json).toContain("bindings");
+  expect(json).toContain("samplingPairs");
+
+  const [roundTripped] = JSON.parse(json) as { bindings?: unknown; samplingPairs?: unknown; name?: string }[];
+  expect(roundTripped?.name).toBe("fs_main");
+  expect(roundTripped?.bindings).toEqual(live.bindings);
+  expect(roundTripped?.samplingPairs).toEqual([{ texture: { group: 0, binding: 1 }, sampler: { group: 0, binding: 2 }, mode: "filtering" }]);
+});
+
+test("vertex inputs, bindings and sampling pairs all round-trip through JSON", () => {
+  const reflection = reflectSource(`
+    @group(0) @binding(0) var<uniform> view: vec4f;
+    @group(0) @binding(1) var tex: texture_2d<f32>;
+    @group(0) @binding(2) var samp: sampler;
+    @vertex fn vs(@location(0) position: vec2f) -> @builtin(position) vec4f { return vec4f(position, 0.0, 1.0) + view; }
+    @fragment fn fs(@location(0) uv: vec2f) -> @location(0) vec4f { return textureSample(tex, samp, uv); }
+  `);
+
+  const roundTripped = JSON.parse(JSON.stringify(reflection.entryPoints)) as typeof reflection.entryPoints;
+  for (const [index, entry] of reflection.entryPoints.entries()) {
+    expect(roundTripped[index]?.bindings).toEqual(entry.bindings);
+    expect(roundTripped[index]?.samplingPairs).toEqual(entry.samplingPairs);
+    expect(roundTripped[index]?.inputs).toEqual(entry.inputs);
+  }
+  expect(roundTripped[0]?.inputs).toEqual([{ name: "position", location: 0, type: { kind: "vector", width: 2, element: { kind: "scalar", name: "f32" } } }]);
+  expect(roundTripped[1]?.inputs).toBeUndefined();
+});
+
+test("lossless serialization keeps the whole-program bindings resolveShader re-attaches", async () => {
+  const { reflection } = await resolveShader({
+    entry: "/main.wgsl",
+    minify: false,
+    validate: false,
+    modules: {
+      "/helper.wgsl": `export fn sample_it(t: texture_2d<f32>, s: sampler, uv: vec2f) -> vec4f { return textureSample(t, s, uv); }`,
+      "/main.wgsl": `import { sample_it } from "./helper.wgsl";
+struct Params { time: f32, }
+@group(0) @binding(0) var<uniform> params: Params;
+@group(0) @binding(1) var tex: texture_2d<f32>;
+@group(0) @binding(2) var samp: sampler;
+@fragment fn fs_main(@location(0) uv: vec2f) -> @location(0) vec4f { return sample_it(tex, samp, uv) * params.time; }`,
+    },
+  });
+  const live = reflection.entryPoints[0]!;
+  expect(live.bindings).toEqual([{ group: 0, binding: 0 }, { group: 0, binding: 1 }, { group: 0, binding: 2 }]);
+
+  const roundTripped = JSON.parse(JSON.stringify(reflection.entryPoints))[0] as typeof live;
+  expect(roundTripped.bindings).toEqual(live.bindings);
+  expect(roundTripped.samplingPairs).toEqual(live.samplingPairs);
+});
+
+test("toJSON is non-enumerable and does not widen Object.keys or spreads", () => {
+  const entry = reflectSource(`
+    @group(0) @binding(0) var<uniform> view: vec4f;
+    @vertex fn vs(@location(0) position: vec2f) -> @builtin(position) vec4f { return vec4f(position, 0.0, 1.0) + view; }
+  `).entryPoints[0]!;
+
+  expect(typeof entry.toJSON).toBe("function");
+  expect(Object.keys(entry)).toEqual(["name", "mangledName", "stage", "workgroupSize"]);
+  expect(Object.keys({ ...entry })).toEqual(["name", "mangledName", "stage", "workgroupSize"]);
+  expect(JSON.stringify({ nested: entry })).toContain("bindings");
+});
+
+test("entry-point properties stay configurable so later reflection passes can re-define them", () => {
+  const entry = reflectSource("@compute @workgroup_size(1) fn main() {}").entryPoints[0]!;
+  for (const key of ["bindings", "samplingPairs", "toJSON"]) {
+    expect(Object.getOwnPropertyDescriptor(entry, key)).toMatchObject({ enumerable: false, configurable: true });
+  }
+});


### PR DESCRIPTION
## Summary

Fixes #252.

The issue reports that `resolveShader(...).reflection.entryPoints[].bindings` omits resources used only inside helper functions called by an entry point. Investigation showed the transitive call-graph walk in `entryBindingUses()` is **correct** — `bindings` for the issue's repro shader is computed completely (including `tex`/`samp` used only inside `sample_it()`).

The actual bug: `publicEntryPoint()` defines `bindings`, `samplingPairs`, and `inputs` as **non-enumerable** properties, so `JSON.stringify`, object spread, and `structuredClone` silently drop them. That is exactly why the reporter's `JSON.stringify(resolved.reflection.entryPoints)` shows no `bindings` field, and why downstream consumers that cross any serialization boundary reconstruct a wrong `GPUBindGroupLayout` (e.g. `sampleType` degrading from `"float"` to `"unfilterable-float"`, failing at `CreateBindGroup`).

Verified drop sites:
- `vgpu check` CLI: the documented `schemaVersion: 1` JSON payload silently lacked per-entry `bindings`/`samplingPairs`/`inputs`.
- Five silent `??` fallbacks in `vgpu-api` (`set-layouts.ts` ×2, `set-core.ts`, `compute.ts`, `draw.ts`) that quietly widened or degraded layouts when the metadata was missing instead of failing loudly.

## Fix

- **`@vgpu/wgsl`**: entry points now carry a non-enumerable, configurable `toJSON()` (new exported `EntryPointInfoJSON` type), making JSON serialization lossless while keeping `Object.keys`/spread/snapshot behavior unchanged (deliberate, test-locked design). Also made the property re-definitions in `resolve-shader.ts` `configurable: true` (previously a second `defineProperty` would throw).
  - Note: `structuredClone`/worker `postMessage` still drop the fields (structured clone ignores `toJSON`); the TSDoc now documents this boundary and the workaround.
- **`vgpu` (api)**: new `entry-metadata.ts` helpers make the five fallback sites fail loudly with error code `VGPU-REFLECT-ENTRY-METADATA-MISSING` instead of emitting a silently-wrong layout. A missing vertex entry remains legal; a vertex entry without `inputs` throws.
- **Changeset**: patch bumps for `@vgpu/wgsl`, `vgpu`, `@vgpu/cli`.

## Tests

- 9 new regression tests (verified red without the fix, green with it):
  - `packages/wgsl/tests/reflect-entry-serialization.test.ts` — issue's exact repro shader: `JSON.stringify(entryPoints)` carries `bindings` + `samplingPairs` (note: `params` is legitimately excluded — the repro shader never uses it).
  - `packages/vgpu-api/tests/reflection-serialization.test.ts` — JSON round-tripped reflection produces byte-identical bind group layout entries vs the direct path.
  - `check-cli.test.ts` — the CLI JSON contract now locks per-entry bindings.
  - Loud-failure tests for the hardened fallback sites.
- One inverted assertion (`reflect-entry-inputs.test.ts`): `JSON.stringify(entry)` now includes `inputs`; the non-enumerability assertions (`Object.keys`, spread) remain.
- Full suite: `npx vitest run` → 1708 passed, 0 failed. `tsc -b` clean.
- Independently reviewed and verified by a separate audit pass, including an end-to-end run of the shipped `vgpu check` binary and adversarial cases (double `resolveShader`, `structuredClone` safety, cross-module imports, minified round-trips).
