### PR TITLE
feat(docs): TGEIST-11 — get-started as real MDX + /docs landing + root meta title/description

### DIFF
--- a/apps/docs-next/content/docs/get-started/agents.mdx
+++ b/apps/docs-next/content/docs/get-started/agents.mdx
@@ -1,0 +1,26 @@
+---
+title: Agents
+description: vgpu is agent-first — point your agent at npx vgpu, or install the vgpu skill.
+---
+
+# Agents
+
+vgpu is an agent-first library. The full documentation ships inside the npm package, versioned with the API in your `node_modules` — an agent can learn and verify vgpu without leaving the terminal.
+
+## Point your agent at the docs
+
+```bash
+npx vgpu
+```
+
+That's the whole instruction. The command prints its own guide — starting with the agent get-started, `vgpu docs cat getting-started.md` — plus the tools to explore and search every reference page, guide, and error code. Your agent takes it from there.
+
+## Install the skill
+
+```bash
+npx skills add vercel-labs/vgpu
+```
+
+For agents that support skills, this installs the vgpu skill: the same reference docs plus guidance on when to load each one, so the agent reads only the doc it needs.
+
+Everything an agent learns this way, you can read on this site — it is the human mirror of the same content.

--- a/apps/docs-next/content/docs/get-started/meta.json
+++ b/apps/docs-next/content/docs/get-started/meta.json
@@ -1,0 +1,9 @@
+{
+  "title": "Get started",
+  "pages": [
+    "agents",
+    "web",
+    "node",
+    "..."
+  ]
+}

--- a/apps/docs-next/content/docs/get-started/node.mdx
+++ b/apps/docs-next/content/docs/get-started/node.mdx
@@ -1,0 +1,157 @@
+---
+title: Node.js
+description: Render headless in Node.js through Dawn — save a PNG or assert on pixels in a test.
+---
+
+# Node.js
+
+In Node.js, vgpu renders headless through Dawn — the same API, no canvas, no browser. Import `init` from `vgpu/node`, render into an offscreen [`Target`](/docs/reference/vgpu/target#target), and read the pixels back.
+
+## Install
+
+```sh
+npm install vgpu
+```
+
+On Linux, vgpu resolves a working Dawn binary automatically. When the stock
+prebuild matches your system it is used directly; on older-GLIBC hosts vgpu
+downloads its own portable Dawn build from GitHub Releases, verified against a
+pinned SHA-256, and caches it locally. If your install runs with scripts
+disabled (`--ignore-scripts`, pnpm v10 allow-lists), the download happens
+lazily on first `init()` instead — or run it yourself:
+
+```sh
+npx vgpu install-dawn
+```
+
+Before your first render, `npx vgpu doctor` checks the machine end to end — it
+acquires an adapter and renders a real frame, and when something is missing it
+prints the exact fix as JSON. Run it once before debugging anything else.
+
+> Good to know: no GPU and no driver? `npx vgpu install-software-renderer` sets
+> up a portable CPU renderer once; `init()` uses it automatically after that.
+
+Air-gapped or custom environments can point `VGPU_DAWN_BINARY` at a local
+binary. When no binary can be resolved, `init()` throws a structured
+`VGPU-NODE-PREBUILD-MISSING` error that names the exact reason and fix. See
+[`createNodeAdapter`](/docs/reference/vgpu-adapter-node/create-node-adapter) for the
+full resolution order.
+
+## Choose an environment
+
+Start every new machine with `npx vgpu doctor`. After that, choose the mode
+that matches what the environment is supposed to guarantee:
+
+| Environment | Setup | Runtime choice |
+| --- | --- | --- |
+| Local workstation | Install the normal GPU driver | `init()` — use normal system discovery |
+| Server or sandbox without a GPU | Run `npx vgpu install-software-renderer` once | `init()` — use the cached CPU renderer only when normal discovery finds nothing |
+| Deterministic screenshots and pixel tests | Cache the software renderer in the CI image | `init({ adapter: "software" })` — force the same Mesa renderer everywhere |
+| GPU-required CI | Install the vendor driver | `init({ adapter: "hardware" })` — fail instead of silently running on CPU |
+| Air-gapped runner | Pre-populate the Dawn and software-renderer caches while the image has network access | Select `auto`, `hardware`, or `software` normally at runtime |
+
+### Configure it from TypeScript
+
+```ts
+import { init } from "vgpu/node";
+
+const gpu = await init();                        // auto: normal adapter first, cached CPU fallback last
+const hardware = await init({ adapter: "hardware" }); // require a real GPU
+const software = await init({ adapter: "software" }); // force deterministic CPU rendering
+
+console.log(software.adapter);
+// { name: "llvmpipe: Mesa 25.0.7 ...", type: "cpu" }
+```
+
+`auto` never downloads the software renderer. It uses lavapipe only after you
+have explicitly installed it and normal adapter discovery returned nothing.
+A working system adapter always wins.
+
+### Override it from CI
+
+Environment overrides win over the TypeScript option and announce themselves
+once on stderr, so CI can force a policy without changing application code:
+
+```sh
+VGPU_ADAPTER=software node render.mjs  # deterministic CPU pixels
+VGPU_ADAPTER=hardware pnpm test        # require a GPU and fail loudly without one
+```
+
+Use the SDK option for the project's declared behavior and the environment
+variable for temporary CI or debugging intervention. The browser API does not
+need this configuration — `import { init } from "vgpu"` continues to let the
+browser choose its adapter.
+
+Whichever mode you use, release the device when the process is done:
+
+```ts
+try {
+  // render, read pixels, write artifacts
+  await gpu.settled();
+} finally {
+  gpu.dispose();
+}
+```
+
+For loader resolution, distro-specific dependencies, Docker, and lifecycle
+details, see [`createNodeDevice`](/docs/reference/vgpu-adapter-node/create-node-device).
+
+## Save a PNG
+
+`target.read()` resolves to the rendered RGBA bytes. Hand them to any PNG encoder — here, `pngjs`:
+
+```ts
+import { writeFileSync } from "node:fs";
+import { PNG } from "pngjs";
+import { init, effect, target } from "vgpu/node";
+
+const gradientSource = `
+  @fragment fn fs_main(@location(0) uv: vec2f) -> @location(0) vec4f {
+    return vec4f(uv, 0.4, 1.0);
+  }
+`;
+
+const gpu = await init();
+const colorTarget = target(gpu, { size: [256, 256] });
+
+effect(gpu, gradientSource).draw(colorTarget);
+const pixels = await colorTarget.read(); // RGBA bytes
+
+const png = new PNG({ width: colorTarget.size[0], height: colorTarget.size[1] });
+png.data.set(pixels);
+writeFileSync("gradient.png", PNG.sync.write(png));
+```
+
+## Write a test
+
+The same render runs inside a test. Read the pixels and assert on them:
+
+```ts
+import { expect, test } from "vitest";
+import { init, effect, target } from "vgpu/node";
+
+const gradientSource = `
+  @fragment fn fs_main(@location(0) uv: vec2f) -> @location(0) vec4f {
+    return vec4f(uv, 0.4, 1.0);
+  }
+`;
+
+test("gradient renders", async () => {
+  const gpu = await init();
+  const colorTarget = target(gpu, { size: [64, 64] });
+
+  effect(gpu, gradientSource).draw(colorTarget);
+  const pixels = await colorTarget.read();
+
+  // center pixel: blue is the constant 0.4 (~102 of 255), alpha is 1.0
+  const center = (32 * 64 + 32) * 4;
+  expect(pixels[center + 2]).toBeGreaterThan(95);
+  expect(pixels[center + 2]).toBeLessThan(110);
+  expect(pixels[center + 3]).toBe(255);
+});
+```
+
+> Good to know: use `vgpu/mock` for deterministic unit tests that need no GPU; reach for `vgpu/node` when real Dawn/WebGPU behavior is under test.
+
+> Good to know: call `gpu.dispose()` when you are done — it stops Dawn's event
+> polling so the process exits on its own instead of hanging.

--- a/apps/docs-next/content/docs/get-started/web.mdx
+++ b/apps/docs-next/content/docs/get-started/web.mdx
@@ -1,0 +1,81 @@
+---
+title: Web
+description: Install vgpu, render a gradient to a canvas, and load .wgsl files in Next.js or Vite.
+---
+
+# Web
+
+In the browser, vgpu renders with WebGPU straight to a `<canvas>`. Install the package, write a fragment shader, and draw.
+
+## Install
+
+```sh
+npm install vgpu
+```
+
+## Render a gradient
+
+Create a context, wrap your canvas in a [`Surface`](/docs/reference/vgpu/surface#surface), and draw an effect:
+
+```ts
+import { init, effect, surface } from "vgpu";
+import gradientSource from "./gradient.wgsl";
+
+const gpu = await init();
+const canvas = document.querySelector("canvas")!;
+const canvasSurface = surface(gpu, canvas);
+const gradient = effect(gpu, gradientSource);
+
+gradient.draw(canvasSurface); // renders immediately
+```
+
+```wgsl
+// gradient.wgsl
+@fragment fn fs_main(@location(0) uv: vec2f) -> @location(0) vec4f {
+  return vec4f(uv, 0.4, 1.0);
+}
+```
+
+## Load .wgsl files in Next.js
+
+Add the loader rule to your Next.js config:
+
+```js
+// next.config.mjs
+const config = {
+  turbopack: {
+    rules: {
+      "*.wgsl": {
+        loaders: ["@vgpu/wgsl/loader-webpack"],
+        as: "*.js",
+      },
+    },
+  },
+};
+
+export default config;
+```
+
+> Good to know: for webpack builds, add the same loader as a module rule: `config.module.rules.push({ test: /\.wgsl$/, use: "@vgpu/wgsl/loader-webpack" })`.
+
+## Load .wgsl files in Vite
+
+Add the plugin from `@vgpu/wgsl/loader-vite`:
+
+```js
+// vite.config.js
+import { defineConfig } from "vite";
+import { wgslVitePlugin } from "@vgpu/wgsl/loader-vite";
+
+export default defineConfig({
+  plugins: [wgslVitePlugin()],
+});
+```
+
+## Type .wgsl imports
+
+Create a `wgsl-env.d.ts` in your project so TypeScript types every `.wgsl` import as a string:
+
+```tsx
+/// <reference types="@vgpu/wgsl/wgsl-types" />
+```

--- a/apps/docs-next/content/docs/index.mdx
+++ b/apps/docs-next/content/docs/index.mdx
@@ -1,0 +1,16 @@
+---
+title: Documentation
+description: Documentation for vgpu, the WebGPU library designed for agents.
+---
+
+Documentation for vgpu, the WebGPU library designed for agents.
+
+vgpu runs in two places with the same API: the browser, where WebGPU renders straight to a canvas, and Node.js, where Dawn renders headless for scripts, servers, and tests.
+
+- [Get started](/docs/get-started) — install vgpu and render with `init()`.
+- [Concepts](/docs/concepts) — context, effects, passes, frames, and render bundles.
+- [Guides](/docs/guides) — performance, testing, and shader authoring.
+- [API Reference](/docs/reference) — the full package map and generated topic pages.
+- [CLI](/docs/cli) — the `vgpu` command line.
+- [ML](/docs/ml) — running ONNX models alongside vgpu on a shared `GPUDevice`.
+- [Examples](/examples) — live WebGPU demos with read-only source views.

--- a/apps/docs-next/content/docs/index.mdx
+++ b/apps/docs-next/content/docs/index.mdx
@@ -7,10 +7,10 @@ Documentation for vgpu, the WebGPU library designed for agents.
 
 vgpu runs in two places with the same API: the browser, where WebGPU renders straight to a canvas, and Node.js, where Dawn renders headless for scripts, servers, and tests.
 
-- [Get started](/docs/get-started) — install vgpu and render with `init()`.
-- [Concepts](/docs/concepts) — context, effects, passes, frames, and render bundles.
+- [Get started](/docs/get-started) — install `vgpu` and render with `init()`.
+- [Concepts](/docs/concepts) — learn `Gpu`, `set()`, targets, frames, bundles, and adapters.
 - [Guides](/docs/guides) — performance, testing, and shader authoring.
-- [API Reference](/docs/reference) — the full package map and generated topic pages.
+- [API Reference](/docs/reference) — package map and generated topic pages.
 - [CLI](/docs/cli) — the `vgpu` command line.
 - [ML](/docs/ml) — running ONNX models alongside vgpu on a shared `GPUDevice`.
 - [Examples](/examples) — live WebGPU demos with read-only source views.

--- a/apps/docs-next/content/docs/meta.json
+++ b/apps/docs-next/content/docs/meta.json
@@ -1,5 +1,7 @@
 {
   "root": true,
+  "title": "Documentation",
+  "description": "Documentation for vgpu, the WebGPU library designed for agents.",
   "pages": [
     "get-started",
     "concepts",

--- a/docs/nav.json
+++ b/docs/nav.json
@@ -1,4 +1,8 @@
 {
+  "root": {
+    "title": "Documentation",
+    "description": "Documentation for vgpu, the WebGPU library designed for agents."
+  },
   "packageOrder": [
     "vgpu",
     "vgpu/scene",

--- a/packages/vgpu/lib/docs/generate/generate-geistdocs.js
+++ b/packages/vgpu/lib/docs/generate/generate-geistdocs.js
@@ -374,6 +374,26 @@ export function buildMetaFiles(nav, pages) {
   rootMeta.pages = rootPages;
   files.set("meta.json", serializeJson(rootMeta));
 
+  // -- get-started: literal order from the Get started section (TGEIST-11) --
+  // The 3 pages here are hand-authored .mdx (EXTERNALLY_OWNED_META_ENTRIES), but their *order* has
+  // no reason to be hand-authored too: docs/nav.json's "Get started" section already declares it
+  // (Agents, Web, Node.js), the same source every other section's meta.json is derived from below.
+  // Emitting this file — instead of leaving it for a human to create by hand next to hand-authored
+  // pages — is what makes `prune()`'s "I own every meta.json" invariant actually true: an
+  // unemitted-but-present get-started/meta.json is exactly the file `prune()` deletes as an orphan
+  // on the next run, sidebar order silently reverting to alphabetical. Deriving it here removes the
+  // hand-authored copy instead of trying to make prune() smarter about what it should spare.
+  const getStartedSection = findSection(nav, "Get started");
+  if (getStartedSection) {
+    files.set(
+      "get-started/meta.json",
+      serializeJson({
+        title: getStartedSection.title,
+        pages: [...sectionItemSlugs(getStartedSection, "/get-started"), "..."],
+      }),
+    );
+  }
+
   // -- concepts: literal order from the Concepts section ---------------------
   const conceptsSection = findSection(nav, "Concepts");
   if (conceptsSection) {
@@ -434,6 +454,11 @@ export function buildMetaFiles(nav, pages) {
   // either way it silently hides a page, so refuse to emit.
   for (const [metaPath, contents] of files) {
     const dir = metaPath === "meta.json" ? "" : `${dirname(metaPath)}/`;
+    // The whole subtree is hand-authored (get-started/**.mdx today) when `dir` itself is one of
+    // EXTERNALLY_OWNED_META_ENTRIES: every entry in *this* meta.json points at a page this target
+    // does not emit, by construction, so none of them can resolve against `emittedPaths` below.
+    const dirIsExternallyOwned = EXTERNALLY_OWNED_META_ENTRIES.includes(dir.replace(/\/$/u, ""));
+    if (dirIsExternallyOwned) continue;
     for (const entry of JSON.parse(contents).pages ?? []) {
       if (entry === "..." || /^---.*---$/u.test(entry) || /^(?:external:)?\[.*\]\(.*\)$/u.test(entry)) continue;
       if (EXTERNALLY_OWNED_META_ENTRIES.includes(entry)) continue;

--- a/packages/vgpu/lib/docs/generate/generate-geistdocs.js
+++ b/packages/vgpu/lib/docs/generate/generate-geistdocs.js
@@ -363,7 +363,16 @@ export function buildMetaFiles(nav, pages) {
     const segments = href.slice(1).split("/");
     rootPages.push(segments.length === 1 ? segments[0] : `[${section.title}](/docs${href})`);
   }
-  files.set("meta.json", serializeJson({ root: true, pages: rootPages }));
+  // Root branding (TGEIST-11 gap 2, flagged in the #278 review): nav.json's optional
+  // `root.{title,description}` becomes content/docs/meta.json's own `title`/`description`, the
+  // same keys `geistdocsMetaSchema` already accepts on every other directory's meta.json. nav.json
+  // (TGEIST-03) stays the single source; this emitter stays a mechanical translation, same as every
+  // section above — no new concept, just two more optional fields carried through.
+  const rootMeta = { root: true };
+  if (typeof nav.root?.title === "string") rootMeta.title = nav.root.title;
+  if (typeof nav.root?.description === "string") rootMeta.description = nav.root.description;
+  rootMeta.pages = rootPages;
+  files.set("meta.json", serializeJson(rootMeta));
 
   // -- concepts: literal order from the Concepts section ---------------------
   const conceptsSection = findSection(nav, "Concepts");


### PR DESCRIPTION
feat(docs): TGEIST-11 — get-started as real MDX + /docs landing + root meta title/description

- content/docs/get-started/{agents,web,node}.mdx: migrated from
  apps/docs/content/get-started/*.mdx as real hand-authored MDX (Decision 5).
  Frontmatter normalized to title + description (from the old summary field);
  prevNext dropped (the sidebar derives it). Body is byte-identical to the
  source (verified with a plain-text diff) — only the frontmatter changed.
  content/docs/get-started/meta.json orders them Agents, Web, Node.js, the
  same order already curated in docs/nav.json's Get started section.

- content/docs/index.mdx: the /docs landing page (F2 gap flagged in the #278
  review — the template's demo index.mdx was removed and nothing replaced
  it). Copy is the docs site's existing intro text, verbatim: the meta
  description from the old apps/docs/app/docs/layout.tsx ("Documentation for
  vgpu, the WebGPU library designed for agents.") plus the platform-neutral
  intro paragraph from the old get-started overview page, followed by a
  plain link list to every top-level section (styled by geistdocs, no new
  component).

- docs/nav.json: added an optional root.{title,description}, mirroring the
  same text used in content/docs/index.mdx, as the single source for the
  root meta.json's branding.

- packages/vgpu/lib/docs/generate/generate-geistdocs.js: buildMetaFiles now
  carries nav.root.title/description through to the emitted root meta.json
  (both optional keys already accepted by geistdocsMetaSchema). Minimal,
  additive change — no other meta.json shape changes; re-run is still
  idempotent (verified: zero diff besides the two new keys).

Verified:
- generate:docs:geistdocs / check:docs-content / check-drift.js /
  check-nav-coverage.mjs all green; the generator's prune only touched
  meta.json — get-started/**.mdx and index.mdx are untouched by it.
- pnpm --filter docs-next build: green, /docs and /docs/get-started/* are
  in the static output.
- check:mdast-parity: green (98 pages incl. get-started + index.mdx; no
  text lost, no unresolved link, no un-highlightable fence).
- /api/search indexes both the hand-authored pages (agents/web/node,
  index.mdx) and the generated corpus in the same run; root meta.json's new
  title ("Documentation") already surfaces in the search breadcrumbs.

Refs: TGEIST-11, TGEIST-04/#278 (root meta gap, get-started/index.mdx
ownership boundary).

---

## Update after review (commit b9664d64)

**Governance note (explicit trail requested by orchestrator):** this PR
touches `docs/nav.json` and `packages/vgpu/lib/docs/generate/generate-geistdocs.js`,
both listed as **prohibited files** in TGEIST-11's own ticket scope. This was
**authorized by the orchestrator's dispatch** for gap 2 ("root meta.json no
tiene title/description ... quizás nav.json+generador (mínimo)") — the
reviewer flagged that this authorization wasn't visible from the diff alone,
so recording it here explicitly. Both files are owned by already-merged
tickets TGEIST-03 (`nav.json`) and TGEIST-04 (`generate-geistdocs.js`); every
change in both commits is minimal and mechanical (carry two optional fields
through / derive one more meta.json the same way concepts and ml already
are), and every existing gate for those files
(`check:docs-content`, `check-drift.js`, `check-nav-coverage.mjs`) stayed
green across both commits, plus a fresh idempotency check (two consecutive
generator runs, zero diff).

**Bug fixed (the reviewer's main finding):** `content/docs/get-started/meta.json`
was missing from the first commit, so the sidebar/prev-next order fell back
to alphabetical (Agents, **Node.js, Web**) instead of the curated order
(Agents, **Web, Node.js**) already declared in `docs/nav.json`'s "Get
started" section. Root cause: `generate-geistdocs.js`'s `prune()` treats
*any* file named `meta.json` as generator-owned, with no exemption for
`EXTERNALLY_OWNED_META_ENTRIES` directories, so a hand-authored copy is
silently deleted on the next `generate:docs:geistdocs` run — exactly what
happened between my first commit and my own verification.

Fix (option b of the two offered): `buildMetaFiles()` now derives
`get-started/meta.json` from `docs/nav.json`'s "Get started" section via the
existing `sectionItemSlugs()` helper — the same mechanism already used for
`concepts/meta.json` and `ml/meta.json` — instead of hand-authoring it. Once
the emitter produces the file itself, it is part of the `expected` set
`prune()` already respects, so no change to `prune()`'s ownership predicate
was needed at all (rejected option a: broadening what `prune()` spares is a
wider-blast-radius change for a problem that a one-line addition to the
existing nav.json-derivation pattern already solves). Verified post-fix:
`next start` + curl against `/docs/get-started/agents`'s RSC payload now
shows `agents, web, node` in that order; the reviewer's own prune-landmine
repro (drop the file, rerun the generator) now reports "SURVIVED".

**Landing bullets (minor):** replaced two paraphrased `content/docs/index.mdx`
bullets with the literal text they were paraphrasing, found in
`apps/docs/app/page.tsx`'s `docLinks` array (old homepage): Concepts now
reads "learn `Gpu`, `set()`, targets, frames, bundles, and adapters"
(verbatim); API Reference now reads "package map and generated topic pages"
(verbatim). The Guides/CLI/ML bullets have **no equivalent legacy source** —
`docLinks` only ever had 4 entries (Get started, Concepts, API Reference,
Examples) — so those three remain original prose, flagged here rather than
miscredited as ported text.
