### PR TITLE
refactor(wgsl): make EntryPointInfo plain data

### DIFF
--- a/.changeset/lossless-entry-point-reflection.md
+++ b/.changeset/lossless-entry-point-reflection.md
@@ -1,7 +1,0 @@
----
-"@vgpu/wgsl": patch
-"@vgpu/cli": patch
-"vgpu": patch
----
-
-Serialize entry-point reflection losslessly. `EntryPointInfo` now carries a non-enumerable `toJSON()` (returning the new exported `EntryPointInfoJSON` type), so `JSON.stringify(reflection)` keeps each entry point's `bindings`, `samplingPairs` and `inputs` instead of silently dropping them — `vgpu check` output includes the per-entry metadata its documented JSON promises. `Object.keys`/spread behaviour is unchanged, and `structuredClone` still drops those fields because it ignores `toJSON`. Consumers that build bind group layouts now throw `VGPU-REFLECT-ENTRY-METADATA-MISSING` when an entry point arrives without that metadata, instead of falling back to a silently wrong layout (widened stage visibility, `unfilterable-float` textures, or zero vertex attributes).

--- a/.changeset/plain-entry-point-reflection.md
+++ b/.changeset/plain-entry-point-reflection.md
@@ -1,0 +1,11 @@
+---
+"@vgpu/wgsl": minor
+"@vgpu/cli": minor
+"vgpu": minor
+---
+
+`EntryPointInfo` (`bindings`, `samplingPairs`, `inputs`) is now plain data: every field is an ordinary enumerable, own property. `JSON.stringify`, `{ ...entry }`, `Object.keys/entries/assign`, `structuredClone`, and worker `postMessage` all see the full shape — previously `bindings`, `samplingPairs` and `inputs` were non-enumerable, so they were readable through dot access but silently dropped across every serialization/structured-clone boundary (issue #252), including the `vgpu check` CLI JSON payload. The stopgap non-enumerable `toJSON()`/`EntryPointInfoJSON` this package briefly carried is removed in favor of making the underlying data itself lossless.
+
+Consumers that build bind group layouts (`vgpu`'s `set-layouts.ts`) still throw `VGPU-REFLECT-ENTRY-METADATA-MISSING` when an entry point arrives without `bindings`/`samplingPairs`/`inputs` metadata, rather than silently falling back to a wrong layout.
+
+BREAKING CHANGE (pre-1.0): code relying on `Object.keys(entryPoint)`, `{ ...entryPoint }`, or a JSON diff of an entry point *not* containing `bindings`/`samplingPairs`/`inputs` will now see those keys. This is a clean break with no deprecated alias, consistent with this package's other 0.x breaking changes.

--- a/packages/vgpu-api/src/entry-metadata.ts
+++ b/packages/vgpu-api/src/entry-metadata.ts
@@ -6,9 +6,10 @@ import { VGPUError } from "./errors.ts";
  *
  * `bindings`, `samplingPairs` and `inputs` are optional on the type (a compute entry has no
  * `inputs`) but reflection always attaches the two resource fields, and always attaches `inputs` to
- * a vertex entry. Absence therefore means the reflection was hand-built or lost its non-enumerable
- * metadata on the way here — the pre-#252 failure mode, where a `??` fallback silently widened
- * visibility, dropped texture filterability or produced zero vertex attributes. This throws instead.
+ * a vertex entry. Absence therefore means the reflection was hand-built, predates a full
+ * `resolveShader()`/`reflectSource()` pass, or was mutated after the fact — the pre-#252 failure
+ * mode, where a `??` fallback silently widened visibility, dropped texture filterability or
+ * produced zero vertex attributes. This throws instead.
  *
  * One generic accessor, throwing inline rather than through an errors.ts factory: this ships in
  * the client bundle, which is budgeted (`pnpm bundle-check`).

--- a/packages/wgsl/src/runtime/reflect-source.ts
+++ b/packages/wgsl/src/runtime/reflect-source.ts
@@ -11,7 +11,6 @@ export type {
   BindingKind,
   BindingRef,
   EntryPointInfo,
-  EntryPointInfoJSON,
   EntryPointInputInfo,
   HostShareableLayout,
   LayoutMember,

--- a/packages/wgsl/src/runtime/reflect-types.ts
+++ b/packages/wgsl/src/runtime/reflect-types.ts
@@ -64,11 +64,21 @@ export interface SamplingPair {
 }
 
 /**
- * Plain, fully enumerable projection of an {@link EntryPointInfo} — what `JSON.stringify` emits and
- * what `JSON.parse` gives back. Every field an entry point carries is present here, including the
- * three that live behind non-enumerable properties on the live object.
+ * One `@vertex`/`@fragment`/`@compute` entry point.
+ *
+ * ## Serialization contract
+ *
+ * `EntryPointInfo` is **plain data**: every field — including `bindings`, `samplingPairs` and
+ * `inputs` — is an ordinary enumerable, own, writable property. `JSON.stringify`, `{ ...entry }`,
+ * `Object.keys`/`Object.entries`/`Object.assign`, `structuredClone` and worker `postMessage` all see
+ * the complete shape, so nothing is silently dropped across a serialization or structured-clone
+ * boundary (issue #252). There is no `toJSON` hook and no hidden metadata.
+ *
+ * Tests that want a smaller or more stable projection of an entry point should say so explicitly
+ * (destructure the fields they care about, or register a custom snapshot serializer) rather than
+ * relying on the runtime object hiding fields from them.
  */
-export interface EntryPointInfoJSON {
+export interface EntryPointInfo {
   readonly name: string;
   readonly mangledName: string;
   readonly stage: "vertex" | "fragment" | "compute";
@@ -78,34 +88,6 @@ export interface EntryPointInfoJSON {
   readonly bindings?: readonly BindingRef[];
   /** Sampler/texture pairs statically sampled by this entry point and transitive callees. */
   readonly samplingPairs?: readonly SamplingPair[];
-}
-
-/**
- * One `@vertex`/`@fragment`/`@compute` entry point.
- *
- * ## Serialization contract
- *
- * `bindings`, `samplingPairs` and `inputs` are **non-enumerable** own properties: they are read
- * through dot access (`entry.bindings`) but stay out of `Object.keys`, `{ ...entry }`,
- * `Object.assign` and `toEqual`/snapshot comparisons, which keeps reflection snapshots small and
- * stable. That is deliberate and test-locked.
- *
- * Non-enumerability must not mean *lossy*, so every entry point also carries a non-enumerable
- * {@link EntryPointInfo.toJSON} that returns the complete {@link EntryPointInfoJSON}. Consequently
- * `JSON.stringify(entry)` / `JSON.parse(JSON.stringify(reflection))` round-trip all metadata, and
- * consumers behind a JSON boundary (the `vgpu check` CLI payload, RSC) see the same bindings the
- * in-process consumers see.
- *
- * `structuredClone` still drops the three properties — it ignores `toJSON` — and so does worker
- * `postMessage`, which clones structurally. Across those boundaries, send
- * `JSON.parse(JSON.stringify(reflection))` or copy the fields explicitly.
- */
-export interface EntryPointInfo extends EntryPointInfoJSON {
-  /**
-   * Lossless JSON projection, invoked automatically by `JSON.stringify`. Non-enumerable, so it
-   * never shows up in `Object.keys(entry)` or a spread of the entry point.
-   */
-  readonly toJSON?: () => EntryPointInfoJSON;
 }
 
 /** Pipeline-overridable constant (`override`) declaration. `id` is the `@id(N)` pipeline constant ID when the declaration has one; `defaultValue` is the raw initializer expression, present only when the declaration has a default. */

--- a/packages/wgsl/src/runtime/reflect.ts
+++ b/packages/wgsl/src/runtime/reflect.ts
@@ -4,7 +4,7 @@ import { parseDeclarations } from "./reflect-declarations.ts";
 import { layoutOf } from "./reflect-layout.ts";
 import { entrySamplingPairs } from "./reflect-sampling.ts";
 import { buildModuleSymbols, buildRegistry, resolveType, unwrapAlias, type ImportPathResolver } from "./reflect-symbols.ts";
-import type { Attr, BindingInfo, BindingRef, EntryPointInfo, EntryPointInfoJSON, EntryPointInputInfo, HostShareableLayout, ModuleSymbols, ParsedDecls, ParsedEntryPoint, ParsedStructMember, Reflection, Registry } from "./reflect-types.ts";
+import type { Attr, BindingInfo, BindingRef, EntryPointInfo, EntryPointInputInfo, HostShareableLayout, ModuleSymbols, ParsedDecls, ParsedEntryPoint, ParsedStructMember, Reflection, Registry } from "./reflect-types.ts";
 import { numericAttr } from "./reflect-utils.ts";
 import { analyzeWgslTokens } from "./scope-walker.ts";
 
@@ -18,7 +18,6 @@ export type {
   BindingKind,
   BindingRef,
   EntryPointInfo,
-  EntryPointInfoJSON,
   EntryPointInputInfo,
   HostShareableLayout,
   LayoutMember,
@@ -140,25 +139,19 @@ function entryBindingUses(modules: readonly MangleModule[], raw: readonly Parsed
 }
 
 function publicEntryPoint(entry: ParsedEntryPoint, structs: readonly { readonly path: string; readonly mangledName: string; readonly members: readonly ParsedStructMember[] }[], symbols: ReadonlyMap<string, ModuleSymbols>, registry: Registry, bindings: readonly BindingRef[], samplingPairs: EntryPointInfo["samplingPairs"]): EntryPointInfo {
-  const result: EntryPointInfo = { name: entry.name, mangledName: entry.mangledName, stage: entry.stage, workgroupSize: entry.workgroupSize };
-  Object.defineProperty(result, "bindings", { value: bindings.map(({ group, binding }) => ({ group, binding })), enumerable: false, configurable: true });
-  Object.defineProperty(result, "samplingPairs", { value: samplingPairs, enumerable: false, configurable: true });
-  if (entry.stage === "vertex") Object.defineProperty(result, "inputs", { value: vertexInputs(entry, structs, symbols, registry), enumerable: false, configurable: true });
-  Object.defineProperty(result, "toJSON", { value: entryPointToJSON, enumerable: false, configurable: true });
-  return result;
-}
-
-/**
- * `JSON.stringify` hook that keeps entry-point reflection lossless across serialization boundaries.
- *
- * `bindings`, `samplingPairs` and `inputs` are non-enumerable on purpose (snapshot ergonomics), which
- * otherwise makes `JSON.stringify` — and therefore the `vgpu check` payload, workers and any other
- * structural consumer — silently drop them. Reading through `this` rather than a closure keeps the
- * projection correct after `resolveShader()` re-defines the properties with whole-program values.
- */
-function entryPointToJSON(this: EntryPointInfo): EntryPointInfoJSON {
-  const enumerable = { ...this } as Omit<EntryPointInfo, "toJSON">;
-  return { ...enumerable, bindings: this.bindings, samplingPairs: this.samplingPairs, ...(this.inputs ? { inputs: this.inputs } : {}) };
+  // Plain data on purpose: every field is an ordinary enumerable own property, so the whole shape
+  // survives `JSON.stringify`, spread, `Object.keys/assign`, `structuredClone` and `postMessage`.
+  // Key order here is the observable `Object.keys()` order and is asserted in the tests.
+  return {
+    name: entry.name,
+    mangledName: entry.mangledName,
+    stage: entry.stage,
+    workgroupSize: entry.workgroupSize,
+    bindings: bindings.map(({ group, binding }) => ({ group, binding })),
+    samplingPairs,
+    // `inputs` stays absent (not `undefined`-valued) for non-vertex stages.
+    ...(entry.stage === "vertex" ? { inputs: vertexInputs(entry, structs, symbols, registry) } : {}),
+  };
 }
 
 function vertexInputs(entry: ParsedEntryPoint, structs: readonly { readonly path: string; readonly mangledName: string; readonly members: readonly ParsedStructMember[] }[], symbols: ReadonlyMap<string, ModuleSymbols>, registry: Registry): readonly EntryPointInputInfo[] {

--- a/packages/wgsl/src/runtime/reflect.ts
+++ b/packages/wgsl/src/runtime/reflect.ts
@@ -146,10 +146,12 @@ function publicEntryPoint(entry: ParsedEntryPoint, structs: readonly { readonly 
     name: entry.name,
     mangledName: entry.mangledName,
     stage: entry.stage,
-    workgroupSize: entry.workgroupSize,
+    // `workgroupSize` and `inputs` stay absent rather than `undefined`-valued when they do not
+    // apply: an own key valued `undefined` survives structuredClone but is dropped by
+    // JSON.stringify, which would make the key set differ across serialization boundaries.
+    ...(entry.workgroupSize ? { workgroupSize: entry.workgroupSize } : {}),
     bindings: bindings.map(({ group, binding }) => ({ group, binding })),
     samplingPairs,
-    // `inputs` stays absent (not `undefined`-valued) for non-vertex stages.
     ...(entry.stage === "vertex" ? { inputs: vertexInputs(entry, structs, symbols, registry) } : {}),
   };
 }

--- a/packages/wgsl/src/runtime/resolve-shader.ts
+++ b/packages/wgsl/src/runtime/resolve-shader.ts
@@ -8,7 +8,7 @@ import { assertNoMangleCollisions, emitModule, type ExportMap, type ExportTarget
 import { applyMinifyWgsl, normalizeMinifyOption, type MinifyOption } from "./minify.ts";
 import { canonicalEntry, readModule, resolveImport as resolvePath } from "./package-resolution.ts";
 import { parseModule, type ImportDecl } from "./parser.ts";
-import { reflect, type Reflection } from "./reflect.ts";
+import { reflect, type EntryPointInfo, type Reflection } from "./reflect.ts";
 import { reservedIdentifierDiagnostics } from "./reserved-identifiers.ts";
 import { reflectSource } from "./reflect-source.ts";
 import { eliminateDeadDeclarations } from "./declaration-dce.ts";
@@ -17,7 +17,7 @@ import { scan } from "./scanner.ts";
 import { validateWGSL } from "./validation.ts";
 
 export { reflectSource } from "./reflect-source.ts";
-export type { BindingInfo, BindingKind, BindingRef, EntryPointInfo, EntryPointInfoJSON, EntryPointInputInfo, HostShareableLayout, LayoutMember, ReflectedBindingLayout, Reflection, ReflectionFacade, SamplingPair, WGSLType } from "./reflect.ts";
+export type { BindingInfo, BindingKind, BindingRef, EntryPointInfo, EntryPointInputInfo, HostShareableLayout, LayoutMember, ReflectedBindingLayout, Reflection, ReflectionFacade, SamplingPair, WGSLType } from "./reflect.ts";
 export type { MinifyOption, MinifyOptions, NormalizedMinifyOptions } from "./minify.ts";
 export type { ShaderSource } from "../types.ts";
 export interface ResolveOptions {
@@ -58,8 +58,13 @@ export async function resolveShader(opts: ResolveOptions): Promise<ResolvedShade
   const emittedReflection = reflectSource(emittedWgsl, entry);
   for (const reflectedEntry of reflection.entryPoints) {
     const emittedEntry = emittedReflection.entryPoints.find((item) => item.name === reflectedEntry.mangledName);
-    if (emittedEntry?.bindings) Object.defineProperty(reflectedEntry, "bindings", { value: emittedEntry.bindings, enumerable: false, configurable: true });
-    if (emittedEntry?.samplingPairs) Object.defineProperty(reflectedEntry, "samplingPairs", { value: emittedEntry.samplingPairs, enumerable: false, configurable: true });
+    // Whole-program re-attachment: per-module reflection cannot see bindings reached through
+    // imported helpers, so overwrite with the values reflected off the emitted program. The
+    // `readonly` markers on `EntryPointInfo` are a contract for consumers, not for this builder —
+    // narrow the mutation to these two fields instead of widening the public type.
+    const mutable = reflectedEntry as { -readonly [K in "bindings" | "samplingPairs"]: EntryPointInfo[K] };
+    if (emittedEntry?.bindings) mutable.bindings = emittedEntry.bindings;
+    if (emittedEntry?.samplingPairs) mutable.samplingPairs = emittedEntry.samplingPairs;
   }
   const map = sourceMap(modules);
   const minify = normalizeMinifyOption(opts.minify);

--- a/packages/wgsl/tests/reflect-entry-bindings.test.ts
+++ b/packages/wgsl/tests/reflect-entry-bindings.test.ts
@@ -78,10 +78,10 @@ test("function-analysis fallback does not broaden entry visibility to unrelated 
   `)).toEqual({ main: [] });
 });
 
-test("bindings metadata is non-enumerable", () => {
+test("bindings metadata is an ordinary enumerable property", () => {
   const entry = reflectSource("@compute @workgroup_size(1) fn main() {}").entryPoints[0]!;
   expect(entry.bindings).toEqual([]);
-  expect(Object.keys(entry)).not.toContain("bindings");
+  expect(Object.keys(entry)).toContain("bindings");
 });
 
 const pairs = (source: string) => Object.fromEntries(reflectSource(source).entryPoints.map((entry) => [entry.name, entry.samplingPairs]));
@@ -113,10 +113,10 @@ test("sampling pairs compose helper parameters without cross-products", () => {
   ]);
 });
 
-test("sampling pair metadata is non-enumerable", () => {
+test("sampling pair metadata is an ordinary enumerable property", () => {
   const entry = reflectSource("@compute @workgroup_size(1) fn main() {}").entryPoints[0]!;
   expect(entry.samplingPairs).toEqual([]);
-  expect(Object.keys(entry)).not.toContain("samplingPairs");
+  expect(Object.keys(entry)).toContain("samplingPairs");
 });
 
 test("compute entries retain ordinary sampling pairs", () => {

--- a/packages/wgsl/tests/reflect-entry-inputs.test.ts
+++ b/packages/wgsl/tests/reflect-entry-inputs.test.ts
@@ -72,16 +72,17 @@ test("reflection resolves imported struct vertex inputs", async () => {
   ]);
 });
 
-test("vertex inputs remain snapshot-safe by staying non-enumerable", () => {
+test("vertex inputs are an ordinary enumerable property", () => {
   const entry = reflectSource(`
     @vertex fn vs(@location(0) position: vec2f) -> @builtin(position) vec4f { return vec4f(position, 0.0, 1.0); }
   `).entryPoints[0]!;
 
   expect(entry.inputs?.[0]?.name).toBe("position");
-  expect(Object.keys(entry)).toEqual(["name", "mangledName", "stage", "workgroupSize"]);
-  expect(Object.keys({ ...entry })).not.toContain("inputs");
-  // Non-enumerable is about snapshot/spread ergonomics, not about losing data: `toJSON` keeps
-  // serialization lossless (#252).
+  // Intentionally order-sensitive: this locks the observable `Object.keys()` order to the property
+  // order of the object literal in `publicEntryPoint` (reflect.ts). A failure here means that
+  // literal was reordered, not that reflection is broken.
+  expect(Object.keys(entry)).toEqual(["name", "mangledName", "stage", "workgroupSize", "bindings", "samplingPairs", "inputs"]);
+  expect(Object.keys({ ...entry })).toContain("inputs");
   expect(JSON.stringify(entry)).toContain("inputs");
 });
 

--- a/packages/wgsl/tests/reflect-entry-inputs.test.ts
+++ b/packages/wgsl/tests/reflect-entry-inputs.test.ts
@@ -81,7 +81,10 @@ test("vertex inputs are an ordinary enumerable property", () => {
   // Intentionally order-sensitive: this locks the observable `Object.keys()` order to the property
   // order of the object literal in `publicEntryPoint` (reflect.ts). A failure here means that
   // literal was reordered, not that reflection is broken.
-  expect(Object.keys(entry)).toEqual(["name", "mangledName", "stage", "workgroupSize", "bindings", "samplingPairs", "inputs"]);
+  // `workgroupSize` is absent here on purpose: this is a vertex entry, and keys that do not apply
+  // are omitted rather than set to `undefined` so the key set is identical on both sides of a
+  // JSON or structuredClone boundary.
+  expect(Object.keys(entry)).toEqual(["name", "mangledName", "stage", "bindings", "samplingPairs", "inputs"]);
   expect(Object.keys({ ...entry })).toContain("inputs");
   expect(JSON.stringify(entry)).toContain("inputs");
 });

--- a/packages/wgsl/tests/reflect-entry-serialization.test.ts
+++ b/packages/wgsl/tests/reflect-entry-serialization.test.ts
@@ -78,21 +78,60 @@ struct Params { time: f32, }
   expect(roundTripped.samplingPairs).toEqual(live.samplingPairs);
 });
 
-test("toJSON is non-enumerable and does not widen Object.keys or spreads", () => {
-  const entry = reflectSource(`
-    @group(0) @binding(0) var<uniform> view: vec4f;
-    @vertex fn vs(@location(0) position: vec2f) -> @builtin(position) vec4f { return vec4f(position, 0.0, 1.0) + view; }
-  `).entryPoints[0]!;
+// Structured-clone boundaries `toJSON` could never close (#252): these two only pass because the
+// reflection object is plain data — a non-enumerable field is invisible to structuredClone and to
+// worker postMessage, both of which clone structurally and ignore `toJSON`.
+test("entry-point metadata survives structuredClone", async () => {
+  const { reflection } = await resolveShader({
+    entry: "/main.wgsl",
+    minify: false,
+    validate: false,
+    modules: {
+      "/main.wgsl": `
+        @group(0) @binding(0) var<uniform> view: vec4f;
+        @group(0) @binding(1) var tex: texture_2d<f32>;
+        @group(0) @binding(2) var samp: sampler;
+        @vertex fn vs(@location(0) position: vec2f) -> @builtin(position) vec4f { return vec4f(position, 0.0, 1.0) + view; }
+        @fragment fn fs(@location(0) uv: vec2f) -> @location(0) vec4f { return textureSample(tex, samp, uv); }
+      `,
+    },
+  });
 
-  expect(typeof entry.toJSON).toBe("function");
-  expect(Object.keys(entry)).toEqual(["name", "mangledName", "stage", "workgroupSize"]);
-  expect(Object.keys({ ...entry })).toEqual(["name", "mangledName", "stage", "workgroupSize"]);
-  expect(JSON.stringify({ nested: entry })).toContain("bindings");
+  const cloned = structuredClone(reflection.entryPoints);
+  expect(cloned).toHaveLength(reflection.entryPoints.length);
+  for (const [index, entry] of reflection.entryPoints.entries()) {
+    expect(cloned[index]?.bindings).toEqual(entry.bindings);
+    expect(cloned[index]?.samplingPairs).toEqual(entry.samplingPairs);
+    expect(cloned[index]?.inputs).toEqual(entry.inputs);
+  }
+  expect(cloned[0]?.inputs).toEqual([{ name: "position", location: 0, type: { kind: "vector", width: 2, element: { kind: "scalar", name: "f32" } } }]);
+  expect(cloned[1]?.samplingPairs).toEqual([{ texture: { group: 0, binding: 1 }, sampler: { group: 0, binding: 2 }, mode: "filtering" }]);
 });
 
-test("entry-point properties stay configurable so later reflection passes can re-define them", () => {
-  const entry = reflectSource("@compute @workgroup_size(1) fn main() {}").entryPoints[0]!;
-  for (const key of ["bindings", "samplingPairs", "toJSON"]) {
-    expect(Object.getOwnPropertyDescriptor(entry, key)).toMatchObject({ enumerable: false, configurable: true });
+test("entry-point metadata survives a worker postMessage round-trip", async () => {
+  const { reflection } = await resolveShader({
+    entry: "/main.wgsl",
+    minify: false,
+    validate: false,
+    modules: {
+      "/main.wgsl": `
+        @group(0) @binding(0) var<uniform> view: vec4f;
+        @fragment fn fs() -> @location(0) vec4f { return view; }
+      `,
+    },
+  });
+
+  const { port1, port2 } = new MessageChannel();
+  try {
+    const received = new Promise<unknown>((resolve) => {
+      port2.onmessage = (event: { data: unknown }) => resolve(event.data);
+    });
+    port1.postMessage(reflection.entryPoints);
+    const roundTripped = (await received) as typeof reflection.entryPoints;
+    expect(roundTripped[0]?.bindings).toEqual(reflection.entryPoints[0]?.bindings);
+    expect(roundTripped[0]?.samplingPairs).toEqual(reflection.entryPoints[0]?.samplingPairs);
+  } finally {
+    port1.close();
+    port2.close();
   }
 });


### PR DESCRIPTION
## Summary

Follow-up to #259 (issue #252). Makes `EntryPointInfo` **plain data**: `bindings`, `samplingPairs`, and `inputs` are now ordinary enumerable properties, and the non-enumerable `defineProperty` design is removed entirely.

## Motivation

#259 fixed the `JSON.stringify` boundary by adding a `toJSON()` hook, but the root design problem remained: the public reflection type was not plain data. Properties hidden behind `enumerable: false` meant every copy/serialization mechanism saw a different subset of the object:

| Boundary | before #259 | after #259 | now |
|---|---|---|---|
| direct access | ✅ | ✅ | ✅ |
| `JSON.stringify` | ❌ | ✅ (via `toJSON`) | ✅ (naturally) |
| spread `{...entry}` | ❌ | ❌ (by design) | ✅ |
| `structuredClone` / worker `postMessage` | ❌ | ❌ (clone ignores `toJSON`) | ✅ |

The "snapshot cleanliness" rationale for non-enumerability was a presentation concern encoded into the data shape; a repo-wide check found no snapshot tests that get noisier without it.

## Changes

- `publicEntryPoint()` returns a single plain object literal; `entryPointToJSON` deleted. `workgroupSize` and `inputs` use conditional spread so the key is *absent* (not `undefined`) when not applicable — key sets are now identical across live/JSON/clone boundaries for every stage.
- `toJSON()` and the `EntryPointInfoJSON` type from #259 are **removed outright, not deprecated**: #259's changeset was never consumed by a release (local `@vgpu/wgsl` == published `0.2.0`), so they never shipped and no consumer can depend on them. #259's pending changeset is replaced by a single `minor` changeset for `@vgpu/wgsl`, `vgpu`, `@vgpu/cli`.
- `resolve-shader.ts` whole-program re-attachment uses a narrow `-readonly` mapped-type cast instead of `defineProperty` bypassing the type checker.
- The loud-failure hardening from #259 (`VGPU-REFLECT-ENTRY-METADATA-MISSING`) is untouched.

## Tests

- 2 new regression tests closing the boundaries #259 structurally could not: `structuredClone` round-trip and a real `MessageChannel` `postMessage` round-trip (both verified red on the old design, green now).
- Non-enumerability contract tests inverted/removed per plan; exact `Object.keys` order assertion locks the new shape.
- Full unscoped suite: 1708 passed / 0 failed. `tsc -b` clean. Bundle check: ~110 B gzip *smaller* on 4 wgsl entries, all others byte-identical. `wgsl-cachekey-determinism` unaffected (cache keys hash module-level reflection only). 591 docs snippets pass.
- Independently reviewed by a separate adversarial audit pass (plan → build → audit → polish cycle); the audit re-derived its 6-probe contract suite for the plain-data design and confirmed 6/6.
