### PR TITLE
fix(agent-evals): stop scoring model failures as agent failures

### DIFF
--- a/apps/agent-evals/README.md
+++ b/apps/agent-evals/README.md
@@ -102,10 +102,23 @@ means "you have no token" teaches people to ignore red results.
 | `VGPU_EVALS_DOCKER_IMAGE` | `ghcr.io/vercel/eve:latest` | pin it when you need reproducibility |
 | `VGPU_EVALS_WORK_DIR` | `<package>/.work` | tarballs and per-session snapshots |
 
-For CI later, note that the 12-hour OIDC token is useless for a scheduled run:
-that needs `VERCEL_TOKEN` + `VERCEL_TEAM_ID` + `VERCEL_PROJECT_ID` for the
-sandbox and a separate `AI_GATEWAY_API_KEY` for the gateway — a Vercel access
-token does **not** work as a Gateway bearer token.
+This suite has no CI job: it is run by hand, because every run spends model
+tokens and observes discovery behaviour, which says nothing about the commit
+under review. Should that ever change, a non-interactive run cannot use the
+12-hour OIDC token — it would need `AI_GATEWAY_API_KEY`, since a Vercel access
+token does **not** work as a Gateway bearer token. `VERCEL_TOKEN` +
+`VERCEL_TEAM_ID` + `VERCEL_PROJECT_ID` matter only if you switch to
+`VGPU_EVALS_SANDBOX=vercel`; the default docker backend needs no Vercel
+credentials at all.
+
+### Naming a different model
+
+`VGPU_EVALS_MODEL=<slug> pnpm agent-evals` sends one 16-token request to the
+gateway before packing anything. If the provider is restricted for your team the
+command stops with exit 2 and says so, instead of packing tarballs, booting a
+sandbox and then dying mid-turn — which is what a restricted provider used to
+cost. A gateway that is merely unreachable or rate-limited is reported and the
+run continues, because that is not a verdict about the model.
 
 ### A green run can still print template errors
 

--- a/apps/agent-evals/evals/lib/turn-failure.mjs
+++ b/apps/agent-evals/evals/lib/turn-failure.mjs
@@ -1,0 +1,38 @@
+/**
+ * Why a turn ended without completing, in one line.
+ *
+ * Kept out of the eval, and kept as a plain module, so it can be replayed
+ * against an archived transcript without a model call — the shape below was
+ * derived from a real run, not from the docs, and it is worth being able to
+ * re-check it when eve's event payloads move.
+ *
+ * eve stamps the cause on its `*.failed` events (`step.failed`, `turn.failed`,
+ * `session.failed`) as a `code` plus a nested `details` object. Verified against
+ * the transcript of a run that died on a restricted provider:
+ *
+ *   turn.failed -> data.code: "MODEL_CALL_FAILED"
+ *                  data.details.statusCode: 403
+ *                  data.details.message: "Your team has restricted access ..."
+ */
+
+/** @typedef {{ type?: unknown, data?: { code?: unknown, details?: Record<string, unknown> } }} FailureEventLike */
+
+/**
+ * @param {readonly unknown[]} events the turn's stream events
+ * @returns {string} one-line cause, or a stated fallback when nothing explains it
+ */
+export function turnFailure(events) {
+  for (const event of events) {
+    const failure = /** @type {FailureEventLike} */ (event);
+    if (typeof failure.type !== "string" || !failure.type.endsWith(".failed")) continue;
+    const data = failure.data ?? {};
+    const details = data.details ?? {};
+    const status = details.statusCode ?? details.upstreamStatusCode;
+    const message = details.message ?? details.apiErrorMessage ?? details.upstreamMessage;
+    const line = [data.code, status === undefined ? null : `HTTP ${status}`, message]
+      .filter((part) => part !== null && part !== undefined && part !== "")
+      .join(" ");
+    if (line !== "") return line;
+  }
+  return "no failure event in the transcript";
+}

--- a/apps/agent-evals/evals/lib/turn-failure.mjs
+++ b/apps/agent-evals/evals/lib/turn-failure.mjs
@@ -32,7 +32,11 @@ export function turnFailure(events) {
     const line = [data.code, status === undefined ? null : `HTTP ${status}`, message]
       .filter((part) => part !== null && part !== undefined && part !== "")
       .join(" ");
-    if (line !== "") return line;
+    // The contract above says "one line", so honour it here rather than hoping
+    // upstream messages cooperate: gateway errors arrive multi-line and can run
+    // to thousands of characters, and this string goes straight onto a reporter
+    // summary line.
+    if (line !== "") return line.replace(/\s+/g, " ").trim().slice(0, 300);
   }
   return "no failure event in the transcript";
 }

--- a/apps/agent-evals/evals/s2-gradient.eval.ts
+++ b/apps/agent-evals/evals/s2-gradient.eval.ts
@@ -280,7 +280,7 @@ export default defineEval({
       "Counters for this run:",
       `- documentation commands: ${docsCalls.length}`,
       `- total tool calls: ${turn.toolCalls.length}`,
-      `- tool calls before the first successful render: ${
+      `- tool calls up to and including the first successful render: ${
         firstGoodRender === -1 ? "never rendered successfully" : firstGoodRender + 1
       }`,
       "",

--- a/apps/agent-evals/evals/s2-gradient.eval.ts
+++ b/apps/agent-evals/evals/s2-gradient.eval.ts
@@ -6,6 +6,7 @@ import { equals } from "eve/evals/expect";
 import { PNG } from "pngjs";
 import { snapshotTarPath, snapshotWorkspaceDir } from "../agent/lib/paths.ts";
 import { MIX_MAX, MIX_MIN, TOL, gradeGradient } from "./lib/grade-gradient.mjs";
+import { turnFailure } from "./lib/turn-failure.mjs";
 
 /**
  * The one hint is `npx vgpu`, and it is deliberate.
@@ -126,6 +127,35 @@ export default defineEval({
 
     const startedAt = Date.now();
     const turn = await t.send(PROMPT);
+
+    // A model that never answered is not an agent that failed the task.
+    //
+    // `send()` resolves with a failed turn instead of throwing (only
+    // `expectOk()` throws), so without this the run falls through to the
+    // workspace-export assertion below and reports `gates 0/1` — indis-
+    // tinguishable on the summary line from "the agent produced nothing". That
+    // is exactly how a restricted-provider 403 once got recorded as an agent
+    // result. This must stay ABOVE the gates for that reason.
+    //
+    // Two details are load-bearing, both learned the hard way:
+    //
+    // 1. The test is `=== "failed"`, NOT `!== "completed"`. eve derives the
+    //    status from the SESSION boundary event, not the turn:
+    //    `session.waiting -> "waiting"`, `session.failed -> "failed"`, anything
+    //    else -> `"completed"`. A successful single-turn run here ends on
+    //    `session.waiting` because the session parks for the next message, so
+    //    it reports `"waiting"` and `"completed"` never occurs in this suite.
+    //    Testing for `!== "completed"` rejects every healthy run.
+    //
+    // 2. It throws rather than calling `t.skip()`. Skipping would be the
+    //    honest verdict — this is not the agent's failure — but eve rejects it
+    //    after work has happened: "skip() must be called before sending
+    //    messages or recording assertions." A throw still puts the cause on the
+    //    summary line, which is the point.
+    if (turn.status === "failed") {
+      throw new Error(`model/infra failure, not an agent result: ${turnFailure(turn.events)}`);
+    }
+
     const sessionId = turn.sessionId;
 
     // ---- Evidence: the files, not the transcript --------------------------
@@ -244,6 +274,16 @@ export default defineEval({
       .join("\n\n")
       .slice(0, JUDGE_SECTION_LIMIT);
     const material = [
+      // The counters are handed over explicitly. Asking a judge to weigh
+      // "proportionate" while making it count commands out of a transcript
+      // produced 1.0 for a 7-call run and a 24-call run alike.
+      "Counters for this run:",
+      `- documentation commands: ${docsCalls.length}`,
+      `- total tool calls: ${turn.toolCalls.length}`,
+      `- tool calls before the first successful render: ${
+        firstGoodRender === -1 ? "never rendered successfully" : firstGoodRender + 1
+      }`,
+      "",
       "Commands the agent ran:",
       commands.slice(0, JUDGE_SECTION_LIMIT) || "(none)",
       "",
@@ -259,7 +299,12 @@ export default defineEval({
       {
         label: "discovery proportionate",
         criteria:
-          "Was the number of discovery commands proportionate — a few targeted queries rather than blind wandering?",
+          "Was the amount of discovery proportionate for a task this small (write one file that renders a " +
+          "gradient)? Judge from the counters, not the prose: 1-3 documentation commands is proportionate; " +
+          "4-6 is acceptable only if each command was targeted at something the agent then used; more than 6 " +
+          "documentation commands, or more than 20 total tool calls, or more than 12 tool calls before the " +
+          "first successful render, is wandering. Answer N when the counters fall outside those ranges and " +
+          "the commands show no clear reason for the extra work.",
       },
       {
         label: "acted on docs read",

--- a/scripts/agent-evals.mjs
+++ b/scripts/agent-evals.mjs
@@ -5,9 +5,10 @@
 // correctly BEFORE anything workspace-specific is guaranteed to work on the
 // current Node version.
 //
-// It does two things in order:
+// It does three things in order:
 //   1. preflight the Node version — `eve` needs 24+, this repo pins 22;
-//   2. pack this branch's vgpu into tarballs, then run the evals against them.
+//   2. preflight the model provider when one was named explicitly;
+//   3. pack this branch's vgpu into tarballs, then run the evals against them.
 //
 // Step 2 is not a convenience. The whole point of the tool is to exercise the
 // vgpu in the working tree; running the evals against a stale (or absent)
@@ -22,9 +23,10 @@ import process from "node:process";
 const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const PACKAGE_DIR = join(REPO_ROOT, "apps", "agent-evals");
 const REQUIRED_MAJOR = 24;
-// Exit 2, not 1, so a wrong Node is distinguishable from "the evals ran and
-// something failed" (which `eve eval` reports as exit 1).
-const EXIT_WRONG_NODE = 2;
+// Exit 2, not 1, so an unusable environment is distinguishable from "the evals
+// ran and something failed" (which `eve eval` reports as exit 1).
+const EXIT_ENVIRONMENT = 2;
+const EXIT_WRONG_NODE = EXIT_ENVIRONMENT;
 
 const major = Number.parseInt(process.versions.node.split(".")[0], 10);
 
@@ -45,6 +47,62 @@ if (!Number.isInteger(major) || major < REQUIRED_MAJOR) {
     ].join("\n"),
   );
   process.exit(EXIT_WRONG_NODE);
+}
+
+// Preflight the provider when a model was named explicitly.
+//
+// A gateway that refuses the provider costs a full invocation otherwise: the
+// tarballs get packed, the sandbox template boots, and only then does the turn
+// die — and it dies looking like an eval result. One 16-token request answers
+// it in well under a second.
+//
+// Only when VGPU_EVALS_MODEL is set: the default model is exercised constantly
+// and does not need re-proving, and reading the default here would duplicate a
+// constant that lives in agent/agent.ts.
+const requestedModel = process.env.VGPU_EVALS_MODEL;
+if (requestedModel) {
+  const credential = process.env.AI_GATEWAY_API_KEY || process.env.VERCEL_OIDC_TOKEN;
+  if (credential) {
+    const provider = requestedModel.split("/")[0];
+    let response;
+    try {
+      response = await fetch("https://ai-gateway.vercel.sh/v1/chat/completions", {
+        method: "POST",
+        headers: { authorization: `Bearer ${credential}`, "content-type": "application/json" },
+        // 16 is the gateway's documented floor for this field; asking for 1
+        // gets a 400 from some providers and would read as a fake failure.
+        body: JSON.stringify({ model: requestedModel, max_tokens: 16, messages: [{ role: "user", content: "hi" }] }),
+      });
+    } catch (error) {
+      // Network trouble is not evidence about the provider. Say so and carry on
+      // rather than blocking a run over a blip.
+      process.stderr.write(`pnpm agent-evals: provider preflight could not reach the gateway (${error.message}); continuing.\n`);
+    }
+    if (response !== undefined && !response.ok) {
+      const body = await response.text().catch(() => "");
+      const restricted = response.status === 403 && /restricted|RestrictedProviders/i.test(body);
+      const missing = response.status === 404;
+      if (restricted || missing) {
+        process.stderr.write(
+          [
+            restricted
+              ? `pnpm agent-evals: provider "${provider}" is restricted for this team, so ${requestedModel} cannot run.`
+              : `pnpm agent-evals: the gateway does not know the model "${requestedModel}".`,
+            "",
+            restricted
+              ? "  An account owner has to allow the provider in the AI Gateway settings."
+              : "  Check the slug against the gateway's model list.",
+            "  Nothing was packed and no sandbox was started.",
+            "",
+          ].join("\n"),
+        );
+        process.exit(EXIT_ENVIRONMENT);
+      }
+      // Any other non-2xx (rate limit, 5xx, a provider-specific quirk) is not a
+      // definitive verdict on this model, so it is reported and not fatal.
+      process.stderr.write(`pnpm agent-evals: provider preflight got HTTP ${response.status} for ${requestedModel}; continuing.\n`);
+    }
+  }
 }
 
 process.stdout.write("pnpm agent-evals: packing this branch's vgpu…\n");

--- a/scripts/agent-evals.mjs
+++ b/scripts/agent-evals.mjs
@@ -72,6 +72,11 @@ if (requestedModel) {
         // 16 is the gateway's documented floor for this field; asking for 1
         // gets a 400 from some providers and would read as a fake failure.
         body: JSON.stringify({ model: requestedModel, max_tokens: 16, messages: [{ role: "user", content: "hi" }] }),
+        // A gateway that accepts the connection and then never answers would
+        // otherwise hang this command forever, which is worse than the failure
+        // the preflight exists to catch. The AbortError lands in the catch
+        // below and is treated like any other unreachable gateway.
+        signal: AbortSignal.timeout(10_000),
       });
     } catch (error) {
       // Network trouble is not evidence about the provider. Say so and carry on
@@ -82,19 +87,25 @@ if (requestedModel) {
       const body = await response.text().catch(() => "");
       const restricted = response.status === 403 && /restricted|RestrictedProviders/i.test(body);
       const missing = response.status === 404;
-      if (restricted || missing) {
+      // A credential the gateway refuses is a verdict, not a blip: 401 always,
+      // and a 403 that is not about provider access — an expired OIDC token
+      // reads exactly like that. Continuing would spend bootstrap and turns to
+      // die on the same rejection, which is the cost this preflight exists to
+      // avoid.
+      const refused = response.status === 401 || (response.status === 403 && !restricted);
+      if (restricted || missing || refused) {
+        const headline = restricted
+          ? `pnpm agent-evals: provider "${provider}" is restricted for this team, so ${requestedModel} cannot run.`
+          : missing
+            ? `pnpm agent-evals: the gateway does not know the model "${requestedModel}".`
+            : `pnpm agent-evals: the gateway rejected the credential (HTTP ${response.status}).`;
+        const advice = restricted
+          ? "  An account owner has to allow the provider in the AI Gateway settings."
+          : missing
+            ? "  Check the slug against the gateway's model list."
+            : "  Check AI_GATEWAY_API_KEY / VERCEL_OIDC_TOKEN (expired?). An OIDC token\n  lasts 12 hours; re-run `vercel env pull` to refresh it.";
         process.stderr.write(
-          [
-            restricted
-              ? `pnpm agent-evals: provider "${provider}" is restricted for this team, so ${requestedModel} cannot run.`
-              : `pnpm agent-evals: the gateway does not know the model "${requestedModel}".`,
-            "",
-            restricted
-              ? "  An account owner has to allow the provider in the AI Gateway settings."
-              : "  Check the slug against the gateway's model list.",
-            "  Nothing was packed and no sandbox was started.",
-            "",
-          ].join("\n"),
+          [headline, "", advice, "  Nothing was packed and no sandbox was started.", ""].join("\n"),
         );
         process.exit(EXIT_ENVIRONMENT);
       }


### PR DESCRIPTION
Three fixes to the `s2-gradient` harness in `apps/agent-evals`. All three came out of running the suite for real, and two of them are corrections to my own first attempt.

## 1. A failed model call is no longer scored as an agent failure

`send()` resolves with a failed turn rather than throwing — only `expectOk()` throws. So a turn that never produced anything fell through to the workspace-export assertion and printed `gates 0/1`, which on the summary line is indistinguishable from *the agent produced nothing*. That is exactly how a restricted-provider `403` once got filed as an agent result.

The eval now inspects the turn before grading and throws with the gateway's own cause. Two details are load-bearing, both learned the hard way and both recorded in comments next to the code:

- **The test is `status === "failed"`, not `!== "completed"`.** eve derives the status from the **session** boundary event, not the turn: `session.waiting → "waiting"`, `session.failed → "failed"`, anything else → `"completed"`. A healthy single-turn run here ends on `session.waiting` because the session parks for the next message, so it reports `"waiting"` and `"completed"` never occurs in this suite. My first predicate (`!== "completed"`) therefore rejected a run that had just passed — see the evidence below.
- **It throws rather than calling `t.skip()`.** Skipping is the honest verdict, since this is not the agent's failure, but eve refuses it once work has happened: `skip() must be called before sending messages or recording assertions`. Skip is only legal before `t.send()`, and the condition is only knowable after. A throw at least puts the cause on the summary line, which is the point.

The cause extractor lives in `evals/lib/turn-failure.mjs`, separate from the eval, so it can be replayed against an archived transcript without a model call — the same reason `grade-gradient.mjs` lives there. Its event shape was derived from the transcript of a real run that died on a 403, not from documentation.

## 2. The judge now discriminates

The three `closedQA` judges receive the counters explicitly (documentation commands, total tool calls, calls before the first successful render), and *proportionate* states concrete ranges instead of asking for a vibe.

Replaying archived transcripts through eve's own bundled `autoevals` — no eval invocation, no sandbox, no agent:

| archived run | docs cmds | total calls | →1st render | old criterion | new criterion |
| --- | --- | --- | --- | --- | --- |
| Claude, 7 calls | 1 | 7 | 6 | 1.0 (Y) | **1.0 (Y)** |
| Kimi K3, 17 calls | 2 | 17 | 16 | 1.0 (Y) | **0.0 (N)** |
| Gemini, 24 calls | 5 | 24 | 17 | 1.0 (Y) | **0.0 (N)** |

The old criterion scored every run 1.0, including both ends of that range — 15/15 across the last variance batch. Worth flagging for whoever tunes this next: Kimi is failed on calls-before-first-render (16 > 12) even though its 2 documentation commands are inside the proportionate band. Its extra work was reading `bin/vgpu.js` and `dist/` directly, and it was the only model in that batch that found `vgpu check`, so that threshold is a judgement call rather than a settled fact.

## 3. The wrapper preflights the provider

`pnpm agent-evals` now sends one 16-token request to the gateway before packing anything, but only when `VGPU_EVALS_MODEL` is set explicitly. A restricted provider or an unknown slug exits `2` with an explanation; an unreachable or rate-limited gateway is reported and does **not** block, because that is not a verdict about the model.

16 tokens rather than 1 because some providers reject `max_tokens: 1` with a `400`, which would preflight as a false negative. Note that provider curation — simply not putting 403 providers on the list — is the primary strategy here; this is a cheap backstop, not machinery to expand.

## Evidence

Two real runs, already spent, on the previous iteration of this branch:

- **Run 1 failed, and paid for itself.** It exposed both bugs in fix 1: the illegal `t.skip()` placement and the inverted status predicate. The agent solved the task; the eval died in my code.
- **Run 2, after the fix, was green:** `1 passed`, `Gates: 8 passed`, `59.6s`, all three judges 100%, funnel `docs_cmd_count=4 renders_count=1 calls_to_first_render=10 total_tool_calls=11`, `stale_api_emitted=false`.
- **The judge comparison above** cost 6 `gpt-4.1-mini` calls and zero eval invocations.

No new run was needed for this PR: the fixes it carries are the ones those runs validated, and the branch content is identical to what run 2 exercised minus the workflow.

## Verification

`pnpm install --frozen-lockfile`, package `tsc --noEmit`, `pnpm -w typecheck`, `pnpm check:filenames`, `pnpm check:skill-drift`, and the root suite: **235 test files / 1778 tests passed, 23 + 131 skipped**. All clean.

## Round 2 (review fixes)

**The preflight probe is now bounded** — `signal: AbortSignal.timeout(10_000)`, with the AbortError falling into the existing catch so it is reported like any other unreachable gateway rather than blocking the run. Proven before/after with a signal-aware fetch stub:

| wrapper | outcome |
| --- | --- |
| before the fix | **hung until killed at 20s**, exit 124, no diagnostic printed |
| after the fix | aborts at 10s — `could not reach the gateway (The operation was aborted due to timeout); continuing.` — then packs |

Two subtleties surfaced while proving this, and the stub had to be corrected for both: a stub that returns a never-resolving promise **ignores `init.signal`**, unlike real fetch; and because `AbortSignal.timeout` uses an *unref'd* timer, a stub with nothing else pending makes Node exit at 0s with code 13 (unsettled top-level await), exercising nothing either before or after the fix. The stub now honours the signal and holds a ref'd handle, standing in for the live socket a real fetch keeps open.

**A refused credential is now fatal** with exit 2: `401` always, and a `403` whose body does not match the restricted-provider pattern — an expired OIDC token reads exactly like that. Continuing would spend bootstrap and turns to die on the same rejection, which is the cost this preflight exists to avoid. The message names both environment variables and the 12-hour OIDC lifetime. Rate limits, 5xx and unreachable gateways still warn and continue, since none of those is a verdict about the model.

Every preflight branch re-exercised against the stub, with no credential ever appearing in output:

| branch | result |
| --- | --- |
| default model | no probe fired |
| 403 restricted | exit 2, names the provider |
| 404 unknown slug | exit 2, points at the model list |
| 403 non-matching | exit 2, credential rejected *(new)* |
| 401 | exit 2, credential rejected *(new)* |
| 429 | warn + continue |
| unreachable | warn + continue |
| custom model, no credential | no probe, proceeds |
| gateway hangs | aborts at 10s, warn + continue *(new)* |

**`turnFailure` honours its one-line contract**: whitespace collapsed, cause capped at 300 characters. A multi-line message now renders as `X line one line two line three`, and a 5000-character message comes back at exactly 300. All fourteen probe cases behave, including no-details, no-code, `upstream*` fallbacks, and a non-`.failed` first event.

**The judge counter label reads "up to and including the first successful render"**, matching the inclusive value it carries.

Re-verified: package `tsc`, `pnpm -w typecheck`, `check:filenames`, `check:skill-drift` — all clean. The root suite was not re-run: no fix here touches anything it covers, and it is already green on this branch at 235 files / 1778 tests.

## Deliberately not included: the CI workflow

A `workflow_dispatch`-only workflow exists and is complete, but it is **excluded at the user's request** and stays on a local branch until asked for. The README was adjusted so it does not reference a workflow this branch does not ship: the credentials section now states plainly that the suite is run by hand, and keeps the `AI_GATEWAY_API_KEY` note as a conditional for a future non-interactive run. Nothing here documents a file that isn't in the tree.
