### PR TITLE
fix(cli): resolve in-repo CLI version from vgpu-api (#254)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,7 +63,12 @@ like `chore(release): 0.2.0` and merge it to `main`.
 Private packages (`@vgpu/cli`, the docs app) are versioned so they get changelog entries,
 but they are never published. `@vgpu/cli` ships *inside* the `vgpu` tarball: `copy-cli.mjs`
 writes a synthetic `package.json` stamped with `vgpu`'s version, so its own version field
-is internal bookkeeping only.
+is internal bookkeeping only — nothing at runtime reads it. Running the CLI **from a
+checkout** (`node packages/vgpu/bin/vgpu.js ...`) ignores it too: `bin/vgpu.js` detects it is
+in-repo and resolves its version from `packages/vgpu-api/package.json`, so the in-repo binary
+reports (and negotiates with `https://vgpu.sh`) the same version the published package would.
+Never hand-edit `packages/vgpu/package.json`'s version to work around a version-gate error —
+it has no effect.
 
 ### 2. Tag and publish
 

--- a/packages/vgpu/bin/vgpu.js
+++ b/packages/vgpu/bin/vgpu.js
@@ -12,7 +12,31 @@ import { runExamples } from "../lib/examples/run.js";
 
 const here = dirname(fileURLToPath(import.meta.url));
 const packageJson = JSON.parse(readFileSync(resolve(here, "../package.json"), "utf8"));
-const VERSION = packageJson.version;
+
+// In-repo, `../package.json` is packages/vgpu/package.json (`@vgpu/cli`): private, never published,
+// versioned independently of the public `vgpu` package and known to drift from it (see
+// CONTRIBUTING.md). Reporting that version made every in-repo `vgpu examples ...` call fail the
+// server handshake with VGPU-EXAMPLES-CLI-TOO-OLD, so resolve the public version from the sibling
+// `vgpu-api` package instead -- same try/catch-degrade pattern as computeStamp() in
+// lib/docs/generate/generate.js.
+//
+// In the published tarball, `../package.json` is the synthetic `{type,version}` stamp written by
+// packages/vgpu-api/scripts/copy-cli.mjs, which has no `name` field, so this branch is dead code
+// there and the published version keeps coming from the stamp (guarded by a unit test).
+export function resolveVersion(dir, pkg) {
+  if (pkg.name === "@vgpu/cli") {
+    try {
+      const apiPackageJson = JSON.parse(readFileSync(resolve(dir, "../../vgpu-api/package.json"), "utf8"));
+      return apiPackageJson.version;
+    } catch {
+      // Incomplete checkout (sparse clone, deleted sibling): degrade to our own version, never crash.
+      return pkg.version;
+    }
+  }
+  return pkg.version;
+}
+
+const VERSION = resolveVersion(here, packageJson);
 
 const help = `vgpu ${VERSION}
 

--- a/packages/vgpu/tests/cli.test.ts
+++ b/packages/vgpu/tests/cli.test.ts
@@ -1,8 +1,14 @@
-import { readFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 import { expect, test } from "vitest";
-import { runCli } from "../bin/vgpu.js";
+import { resolveVersion, runCli } from "../bin/vgpu.js";
 
-const packageVersion = JSON.parse(readFileSync(new URL("../package.json", import.meta.url), "utf8")).version;
+// Under vitest the CLI always runs in-repo, where `bin/vgpu.js` resolves its version from the
+// public `vgpu` package (packages/vgpu-api) rather than from `@vgpu/cli`'s own private, drifting
+// version -- mirror that resolution here instead of special-casing the test.
+const packageVersion = JSON.parse(readFileSync(new URL("../../vgpu-api/package.json", import.meta.url), "utf8")).version;
 
 function success(args) {
   const result = runCli(args);
@@ -37,6 +43,40 @@ test("routes the bare command and --help/-h to the docs-first guide, exit 0", ()
   expect(runCli(["--help"])).toMatchObject({ code: 0, stdout: routerHelp });
   expect(runCli(["-h"])).toMatchObject({ code: 0, stdout: routerHelp });
   expect(success(["--version"])).toBe(`${packageVersion}\n`);
+});
+
+// The published tarball's `../package.json` is copy-cli.mjs's synthetic `{type,version}` stamp with
+// no `name` field, so the in-repo sibling lookup must never fire there -- even when a sibling
+// vgpu-api/package.json happens to exist at the exact path the branch would read. This test is the
+// executable guard for that hard constraint: if it ever fails, `npx vgpu --version` is wrong.
+test("resolveVersion ignores the sibling vgpu-api package for the published tarball shape", () => {
+  const tmp = mkdtempSync(join(tmpdir(), "vgpu-cli-version-"));
+  try {
+    const here = join(tmp, "dist", "cli", "bin");
+    mkdirSync(here, { recursive: true });
+    // Exactly what copy-cli.mjs writes: type + version, no name.
+    const stamp = { type: "module", version: "9.9.9" };
+    writeFileSync(join(tmp, "dist", "cli", "package.json"), JSON.stringify(stamp));
+    // Decoys with a *different* version, so a passing assertion cannot be a coincidence of both
+    // files agreeing, nor of the sibling read merely throwing into the fallback. One sits at the
+    // exact path the branch would consult from this `here` (resolve(here, "../../vgpu-api") ==
+    // <tmp>/dist/vgpu-api), the other one level further out, so any near-miss of that lookup still
+    // finds a mismatching version instead of falling back to the stamp.
+    for (const dir of [resolve(here, "../../vgpu-api"), join(tmp, "vgpu-api")]) {
+      mkdirSync(dir, { recursive: true });
+      writeFileSync(join(dir, "package.json"), JSON.stringify({ name: "vgpu", version: "1.2.3" }));
+    }
+
+    expect(resolveVersion(here, stamp)).toBe("9.9.9");
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test("resolveVersion resolves the in-repo @vgpu/cli version from the real vgpu-api sibling", () => {
+  const binDir = dirname(fileURLToPath(new URL("../bin/vgpu.js", import.meta.url)));
+  expect(resolveVersion(binDir, { name: "@vgpu/cli", version: "0.0.0-test" })).toBe(packageVersion);
+  expect(packageVersion).not.toBe("0.0.0-test");
 });
 
 test("does not list snapshot/install-dawn/install-software-renderer in the router (still runnable)", async () => {


### PR DESCRIPTION
## Root cause

`packages/vgpu/bin/vgpu.js` read its version from `../package.json` — i.e. `packages/vgpu/package.json`, the **private, never-published** `@vgpu/cli` package (`0.1.8`), which has structurally drifted from the public `vgpu` package (`packages/vgpu-api/package.json`, `0.2.0`).

That version is what the CLI hands to the examples handshake (`bin/vgpu.js` → `runExamples(rest, { version: VERSION })` → `lib/examples/client.js`). The gate is correct — `0.1.8 < 0.2.0-rc.1` (prod's `minimumCliVersion`) — so **every** in-repo `vgpu examples ...` invocation failed with `VGPU-EXAMPLES-CLI-TOO-OLD`, even though the code being exercised was current. Only the gate's *input* was wrong.

## Fix (option (b) from the issue)

`bin/vgpu.js` now resolves its version through a small exported `resolveVersion(dir, pkg)`:

- if `pkg.name === "@vgpu/cli"` (the in-repo case) → read the version from the sibling `packages/vgpu-api/package.json`;
- `try/catch` degrades to the CLI's own version if that sibling is missing/unreadable (sparse clone), so the CLI never crashes on startup — same pattern as `computeStamp()` in `lib/docs/generate/generate.js`;
- otherwise → unchanged behavior.

One `VERSION` const still feeds help text, `--version` **and** the examples gate — no gate-only override, so the CLI can never report one version and negotiate with another.

### The published path is untouched

`packages/vgpu-api/scripts/copy-cli.mjs` and `packages/vgpu-api/bin/vgpu.js` have **zero** changes. The synthetic `dist/cli/package.json` that `copy-cli.mjs` writes is exactly `{type, version}` with **no `name` key**, so the new branch is provably dead code in the tarball. That is now an executable guard, not an assumption: a unit test builds a tarball-shaped fixture (`<tmp>/dist/cli/bin` + a no-`name` stamp) **plus decoy `vgpu-api/package.json` files carrying a different version at the exact path the branch would consult**, and asserts the stamp's own version wins. Removing the `name` check makes that test fail (verified by mutation: `expected '1.2.3' to be '9.9.9'`).

## Before / after (real, against prod `https://vgpu.sh`)

```
# before
$ node packages/vgpu/bin/vgpu.js examples search fluid
{"error":{"code":"VGPU-EXAMPLES-CLI-TOO-OLD","message":"CLI 0.1.8 is older than required 0.2.0-rc.1"}}
exit 5
$ node packages/vgpu/bin/vgpu.js --version
0.1.8

# after
$ node packages/vgpu/bin/vgpu.js examples search fluid
{"revision":"baa4b04cb591...","results":[{"id":"fluid","title":"Interactive Fluid",...,"score":100}]}
exit 0
$ node packages/vgpu/bin/vgpu.js --version
0.2.0
```

## Changes

- `packages/vgpu/bin/vgpu.js` — exported `resolveVersion()`; `VERSION` computed once from it.
- `packages/vgpu/tests/cli.test.ts` — existing help/`--version` expectations now derive from `packages/vgpu-api/package.json` (mirroring the resolver, no hardcoded version string); two new resolver tests (tarball-shape guard with decoys, real in-repo sibling resolution).
- `CONTRIBUTING.md` — the "internal bookkeeping only" note now states the in-repo runtime behavior and warns not to hand-edit `packages/vgpu/package.json`'s version to dodge a version gate.

## Verification

| Gate | Result |
| --- | --- |
| `pnpm build` / `pnpm typecheck` | exit 0 |
| `pnpm vitest run packages/vgpu packages/vgpu-api` | 717 passed, 45 skipped — incl. `pack.test.ts` + `cli-pack.test.ts` unmodified |
| `pnpm bundle-check` | exit 0 (all budgets have headroom) |
| `npm pack` vgpu-api + extract | `dist/cli/package.json` keys are exactly `["type","version"]` (`0.2.0`, no `name`); extracted `dist/cli/bin/vgpu.js --version` → `0.2.0`; `package/bin/vgpu.js --version` → `0.2.0` |
| prod repro | `examples search fluid` exit 0 with JSON results (was `CLI-TOO-OLD`) |
| `pnpm test` | 1724 passed, 131 skipped, exit 0 |
| `pnpm docs:verify-snippets` | `snippets=595 tsc=OK` |

Out of scope (per the issue's rejected option (a)): no `@vgpu/cli` version alignment, no `.changeset/` changes, no `bump:*` script changes.

Fixes #254