### PR TITLE
fix(wgsl): scan a leading-dot float literal as one number token

### DIFF
--- a/.changeset/wgsl-minify-leading-dot-float.md
+++ b/.changeset/wgsl-minify-leading-dot-float.md
@@ -1,0 +1,9 @@
+---
+"@vgpu/wgsl": patch
+---
+
+Minification no longer corrupts leading-dot float literals. WGSL's `decimal_float_literal` may start with a dot (`.5`, `.0`, `.5e2`, `.5f`), but the scanner only opened a number token on a leading digit, so `.5` was tokenized as punctuation `.` plus the number `5`; the token printer's dot/digit separator rule then wrote `. 5`, which no device accepts (`unable to parse right side of assignment`). `.5` is now scanned as one number token, so `out_buf[0] = .5;` minifies to `out_buf[0]=.5;` instead of `out_buf[0]=. 5;`.
+
+This was reachable from every entry point that minifies: `minify: true` threw the naga diagnostic (after #273, whitespace-only minification does too, instead of silently returning broken WGSL), and two shaders shipped in this repository — `apps/docs/examples/fluid/divergence.wgsl` and `project.wgsl`, both containing `…*.5*f32(grid.size.x)…` — could not be built with `minify: true` at all. Affected forms included `.5`, `.0`, `.5e2`, `.5f`, `-.5`, `(.5)`, `max(.5,1.0)`, `array<f32,2>(.5,1.0)`, `x*.25`, and the same literals inside imported modules.
+
+Nothing else about tokenization changes. A `.` is only absorbed into a number when the very next character is a digit, and neither member names nor swizzles can start with a digit, so member access and swizzles (`v.x`, `a.xyz`, `s.inner.value`, `vec2f(1.0,2.0).x`) are untouched; trailing-dot and exponent forms (`1.`, `1.e3`, `1e3`, `0x1p1`, `0x1.8p1`) still go through the leading-digit path and minify byte-identically to before. A dot that is *not* adjacent to its digits in the source (`. 5`) is still printed with its separator rather than being fused into a literal the author did not write.

--- a/packages/wgsl/src/runtime/scanner.ts
+++ b/packages/wgsl/src/runtime/scanner.ts
@@ -61,7 +61,12 @@ export function scan(source: string): Token[] {
       const text = source.slice(start, i);
       push(WGSL_KEYWORDS.has(text) ? "keyword" : "ident", start, i, atLine, atColumn); continue;
     }
-    if (/[0-9]/.test(ch)) {
+    // WGSL's `decimal_float_literal` may start with a dot (`.5`, `.5e2`, `.5f`), so a `.` directly
+    // followed by a digit opens a number token rather than a member access: neither member names nor
+    // swizzles can start with a digit, so `v.x` / `a.xyz` stay punct + ident. Trailing-dot forms
+    // (`1.`, `1.e3`) enter through the leading-digit case and are unchanged.
+    if (/[0-9]/.test(ch) || (ch === "." && /[0-9]/.test(source[i + 1] ?? ""))) {
+      if (ch === ".") step();
       while (i < source.length) {
         const current = source[i]!;
         if (/[A-Za-z0-9_.]/.test(current)) { step(); continue; }

--- a/packages/wgsl/tests/minify-fluid-shaders.test.ts
+++ b/packages/wgsl/tests/minify-fluid-shaders.test.ts
@@ -1,0 +1,38 @@
+import { readFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { expect, test } from "vitest";
+import { resolveShader } from "@vgpu/wgsl/runtime";
+
+/**
+ * The ships-today proof for the leading-dot float fix: `apps/docs/examples/fluid/divergence.wgsl`
+ * and `project.wgsl` both contain `*.5*`, and every `minify: true` build of them used to emit
+ * `*. 5*` — WGSL the device rejects with "unable to parse right side of * expression". These are the
+ * real repository files, read from disk, so the test tracks the shaders as they actually ship.
+ */
+const fluidDir = resolve(dirname(fileURLToPath(import.meta.url)), "../../../apps/docs/examples/fluid");
+const hasDevice = process.env.VGPU_DOCKER_TEST === "1";
+
+async function fluidModules(entryName: string): Promise<Record<string, string>> {
+  return {
+    [`/${entryName}`]: await readFile(resolve(fluidDir, entryName), "utf8"),
+    "/fluid-common.wgsl": await readFile(resolve(fluidDir, "fluid-common.wgsl"), "utf8"),
+  };
+}
+
+for (const entryName of ["divergence.wgsl", "project.wgsl"]) {
+  test(`minify:true keeps the leading-dot floats in apps/docs/examples/fluid/${entryName}`, async () => {
+    const modules = await fluidModules(entryName);
+    // Guards against the fixture drifting away from the literal this test is about.
+    expect(modules[`/${entryName}`]).toContain("*.5*");
+
+    const result = await resolveShader({ entry: `/${entryName}`, modules, minify: true });
+    expect(result.wgsl).not.toContain(". 5");
+    expect((result.wgsl.match(/\*\.5\*/g) ?? []).length).toBe(2);
+  });
+
+  test.skipIf(!hasDevice)(`the real device accepts minified apps/docs/examples/fluid/${entryName}`, async () => {
+    const result = await resolveShader({ entry: `/${entryName}`, modules: await fluidModules(entryName), minify: true, validate: "require" });
+    expect(result.validation).toMatchObject({ mode: "require", attempted: true, ok: true });
+  });
+}

--- a/packages/wgsl/tests/minify-leading-dot-float.test.ts
+++ b/packages/wgsl/tests/minify-leading-dot-float.test.ts
@@ -1,0 +1,84 @@
+import { expect, test } from "vitest";
+import { resolveShader } from "@vgpu/wgsl/runtime";
+import { minifyWgsl } from "../src/runtime/minify.ts";
+import { scan } from "../src/runtime/scanner.ts";
+
+/**
+ * WGSL's `decimal_float_literal` allows a leading dot (`.5`, `.5e2`, `.5f`), so the scanner has to
+ * emit one number token for it. It used to emit `punct:.` + `number:5`, and the printer's
+ * dot/digit separator rule then wrote `. 5` — text the device rejects with "unable to parse right
+ * side of assignment". Two shaders that ship in this repo (`apps/docs/examples/fluid/divergence.wgsl`,
+ * `project.wgsl`) contain `*.5*` and could not be minified at all.
+ */
+
+function tokenSummary(source: string): string {
+  return scan(source).map((token) => `${token.kind}:${token.text}`).join(" | ");
+}
+
+test("scanner reads a leading-dot float as one number token", () => {
+  expect(tokenSummary("let a = .5;")).toBe("keyword:let | ident:a | punct:= | number:.5 | punct:;");
+  expect(tokenSummary("let a = -.5e2f;")).toBe("keyword:let | ident:a | punct:= | punct:- | number:.5e2f | punct:;");
+});
+
+test("scanner still reads a dot before a non-digit as punctuation", () => {
+  // Member access and swizzles can never start with a digit, which is exactly why the leading-dot
+  // number scan is unambiguous.
+  expect(tokenSummary("let a = v.x;")).toBe("keyword:let | ident:a | punct:= | ident:v | punct:. | ident:x | punct:;");
+  expect(tokenSummary("let a = c.xyz;")).toBe("keyword:let | ident:a | punct:= | ident:c | punct:. | ident:xyz | punct:;");
+  expect(tokenSummary("let a = 1.;")).toBe("keyword:let | ident:a | punct:= | number:1. | punct:;");
+});
+
+test("minify keeps leading-dot float literals intact", () => {
+  expect(minifyWgsl("out_buf[0] = .5;")).toBe("out_buf[0]=.5;");
+  expect(minifyWgsl("let a = .0;")).toBe("let a=.0;");
+  expect(minifyWgsl("let a = .5e2;")).toBe("let a=.5e2;");
+  expect(minifyWgsl("let a = .5f;")).toBe("let a=.5f;");
+  expect(minifyWgsl("let a = -.5;")).toBe("let a=-.5;");
+  expect(minifyWgsl("let a = (.5);")).toBe("let a=(.5);");
+  expect(minifyWgsl("let a = max(.5,1.0);")).toBe("let a=max(.5,1.0);");
+  expect(minifyWgsl("let a = array<f32,2>(.5,1.0);")).toBe("let a=array<f32,2>(.5,1.0);");
+  expect(minifyWgsl("let a = x*.25;")).toBe("let a=x*.25;");
+  expect(minifyWgsl("let a = .5 /* comment */ + 1.0;")).toBe("let a=.5+1.0;");
+});
+
+test("minify keeps the shipped fluid-shader expression intact", () => {
+  // Provenance: the `*.5*` expression below is copied from
+  // apps/docs/examples/fluid/divergence.wgsl (`divergence[index_of(p,grid.size)]=…`).
+  expect(minifyWgsl("d[i(p,g.size)] = (r-l)*.5*f32(g.size.x) + (t-b)*.5*f32(g.size.y);"))
+    .toBe("d[i(p,g.size)]=(r-l)*.5*f32(g.size.x)+(t-b)*.5*f32(g.size.y);");
+});
+
+test("minify leaves every other number and member-access form as it was", () => {
+  // Over-fix guards: these outputs are byte-identical to the pre-fix minifier.
+  expect(minifyWgsl("let a = 0.5;")).toBe("let a=0.5;");
+  expect(minifyWgsl("let a = 1.;")).toBe("let a=1.;");
+  expect(minifyWgsl("let a = 1.e3;")).toBe("let a=1.e3;");
+  expect(minifyWgsl("let a = 1e3;")).toBe("let a=1e3;");
+  expect(minifyWgsl("let a = 0x1p1;")).toBe("let a=0x1p1;");
+  expect(minifyWgsl("let a = 0x1.8p1;")).toBe("let a=0x1.8p1;");
+  expect(minifyWgsl("let a = 0xFFu;")).toBe("let a=0xFFu;");
+  expect(minifyWgsl("let a = 0.5 + 1. + 1.e3 + 1e3 + 0x1p1 + 0x1.8p1 + 0xFFu;")).toBe("let a=0.5+1.+1.e3+1e3+0x1p1+0x1.8p1+0xFFu;");
+  expect(minifyWgsl("let a = v.x + v.y;")).toBe("let a=v.x+v.y;");
+  expect(minifyWgsl("let a = c.xyz;")).toBe("let a=c.xyz;");
+  expect(minifyWgsl("let a = s.inner.value;")).toBe("let a=s.inner.value;");
+  expect(minifyWgsl("let a = vec2f(1.0,2.0).x;")).toBe("let a=vec2f(1.0,2.0).x;");
+  expect(minifyWgsl("let a = v./* comment */x;")).toBe("let a=v.x;");
+});
+
+test("minify does not invent a leading-dot float where the source did not have one", () => {
+  // A dot separated from the digits is not a float literal in the input, so the printer must not
+  // fuse it into one: these keep their separators, exactly as before the fix.
+  expect(minifyWgsl("let a = . 5;")).toBe("let a=. 5;");
+  expect(minifyWgsl("let a = 1 . 5;")).toBe("let a=1 . 5;");
+});
+
+test("resolveShader minifies a leading-dot float in an imported module", async () => {
+  const modules = {
+    "/entry.wgsl": "import { half_of } from \"./lib.wgsl\";\n@group(0) @binding(0) var<storage, read_write> out_buf: array<f32>;\n@compute @workgroup_size(1) fn main() {\n  out_buf[0] = half_of(3.0) * .5;\n}\n",
+    "/lib.wgsl": "export fn half_of(v: f32) -> f32 {\n  return v * .5;\n}\n",
+  };
+  const result = await resolveShader({ entry: "/entry.wgsl", modules, minify: true });
+  expect(result.wgsl).not.toContain(". 5");
+  expect(result.wgsl).toContain("*.5");
+  expect((result.wgsl.match(/\*\.5/g) ?? []).length).toBe(2);
+});

--- a/packages/wgsl/tests/validation-real-device.test.ts
+++ b/packages/wgsl/tests/validation-real-device.test.ts
@@ -19,8 +19,8 @@ test.skipIf(!hasDevice)("require mode throws the naga diagnostic for an invalid 
 
 /**
  * Fixture for the "the returned artifact is the validated artifact" guarantee, using a leading-dot
- * float literal: `.5` is valid WGSL (the device accepts this source verbatim), but the whitespace
- * minifier currently splits it into `. 5`, which the device rejects.
+ * float literal: `.5` is valid WGSL (the device accepts this source verbatim), and the whitespace
+ * minifier used to split it into `. 5`, which the device rejects.
  */
 const DOT_FIVE_WGSL = "@group(0) @binding(0) var<storage, read_write> out_buf: array<f32>;\n@compute @workgroup_size(1) fn main() {\n  out_buf[0] = .5;\n}\n";
 
@@ -45,12 +45,12 @@ test.skipIf(!hasDevice)("whitespace-only minification never returns WGSL the dev
   expect(roundTrip.validation).toMatchObject({ attempted: true, ok: true });
 });
 
-test.skipIf(!hasDevice)("a `.5` literal split by whitespace minification is caught instead of shipped", async () => {
-  // Pinned to today's minifier behaviour: `.5` -> `. 5` is a live printer bug, so the *correct*
-  // outcome for this input right now is a loud naga diagnostic. Fixing the printer flips this test
-  // — replace the body with `await expect(resolveDotFiveWhitespaceMinified()).resolves.toMatchObject(
-  // { validation: { ok: true } })` and keep the test above unchanged; it already covers both worlds.
-  await expect(resolveDotFiveWhitespaceMinified()).rejects.toMatchObject({ code: "VGPU-WGSL-NAGA-UNKNOWN" });
+test.skipIf(!hasDevice)("a `.5` literal survives whitespace minification and validates", async () => {
+  // Pins the fix for the split-literal bug: the scanner now reads `.5` as one number token, so this
+  // input minifies to WGSL the device accepts instead of `. 5` (which used to raise a loud naga
+  // diagnostic here). A regression in the scanner or in the printer's separator rules fails this.
+  await expect(resolveDotFiveWhitespaceMinified()).resolves.toMatchObject({ validation: { mode: "require", attempted: true, ok: true } });
+  expect((await resolveDotFiveWhitespaceMinified()).wgsl).toContain("=.5;");
 });
 
 test.skipIf(!hasDevice)("whitespace-only minification reports attempted/ok for output the device accepts", async () => {


### PR DESCRIPTION
## The issue

The whitespace minifier corrupts WGSL float literals written with a leading dot. Found by differential fuzzing (valid input → minified output must still validate on a real device):

```wgsl
// input (valid WGSL — decimal_float_literal may start with '.')
out_buf[0] = .5;
```

```wgsl
// minified output on main — INVALID
out_buf[0]=. 5;
// device: error: unable to parse right side of assignment
```

**This breaks two shaders shipping in this repo today**: `apps/docs/examples/fluid/divergence.wgsl` and `project.wgsl` both contain `*.5*` and fail under `minify: true`. Also affected: `.0`, `.5e2`, `.5e+2`, `.5f`, `-.5`, `(.5)`, `(.5).x`, `arr[.5]`, `max(.5, 1.0)`, `array<f32,2>(.5, ...)` — including inside imported modules.

## Root cause — the scanner, not the printer

The scanner's number path only opened on `/[0-9]/`, so `.5` tokenized as **two tokens**: `punct(.)` + `number(5)`:

```
"let a = .5;"  →  keyword:let | ident:a | punct:= | punct:. | number:5 | punct:;
```

Given those tokens, the printer's behavior is actually *correct* — it must keep a separator between a lone `.` and a digit to preserve fidelity for degenerate input (`. 5` written by an author must stay `. 5`). The printer had no way to recover the distinction the scanner had already destroyed.

Worse, the scanner was lying to every downstream consumer, not just the printer: `scope-walker`, `declaration-dce`, and the mangler all treat a `.` token as **member access** — so `.5` was flowing through reflection/DCE/renaming analysis as a member-access dot.

## The fix (6 lines, at the source)

```ts
// scanner.ts — number path now accepts a leading dot when followed by a digit
-    if (/[0-9]/.test(ch)) {
+    if (/[0-9]/.test(ch) || (ch === "." && /[0-9]/.test(source[i + 1] ?? ""))) {
+      if (ch === ".") step();
```

`.5` is now **one number token**. Disambiguation is total: the `.` is absorbed only when the *next character* is a digit, and neither member names nor swizzles can start with a digit — so `v.x`, `a.xyz`, `s.inner.value` are untouched, and `1.` / `1.e3` / `0x1.8p1` still enter via the leading-digit branch. The printer is deliberately unchanged: `. 5` and `1 . 5` (degenerate but re-printable input) still round-trip with their separators.

## Verification

- **Differential tokenizer probe (39 degenerate inputs, main vs this branch):** every difference involves a leading-dot literal; everything else is byte-identical (`v.x`, member chains, `1.`, `1.e3`, `0x1p3`, `0x1.8p1`, `1..5`, `.5.x`, `(.5).x`, end-of-source `.`).
- **The two fluid shaders** now resolve with `minify: true` + `validate: "require"` and pass on a real device; a new test reads the *actual repo files* with a drift guard (`toContain("*.5*")`).
- The test that #273 deliberately **pinned to this bug** is flipped and renamed ("a `.5` literal survives whitespace minification and validates") — the two PRs were coupled by design so this fix couldn't land without updating the validation guarantee's evidence.
- Red/green: 9 tests fail with main's scanner, 17/17 pass with the fix (real-device lane included).
- Full suite 1821 passed / 0 failed · `tsc -b` clean · bundle +10 B gzip · cache keys unaffected (they hash normalized *input* source, never minified text) · fuzz harnesses re-run: all F1 cases clean, corpus 151 files / 0 findings, determinism byte-identical.
- `.5` is preserved as `.5` (not normalized to `0.5`) — 1 byte cheaper and closer to the author's source.

Part of the minifier stress-test campaign (fix 2 of 3, after #273's validation safety net). Independently reviewed (adversarial audit with its own differential probe; found the fix also cures corruption shapes beyond the ones originally reported).
