### PR TITLE
TGEIST-09: galería /examples con chrome geistdocs (lógica verbatim)

### DIFF
--- a/apps/docs-next/app/[lang]/examples/[slug]/page.tsx
+++ b/apps/docs-next/app/[lang]/examples/[slug]/page.tsx
@@ -1,0 +1,64 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { Button } from "@vercel/geistdocs/components/button";
+import { ExamplePreview } from "@/components/example-preview";
+import { ExampleSourceViewer } from "@/components/example-source-viewer";
+import { translations } from "@/geistdocs";
+// TGEIST-09: `examples`/`getExample` are the verbatim registry ported by
+// TGEIST-07 (`lib/examples-registry.ts`) -- unmodified by this ticket.
+import { examples, getExample } from "@/lib/examples-registry";
+
+interface ExampleDetailPageProps {
+  params: Promise<{ lang: string; slug: string }>;
+}
+
+export function generateStaticParams() {
+  return Object.keys(translations).flatMap((lang) =>
+    examples.map((example) => ({ lang, slug: example.meta.slug })),
+  );
+}
+
+export async function generateMetadata({
+  params,
+}: ExampleDetailPageProps): Promise<Metadata> {
+  const { slug } = await params;
+  const example = getExample(slug);
+  if (!example) return {};
+
+  return {
+    title: example.meta.title,
+    description: example.meta.description,
+  };
+}
+
+const ExampleDetailPage = async ({ params }: ExampleDetailPageProps) => {
+  const { slug } = await params;
+  const example = getExample(slug);
+  if (!example) notFound();
+
+  return (
+    <main className="mx-auto max-w-[880px] px-4 pt-12 pb-32 sm:px-6">
+      <div className="mb-6 flex flex-wrap items-end justify-between gap-4">
+        <div>
+          <h1 className="font-medium! text-heading-32 text-gray-1000 tracking-tighter sm:text-heading-40">
+            {example.meta.title}
+          </h1>
+          <p className="mt-3 max-w-2xl text-copy-16 text-gray-900">
+            {example.meta.description}
+          </p>
+        </div>
+        <Button asChild variant="outline">
+          <Link href={`/preview/${example.meta.slug}`}>Open fullscreen</Link>
+        </Button>
+      </div>
+
+      <div className="flex flex-col gap-6">
+        <ExamplePreview slug={example.meta.slug} title={example.meta.title} />
+        <ExampleSourceViewer files={example.sources} />
+      </div>
+    </main>
+  );
+};
+
+export default ExampleDetailPage;

--- a/apps/docs-next/app/[lang]/examples/layout.tsx
+++ b/apps/docs-next/app/[lang]/examples/layout.tsx
@@ -1,0 +1,18 @@
+import type { Metadata } from "next";
+
+// TGEIST-09: metadata-only wrapper -- chrome (Navbar/Footer) already comes
+// from `app/[lang]/layout.tsx`; `/examples` does not get a bespoke sidebar
+// like the old app's `ExamplesSidebar` (Decision 1': chrome rehecho with
+// geistdocs primitives, same as the `/templates`-style top-level sections in
+// the reference geistdocs deployment).
+export const metadata: Metadata = {
+  title: {
+    default: "Examples",
+    template: "%s | Examples",
+  },
+  description: "Interactive WebGPU examples built with vgpu.",
+};
+
+export default function ExamplesLayout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/apps/docs-next/app/[lang]/examples/page.tsx
+++ b/apps/docs-next/app/[lang]/examples/page.tsx
@@ -1,0 +1,36 @@
+import { ExampleCard } from "@/components/example-card";
+import { translations } from "@/geistdocs";
+// TGEIST-09: `examplesMetadata` is the verbatim, unmodified data source
+// ported by TGEIST-07 (`lib/examples-metadata.ts`) -- this page only decides
+// how it is painted, not what is shown or in what order.
+import { examplesMetadata } from "@/lib/examples-metadata";
+
+const title = "Examples";
+const description =
+  "Fullscreen shaders, compute pipelines, raw WebGPU interop, and read-only source files compiled directly by this docs app.";
+
+export const metadata = {
+  title,
+  description,
+};
+
+export const generateStaticParams = () => Object.keys(translations).map((lang) => ({ lang }));
+
+const ExamplesPage = () => (
+  <main className="mx-auto max-w-[1200px] px-4 pb-32 sm:px-6">
+    <header className="pt-12 pb-8 sm:pt-16 sm:pb-10">
+      <h1 className="font-medium! text-heading-32 text-gray-1000 tracking-tighter sm:text-heading-40">
+        {title}
+      </h1>
+      <p className="mt-3 max-w-2xl text-copy-16 text-gray-900">{description}</p>
+    </header>
+
+    <div className="grid gap-5 sm:grid-cols-2 xl:grid-cols-3">
+      {examplesMetadata.map((example) => (
+        <ExampleCard example={example} key={example.slug} />
+      ))}
+    </div>
+  </main>
+);
+
+export default ExamplesPage;

--- a/apps/docs-next/components/example-card.tsx
+++ b/apps/docs-next/components/example-card.tsx
@@ -1,0 +1,55 @@
+import Image from "next/image";
+import Link from "next/link";
+import { Badge } from "@vercel/geistdocs/components/badge";
+import { Card, CardContent, CardHeader, CardTitle } from "@vercel/geistdocs/components/card";
+import type { ExampleMeta } from "@/lib/example-meta";
+
+// TGEIST-09: chrome for the `/examples` gallery is rehecho with geistdocs
+// primitives (`Card`, `Badge`) -- the data shown (title, description,
+// thumbnail, tags/capabilities) comes verbatim from `examples-metadata.ts`
+// (TGEIST-07), unmodified by this component.
+interface ExampleCardProps {
+  example: ExampleMeta;
+}
+
+const MAX_VISIBLE_TAGS = 3;
+
+export function ExampleCard({ example }: ExampleCardProps) {
+  return (
+    <Link className="block no-underline" href={`/examples/${example.slug}`}>
+      <Card className="group h-full gap-0 overflow-hidden p-0 transition-colors hover:border-gray-alpha-600">
+        <div className="relative aspect-video w-full overflow-hidden bg-gray-1000">
+          {example.thumbnail ? (
+            <Image
+              alt={example.title}
+              className="object-cover"
+              fill
+              loading="eager"
+              sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
+              src={example.thumbnail}
+            />
+          ) : (
+            <div className="absolute inset-0 bg-gradient-to-br from-blue-700/40 via-purple-700/20 to-black" />
+          )}
+        </div>
+        <CardHeader className="px-4 pt-4">
+          <CardTitle className="text-[16px] leading-tight group-hover:text-blue-700">
+            {example.title}
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="flex flex-1 flex-col gap-3 px-4 pb-4">
+          <p className="line-clamp-2 text-copy-14 text-gray-900">{example.description}</p>
+          {example.tags.length > 0 ? (
+            <ul className="flex flex-wrap gap-1.5" aria-label="Tags">
+              {example.tags.slice(0, MAX_VISIBLE_TAGS).map((tag) => (
+                <li key={tag}>
+                  <Badge variant="secondary">{tag}</Badge>
+                </li>
+              ))}
+            </ul>
+          ) : null}
+        </CardContent>
+      </Card>
+    </Link>
+  );
+}

--- a/apps/docs-next/components/example-preview.tsx
+++ b/apps/docs-next/components/example-preview.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+// TGEIST-09: verbatim behaviour of the old app's `ExamplePreview` (embeds the
+// `/preview/<slug>` route -- owned by TGEIST-08 -- in an iframe and surfaces
+// `postMessage`-reported render errors), only the chrome around it changed.
+interface ExamplePreviewProps {
+  slug: string;
+  title: string;
+}
+
+interface PreviewErrorMessage {
+  type: "vgpu-example-error";
+  slug: string;
+  message: string;
+}
+
+function isPreviewErrorMessage(value: unknown): value is PreviewErrorMessage {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    (value as PreviewErrorMessage).type === "vgpu-example-error" &&
+    typeof (value as PreviewErrorMessage).slug === "string" &&
+    typeof (value as PreviewErrorMessage).message === "string"
+  );
+}
+
+export function ExamplePreview({ slug, title }: ExamplePreviewProps) {
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    setError(null);
+  }, [slug]);
+
+  useEffect(() => {
+    const onMessage = (event: MessageEvent) => {
+      if (event.origin !== window.location.origin) return;
+      if (!isPreviewErrorMessage(event.data)) return;
+      if (event.data.slug !== slug) return;
+      setError(event.data.message);
+    };
+    window.addEventListener("message", onMessage);
+    return () => window.removeEventListener("message", onMessage);
+  }, [slug]);
+
+  return (
+    <div className="relative aspect-video w-full overflow-hidden rounded-lg border bg-black shadow-2xl">
+      <iframe
+        allow="fullscreen"
+        className="h-full w-full border-0 bg-black"
+        src={`/preview/${slug}`}
+        title={`${title} preview`}
+      />
+      {error ? (
+        <div className="absolute inset-0 overflow-auto bg-black/85 p-5 text-sm text-red-300 backdrop-blur-sm">
+          <div className="mb-3 font-semibold text-red-200">Preview error</div>
+          <pre className="whitespace-pre-wrap rounded-md border border-red-800/40 bg-red-950/40 p-3 font-mono text-xs leading-5">
+            {error}
+          </pre>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/docs-next/components/example-source-viewer.tsx
+++ b/apps/docs-next/components/example-source-viewer.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import { CodeBlock } from "@vercel/geistdocs/components/code-block";
+import { useState } from "react";
+import { cn } from "@/lib/utils";
+
+// TGEIST-09: reads the example's source files exactly as returned by
+// `getExample()`/`examples-registry.ts` (TGEIST-07, verbatim) and renders
+// them with geistdocs' own `CodeBlock` chrome instead of the old app's
+// custom `CodeViewer`/Shiki setup. A lightweight in-house file switcher is
+// used instead of `CodeBlockTabs` (that helper's bundled types don't line up
+// with a plain array of file tabs), keeping this to geistdocs primitives
+// without fighting an unrelated typing mismatch.
+export interface SourceFile {
+  readonly name: string;
+  readonly lang: string;
+  readonly code: string;
+}
+
+interface ExampleSourceViewerProps {
+  files: readonly SourceFile[];
+}
+
+export function ExampleSourceViewer({ files }: ExampleSourceViewerProps) {
+  const [activeName, setActiveName] = useState(files[0]?.name);
+
+  if (files.length === 0) {
+    return (
+      <p className="rounded-lg border border-dashed p-4 text-copy-14 text-gray-900">
+        No source files available.
+      </p>
+    );
+  }
+
+  const active = files.find((file) => file.name === activeName) ?? files[0];
+
+  return (
+    <div className="flex flex-col gap-3">
+      {files.length > 1 ? (
+        <div className="flex flex-wrap gap-1 overflow-x-auto rounded-sm border bg-background-200 p-1">
+          {files.map((file) => (
+            <button
+              className={cn(
+                "rounded-sm px-3 py-1.5 font-mono text-sm transition-colors",
+                file.name === active.name
+                  ? "bg-background-100 text-gray-1000"
+                  : "text-gray-800 hover:text-gray-1000",
+              )}
+              key={file.name}
+              onClick={() => setActiveName(file.name)}
+              type="button"
+            >
+              {file.name}
+            </button>
+          ))}
+        </div>
+      ) : null}
+      <CodeBlock title={active.name}>
+        <code>{active.code}</code>
+      </CodeBlock>
+    </div>
+  );
+}


### PR DESCRIPTION
## TGEIST-09 — F3 · Galería `/examples` con chrome geistdocs

Rehace el chrome visual de `/examples` con primitivas geistdocs (`Card`, `Badge`, `CodeBlock`), manteniendo la **lógica verbatim** de `examples-registry.ts` / `examples-metadata.ts` (TGEIST-07, sin editar).

### Archivos nuevos
- `apps/docs-next/app/[lang]/examples/{layout,page}.tsx` — galería: grid de `ExampleCard`, `generateStaticParams` por `lang` (en/cn).
- `apps/docs-next/app/[lang]/examples/[slug]/page.tsx` — detalle: título/descripción, botón "Open fullscreen" → `/preview/<slug>` (TGEIST-08), `ExamplePreview` (iframe) + `ExampleSourceViewer` (selector de archivo + `CodeBlock` geistdocs).
- `apps/docs-next/components/example-card.tsx` — card nueva (`Card`/`Badge` de `@vercel/geistdocs`), datos (thumbnail/título/descripción/tags) verbatim del vocabulario.
- `apps/docs-next/components/example-preview.tsx`, `example-source-viewer.tsx` — soporte nuevo para el detalle.

### Decisión de i18n (verificada empíricamente)
La ruta vive bajo **`app/[lang]/examples/**`**, no en `app/examples/**` top-level.

El proxy (`createProxy` de `@vercel/geistdocs`, `hideLocale: 'default-locale'`) reescribe toda request sin prefijo de idioma a `/<defaultLang><pathname>` vía `NextResponse.rewrite` **antes** de que Next.js resuelva rutas de App Router. Una request a `/examples` se reescribe internamente a `/en/examples`, y solo hace match si la carpeta vive bajo `app/[lang]/`.

Confirmado con curl contra `next start`:
```
GET /examples        -> 200, x-middleware-rewrite: /en/examples
GET /en/examples      -> 307 -> /examples   (hideLocale: default-locale)
GET /cn/examples      -> 200
GET /examples/gradient -> 200, title "Simple Gradient | Examples"
GET /examples/does-not-exist -> 404
```

Y con el precedente en vivo de geistdocs 1.15.2 en producción: `eve/apps/docs/app/[lang]/{templates,integrations,resources}` — ninguna sección "fuera de /docs" vive fuera de `[lang]`, igual que `(home)`.

`docsHref()` ya trae la excepción de `/examples` (TGEIST-05, `lib/remark-geist/doc-link-index.mjs`), por lo que `[Examples](/examples)` en `content/docs/meta.json` no lleva prefijo `/docs` — verificado en el HTML de `/docs/cli` (`href="/examples"`, sin `/docs/examples`).

### Verificación
- `pnpm --filter docs-next build` verde: `/[lang]/examples` y `/[lang]/examples/[slug]` generan 19 ejemplos × 2 langs = 38 páginas estáticas, sin error.
- `git diff` vacío en `lib/examples-registry.ts`, `example-meta.ts`, `example-thumbs.generated.ts`, `example-slugs.ts`.
- `apps/docs/**` (app vieja) intacto — sin cambios.
- `apps/preview/**` no tocado (dominio de TGEIST-08, en paralelo).
- Screenshots de la galería y el detalle adjuntos abajo.

### Coordinación F3
Corre en paralelo con TGEIST-08 (previews), TGEIST-10 (landing) y TGEIST-11 (get-started/content) — archivos disjuntos, sin tocar `app/preview/**`, la home, ni `package.json`.

**NO mergear** — abierto para revisión, ver TGEIST-INDEX.