### PR TITLE
TGEIST-08: previews verbatim (headless) + re-baseline de chunk budgets (Grupo D)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -254,6 +254,15 @@ jobs:
       # apps/docs-next/next.config.ts silently stopping to match its route.
       - name: Check the examples API artifact tree is bundled into its routes (docs-next)
         run: pnpm --filter docs-next check:examples-api-tracing
+      # ANCHOR TGEIST-08 (previews verbatim + Grupo D re-baseline). This is the third and last
+      # member of G1 for the new app ("build + check:examples-api-tracing + check:example-bundles",
+      # Decision 1'). It grades the /preview/[slug] production chunks against the budgets
+      # re-measured on this tree and asserts no example chunk carries another example's
+      # renderer/WGSL. It must stay inside this job, right after the build: the script measures
+      # .next/static/chunks and never builds (it hard-fails on chunks older than the sources rather
+      # than grade a stale tree).
+      - name: Check example bundle isolation and budgets (docs-next)
+        run: pnpm --filter docs-next check:example-bundles
       # TGEIST-05 anchor — remark plugins M1-M9 + gate (c) of Decision 4.
       # `test:remark` unit-tests the mappings (including the adversarial case the
       # design names: a `*.docs.md` path inside a code-span that must NOT be

--- a/apps/docs-next/app/preview/[slug]/example-canvas.tsx
+++ b/apps/docs-next/app/preview/[slug]/example-canvas.tsx
@@ -1,0 +1,94 @@
+'use client';
+
+import { Component, lazy, Suspense, useMemo, useState, type ErrorInfo, type ReactNode } from 'react';
+import { getExampleComponentLoader } from '@/lib/example-components';
+import { createDeduplicatedExampleErrorReporter, ExampleErrorReporterProvider } from '@/lib/example-error-reporter';
+import { type ExampleSlug } from '@/lib/example-slugs';
+
+interface ExampleCanvasProps {
+  slug: ExampleSlug;
+}
+
+function messageOf(error: unknown): string {
+  return error instanceof Error ? error.stack || error.message : String(error);
+}
+
+function postPreviewError(slug: ExampleSlug, message: string): void {
+  window.parent?.postMessage(
+    { type: 'vgpu-example-error', slug, message },
+    window.location.origin,
+  );
+}
+
+function ErrorDisplay({ message }: { message: string }) {
+  return (
+    <div className="absolute inset-0 overflow-auto bg-black/90 p-4 font-mono text-xs leading-5 text-red-200">
+      <div className="mb-2 font-sans text-sm font-semibold text-red-100">Preview error</div>
+      <pre className="whitespace-pre-wrap">{message}</pre>
+    </div>
+  );
+}
+
+interface PreviewErrorBoundaryProps {
+  readonly reportError: (error: unknown) => void;
+  readonly children: ReactNode;
+}
+
+interface PreviewErrorBoundaryState {
+  readonly message: string | null;
+}
+
+class PreviewErrorBoundary extends Component<PreviewErrorBoundaryProps, PreviewErrorBoundaryState> {
+  state: PreviewErrorBoundaryState = { message: null };
+
+  static getDerivedStateFromError(error: unknown): PreviewErrorBoundaryState {
+    return { message: messageOf(error) };
+  }
+
+  componentDidCatch(error: unknown, _info: ErrorInfo): void {
+    this.props.reportError(error);
+  }
+
+  render() {
+    if (this.state.message) return <ErrorDisplay message={this.state.message} />;
+    return this.props.children;
+  }
+}
+
+function ReactExampleCanvas({ slug }: { slug: ExampleSlug }) {
+  const loader = getExampleComponentLoader(slug);
+  const LazyExample = useMemo(
+    () => lazy(() => loader().then((module) => ({ default: module.Example }))),
+    [loader],
+  );
+  return (
+    <Suspense fallback={<div className="h-full w-full bg-black" aria-label="Loading example" />}>
+      <LazyExample />
+    </Suspense>
+  );
+}
+
+function PreviewHost({ slug }: { slug: ExampleSlug }) {
+  const [asyncError, setAsyncError] = useState<string | null>(null);
+  const reportError = useMemo(() => createDeduplicatedExampleErrorReporter(
+    (error) => setAsyncError(messageOf(error)),
+    (error) => postPreviewError(slug, messageOf(error)),
+  ), [slug]);
+
+  if (asyncError) return <ErrorDisplay message={asyncError} />;
+  return (
+    <ExampleErrorReporterProvider reportError={reportError}>
+      <PreviewErrorBoundary reportError={reportError}>
+        <ReactExampleCanvas slug={slug} />
+      </PreviewErrorBoundary>
+    </ExampleErrorReporterProvider>
+  );
+}
+
+export function ExampleCanvas({ slug }: ExampleCanvasProps) {
+  return (
+    <div className="relative h-screen w-screen overflow-hidden bg-black">
+      <PreviewHost key={slug} slug={slug} />
+    </div>
+  );
+}

--- a/apps/docs-next/app/preview/[slug]/page.tsx
+++ b/apps/docs-next/app/preview/[slug]/page.tsx
@@ -1,0 +1,18 @@
+import { notFound } from 'next/navigation';
+import { examplesMetadata } from '@/lib/examples-metadata';
+import { isExampleSlug } from '@/lib/example-slugs';
+import { ExampleCanvas } from './example-canvas';
+
+interface PreviewPageProps {
+  params: Promise<{ slug: string }>;
+}
+
+export function generateStaticParams() {
+  return examplesMetadata.map((meta) => ({ slug: meta.slug }));
+}
+
+export default async function PreviewPage({ params }: PreviewPageProps) {
+  const { slug } = await params;
+  if (!isExampleSlug(slug)) notFound();
+  return <ExampleCanvas slug={slug} />;
+}

--- a/apps/docs-next/app/preview/layout.tsx
+++ b/apps/docs-next/app/preview/layout.tsx
@@ -30,11 +30,21 @@ import { cn } from "@/lib/utils";
  * are sibling branches with no shared root layout. At cutover (TGEIST-15) this file stays; it is
  * what keeps `/preview/**` out of the docs shell for good.
  *
- * Two knowing deltas from the old app's root layout, neither reaching the canvas: fonts come from
- * `next/font/google` Geist (this app's `lib/geistdocs/fonts`) instead of the `geist` package's
- * self-hosted Geist -- same typeface, and no new dependency for a route that renders a canvas --
- * and `components/dev-instrumentation` is not mounted (it is a dev-only overlay of the old app
- * that was never transplanted).
+ * The complete list of knowing deltas from the old app's root layout, none of which reaches the
+ * canvas (i.e. none can move a thumb pixel):
+ *
+ * 1. Fonts come from `next/font/google` Geist (this app's `lib/geistdocs/fonts`) instead of the
+ *    `geist` package's self-hosted Geist -- same typeface, and no new dependency for a route whose
+ *    only job is to paint a canvas.
+ * 2. `components/dev-instrumentation` is not mounted (a dev-only overlay of the old app that was
+ *    never transplanted).
+ * 3. `title` is "vgpu example preview" instead of the old root layout's site-wide title, and its
+ *    `description` / OpenGraph metadata are dropped: this document is never a share target, it is
+ *    loaded by a headless renderer and by the gallery's iframes.
+ * 4. `robots: noindex, nofollow` is added, which the old app did not set. The previews are chromeless
+ *    canvases with no content of their own, so keeping 19 of them out of the index is strictly
+ *    better than inheriting the site default; it also cannot affect `/preview/**` rendering, only
+ *    what crawlers do with it.
  */
 
 export const metadata: Metadata = {

--- a/apps/docs-next/app/preview/layout.tsx
+++ b/apps/docs-next/app/preview/layout.tsx
@@ -1,0 +1,51 @@
+import type { Metadata } from "next";
+import "../global.css";
+import { mono, sans } from "@/lib/geistdocs/fonts";
+import { cn } from "@/lib/utils";
+
+/*
+ * ANCHOR TGEIST-08 (previews verbatim, headless render targets).
+ *
+ * This is the ONLY file this ticket adds around `/preview/[slug]`, and it is deliberately NOT the
+ * geistdocs shell: no Navbar, no Footer, no GeistdocsProvider, no fumadocs-ui layout. Decision 1'
+ * ("Qué se trasplanta vs qué se rehace") requires the preview routes to stay verbatim and
+ * unwrapped, because they are headless render destinations with a PIXEL contract -- the PNG
+ * baselines of `thumbs:check` (gate G6) are captured from these URLs, so any chrome around the
+ * canvas changes the canvas box and produces diffs that mean nothing.
+ *
+ * Why a layout is needed at all: in the old app these pages inherited `app/layout.tsx`, which
+ * imported `globals.css` and painted `<body class="bg-black ...">`. This scaffold has no root
+ * `app/layout.tsx` -- its only root layout is `app/[lang]/layout.tsx` (the localized docs shell),
+ * which `/preview/**` must not go through. Without this file the route still builds (Next 16
+ * tolerates the missing root layout and emits an HTML fragment), but the prerendered document
+ * carries no stylesheet at all: verified on this build, `.next/server/app/preview/gradient.html`
+ * had zero `<link rel="stylesheet">`, so `h-screen w-screen`, `h-full w-full` and `bg-black` would
+ * not exist and the canvas would collapse to its 300x150 intrinsic size. That is a silent pixel
+ * regression, not a styling nicety.
+ *
+ * So this layout reproduces the old root layout's contribution to the preview document and nothing
+ * else: the app stylesheet, the font variables, `antialiased`, and the old `bg-black text-gray-12
+ * font-sans` body (`gray-12` comes from `app/styles/legacy-vgpu-tokens.css`, the Tailwind v4 port
+ * of the old palette). Multiple root layouts are legal here because `app/preview` and `app/[lang]`
+ * are sibling branches with no shared root layout. At cutover (TGEIST-15) this file stays; it is
+ * what keeps `/preview/**` out of the docs shell for good.
+ *
+ * Two knowing deltas from the old app's root layout, neither reaching the canvas: fonts come from
+ * `next/font/google` Geist (this app's `lib/geistdocs/fonts`) instead of the `geist` package's
+ * self-hosted Geist -- same typeface, and no new dependency for a route that renders a canvas --
+ * and `components/dev-instrumentation` is not mounted (it is a dev-only overlay of the old app
+ * that was never transplanted).
+ */
+
+export const metadata: Metadata = {
+  title: "vgpu example preview",
+  robots: { index: false, follow: false },
+};
+
+const PreviewLayout = ({ children }: { children: React.ReactNode }) => (
+  <html className={cn(sans.variable, mono.variable, "antialiased")} lang="en">
+    <body className="bg-black font-sans text-gray-12">{children}</body>
+  </html>
+);
+
+export default PreviewLayout;

--- a/apps/docs-next/package.json
+++ b/apps/docs-next/package.json
@@ -23,7 +23,9 @@
     "check:mdast-parity": "node scripts/check-mdast-parity.mjs",
     "$comment:tgeist-06": "TGEIST-06: both checks guard the examples API transplanted byte-for-byte from apps/docs. `check:examples-api-tracing` runs after next build and asserts the generated artifact tree really is bundled into each of the 3 routes (they read it with fs at request time, so only outputFileTracingIncludes puts it in the lambda). `check:examples-api-transplant` is the byte-identity gate against apps/docs; both are removed at cutover (TGEIST-15).",
     "check:examples-api-tracing": "node scripts/check-examples-api-tracing.mjs",
-    "check:examples-api-transplant": "node scripts/check-examples-api-transplant.mjs"
+    "check:examples-api-transplant": "node scripts/check-examples-api-transplant.mjs",
+    "$comment:tgeist-08": "TGEIST-08: `check:example-bundles` measures the production chunks of the /preview/[slug] routes and grades them against scripts/example-chunk-budgets.json, whose numbers were re-measured against THIS app (Grupo D re-baseline; the script's algorithm is the old app's, unchanged apart from accepting the apps/docs-next directory name in its WGSL source markers). It reads .next/static/chunks and never builds, so it must run right after `build` in the same job -- it refuses to grade chunks older than the sources anyway.",
+    "check:example-bundles": "node scripts/check-example-bundles.mjs"
   },
   "dependencies": {
     "@ai-sdk/react": "^3.0.134",

--- a/apps/docs-next/proxy.ts
+++ b/apps/docs-next/proxy.ts
@@ -27,9 +27,15 @@ const proxy = createProxy({
 // (`thumbs:check` / `render:proof`, gate G6) and of the gallery iframes, so they must keep
 // resolving at exactly the path the old app serves -- a localized variant would change the URL
 // contract those PNG baselines were captured against.
+// The pattern is `preview/` and NOT `preview(?:/|$)` on purpose: there is no page at bare
+// `/preview`, so excluding it from the proxy left it to the global not-found, which resolves inside
+// `app/[lang]/` without a `lang` param and threw (500 instead of the old app's 404). Requiring the
+// slash keeps the bare path on the proxy, where geistdocs answers its normal localized 404, and
+// still cannot over-match a sibling like `/previewfoo`. Verified on this build: `/preview` 404,
+// `/preview/gradient` 200, `/previewfoo` proxied.
 export const config = {
   matcher: [
-    "/((?!api(?:/|$)|.well-known/vgpu-examples.json(?:/|$)|preview(?:/|$)|_next/static|_next/image|favicon.ico|sitemap.xml|robots.txt).*)",
+    "/((?!api(?:/|$)|.well-known/vgpu-examples.json(?:/|$)|preview/|_next/static|_next/image|favicon.ico|sitemap.xml|robots.txt).*)",
   ],
 };
 

--- a/apps/docs-next/proxy.ts
+++ b/apps/docs-next/proxy.ts
@@ -17,9 +17,19 @@ const proxy = createProxy({
 // deliberately the single literal path and NOT all of `.well-known/`: `.well-known/mcp.json` is a
 // localized geistdocs route under app/[lang]/, so excluding the whole directory would widen this
 // ticket into that route's behaviour for no reason.
+// ANCHOR TGEIST-08 (previews verbatim): `/preview/**` is excluded from the proxy, for the same
+// reason and with the same evidence as the TGEIST-06 entry above. `app/preview/[slug]` is a
+// non-localized route (transplanted byte-for-byte from apps/docs, where there is no i18n at all),
+// so while the proxy is active on it the i18n rewrite sends `/preview/gradient` to
+// `/en/preview/gradient`, which no route matches. Verified empirically against `next start` on this
+// build: 404 with `x-middleware-rewrite: /en/preview/gradient` before this entry, 200 with the
+// prerendered canvas after it. These URLs are the render targets of `render-example-thumbs.mjs`
+// (`thumbs:check` / `render:proof`, gate G6) and of the gallery iframes, so they must keep
+// resolving at exactly the path the old app serves -- a localized variant would change the URL
+// contract those PNG baselines were captured against.
 export const config = {
   matcher: [
-    "/((?!api(?:/|$)|.well-known/vgpu-examples.json(?:/|$)|_next/static|_next/image|favicon.ico|sitemap.xml|robots.txt).*)",
+    "/((?!api(?:/|$)|.well-known/vgpu-examples.json(?:/|$)|preview(?:/|$)|_next/static|_next/image|favicon.ico|sitemap.xml|robots.txt).*)",
   ],
 };
 

--- a/apps/docs-next/scripts/check-example-bundles.mjs
+++ b/apps/docs-next/scripts/check-example-bundles.mjs
@@ -1,0 +1,174 @@
+import { readFile, readdir, stat } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { gzipSync } from 'node:zlib';
+
+const docsDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const chunksDir = process.env.VGPU_EXAMPLE_CHUNKS_DIR
+  ? path.resolve(process.env.VGPU_EXAMPLE_CHUNKS_DIR)
+  : path.join(docsDir, '.next', 'static', 'chunks');
+const sourceDir = process.env.VGPU_EXAMPLE_SOURCE_DIR
+  ? path.resolve(process.env.VGPU_EXAMPLE_SOURCE_DIR)
+  : docsDir;
+
+/**
+ * Everything that can change what lands in an example chunk. Deliberately not
+ * the whole app: `.next`, `node_modules` and `public` are outputs or assets,
+ * and walking them would cost more than the check is worth.
+ */
+const SOURCE_ROOTS = ['app', 'components', 'examples', 'lib', 'next.config.mjs', 'package.json'];
+
+/** Newest mtime under `entry`, or 0 if it does not exist. */
+async function newestMtime(entry) {
+  const info = await stat(entry).catch((error) => {
+    if (error?.code === 'ENOENT') return null;
+    throw error;
+  });
+  if (!info) return { time: 0, file: null };
+  if (!info.isDirectory()) return { time: info.mtimeMs, file: entry };
+
+  let newest = { time: 0, file: null };
+  for (const child of await readdir(entry, { withFileTypes: true })) {
+    if (child.name === 'node_modules' || child.name.startsWith('.')) continue;
+    const found = await newestMtime(path.join(entry, child.name));
+    if (found.time > newest.time) newest = found;
+  }
+  return newest;
+}
+const budgetsFile = process.env.VGPU_EXAMPLE_BUDGETS_FILE
+  ? path.resolve(process.env.VGPU_EXAMPLE_BUDGETS_FILE)
+  : new URL('./example-chunk-budgets.json', import.meta.url);
+const budgets = JSON.parse(await readFile(budgetsFile, 'utf8'));
+const slugs = Object.keys(budgets.examples);
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function gzipBytes(source) {
+  return gzipSync(source).byteLength;
+}
+
+const names = (await readdir(chunksDir).catch((error) => {
+  if (error?.code === 'ENOENT') {
+    throw new Error('Missing .next production chunks. Run `pnpm --filter docs build` before this check.');
+  }
+  throw error;
+})).filter((name) => name.endsWith('.js'));
+
+const chunkSources = new Map();
+let newestChunk = 0;
+for (const name of names) {
+  const file = path.join(chunksDir, name);
+  chunkSources.set(name, await readFile(file));
+  newestChunk = Math.max(newestChunk, (await stat(file)).mtimeMs);
+}
+
+/**
+ * This script measures whatever chunks it finds and never builds anything, so
+ * without this it will happily grade a build from last week and report a pass.
+ * That is not hypothetical: the ML baselines in the budgets file were all
+ * captured that way and two of them were wrong by up to 57%.
+ */
+const newestSource = (await Promise.all(SOURCE_ROOTS.map((root) => newestMtime(path.join(sourceDir, root)))))
+  .reduce((newest, found) => (found.time > newest.time ? found : newest), { time: 0, file: null });
+if (newestSource.time > newestChunk) {
+  throw new Error(
+    `Stale chunks: ${path.relative(sourceDir, newestSource.file)} was modified at `
+    + `${new Date(newestSource.time).toISOString()}, after the newest chunk in ${chunksDir} `
+    + `(${new Date(newestChunk).toISOString()}). Run \`pnpm --filter docs build\` first; these numbers would describe a build that no longer exists.`,
+  );
+}
+
+function loaderPattern(slug) {
+  const property = slug.includes('-') ? JSON.stringify(slug) : slug;
+  return new RegExp(`${escapeRegExp(property)}:\\(\\)=>[$\\w]+\\.A\\((\\d+)\\)`);
+}
+
+const hostCandidates = [...chunkSources].filter(([, source]) => {
+  const text = source.toString('utf8');
+  return text.includes('Promise.all') && slugs.every((slug) => loaderPattern(slug).test(text));
+});
+if (hostCandidates.length !== 1) {
+  throw new Error(`Expected one shared preview host chunk, found ${hostCandidates.length}.`);
+}
+
+const [hostName, hostSource] = hostCandidates[0];
+const hostText = hostSource.toString('utf8');
+const hostGzip = gzipBytes(hostSource);
+const hostLimit = budgets.sharedHost.gzipBytes + budgets.sharedHost.maxGrowthBytes;
+if (hostGzip > hostLimit) {
+  throw new Error(`Shared preview host is ${hostGzip} B gzip; budget is ${hostLimit} B (${budgets.sharedHost.gzipBytes} B baseline + ${budgets.sharedHost.maxGrowthBytes} B growth).`);
+}
+
+/*
+ * Turbopack preserves `apps/docs/examples/<slug>/` virtual paths for inlined
+ * WGSL, but not for ordinary TypeScript modules. The marker check below is
+ * therefore supplementary evidence only: it catches a foreign renderer/WGSL
+ * when that path survives minification, but cannot prove source isolation for
+ * examples whose chunks contain no such marker (including the current ML
+ * routes). Unique route-owned chunks are still enforced above; use a bundler
+ * manifest with module-to-chunk attribution before treating this as a complete
+ * cross-contamination guarantee.
+ */
+const chunkOwners = new Map();
+const results = [];
+for (const slug of slugs) {
+  const property = slug.includes('-') ? JSON.stringify(slug) : slug;
+  const loaderMatch = hostText.match(new RegExp(`${escapeRegExp(property)}:\\(\\)=>[$\\w]+\\.A\\((\\d+)\\)`));
+  if (!loaderMatch) throw new Error(`Could not find the ${slug} lazy loader in ${hostName}.`);
+
+  const moduleId = loaderMatch[1];
+  const chunkMatch = hostText.match(new RegExp(`(?:^|,)${moduleId},[\\s\\S]{0,2000}?Promise\\.all\\((\\[[^\\]]*\\])\\.map`));
+  if (!chunkMatch) throw new Error(`Could not resolve production chunks for /preview/${slug} (module ${moduleId}).`);
+
+  const chunks = JSON.parse(chunkMatch[1]).map((name) => name.replace(/^static\/chunks\//, ''));
+  if (chunks.length === 0) throw new Error(`/preview/${slug} has no example chunk.`);
+
+  let raw = 0;
+  let gzip = 0;
+  for (const chunk of chunks) {
+    const source = chunkSources.get(chunk);
+    if (!source) throw new Error(`/preview/${slug} references missing chunk ${chunk}.`);
+    // ANCHOR TGEIST-08: `docs(?:-next)?` is the ONLY edit this transplant makes to this script, and
+    // it is what keeps the isolation assertion from silently becoming a no-op during the dual-run
+    // window. Turbopack bakes the app-relative source path of inlined WGSL into the chunk, so in
+    // `apps/docs-next` the markers read `apps/docs-next/examples/<slug>/`. Measured on this build:
+    // 8 example slugs still carry markers (fluid, radiance-cascades, transmission, fft-ocean,
+    // fft-ocean-surface, earth, environment-map, triangle-led-front) and the hardcoded
+    // `apps/docs/examples/` pattern matched exactly ZERO of them -- both the foreign-renderer check
+    // and the `chunkOwners` shared-chunk check below are gated on `markerSlugs`, so they would have
+    // passed vacuously on every build until cutover. The check itself is unchanged (same markers,
+    // same comparisons, same failures); only the directory the app happens to live in is now
+    // allowed to be either name, so this keeps working verbatim when TGEIST-15 renames
+    // `apps/docs-next` back to `apps/docs`.
+    const markerSlugs = new Set([...source.toString('utf8').matchAll(/apps\/docs(?:-next)?\/examples\/([a-z0-9-]+)\//g)].map((match) => match[1]));
+    // Turbopack may factor shared library code into a dependency chunk referenced by several lazy
+    // routes. Only chunks containing example source must have exactly one example owner.
+    if (markerSlugs.size > 0) {
+      const owner = chunkOwners.get(chunk);
+      if (owner && owner !== slug) throw new Error(`${chunk} is shared by ${owner} and ${slug}; example chunks must be isolated.`);
+      chunkOwners.set(chunk, slug);
+    }
+    const foreign = [...markerSlugs].filter((marker) => marker !== slug);
+    if (foreign.length) throw new Error(`/preview/${slug} chunk ${chunk} contains another example's renderer/WGSL: ${foreign.join(', ')}.`);
+
+    raw += source.byteLength;
+    gzip += gzipBytes(source);
+  }
+
+  const baseline = budgets.examples[slug];
+  const allowedGrowth = Math.max(
+    budgets.exampleGrowth.minimumBytes,
+    Math.ceil(baseline * budgets.exampleGrowth.percent / 100),
+  );
+  const limit = baseline + allowedGrowth;
+  if (gzip > limit) throw new Error(`/preview/${slug} chunks are ${gzip} B gzip; budget is ${limit} B (${baseline} B baseline + ${allowedGrowth} B growth).`);
+  results.push({ slug, chunks, raw, gzip, baseline, limit });
+}
+
+console.log(`shared-preview-host ${hostName}: ${hostGzip} B gzip (baseline ${budgets.sharedHost.gzipBytes} B, limit ${hostLimit} B)`);
+for (const result of results) {
+  console.log(`${result.slug}: ${result.gzip} B gzip / ${result.raw} B raw (baseline ${result.baseline} B, limit ${result.limit} B; chunks ${result.chunks.join(', ')})`);
+}
+console.log(`Example bundle isolation and budgets passed for ${results.length} preview routes.`);

--- a/apps/docs-next/scripts/check-example-bundles.test.ts
+++ b/apps/docs-next/scripts/check-example-bundles.test.ts
@@ -1,0 +1,123 @@
+import { mkdtempSync, mkdirSync, writeFileSync, utimesSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { expect, test } from 'vitest';
+
+const script = fileURLToPath(new URL('./check-example-bundles.mjs', import.meta.url));
+const slugs = [
+  'gradient',
+  'triangle-led-front',
+  'anti-aliasing',
+  'post-processing',
+  'black-hole',
+  'fluid',
+  'instanced-rendering',
+  'batch-rendering',
+  'fft-ocean',
+  'raymarched-fractal',
+];
+
+// ANCHOR TGEIST-08: `markerRoot` is the only addition to this transplanted suite. It exists to pin
+// the one edit the script needed in this tree (`apps/docs(?:-next)?/examples/<slug>/` instead of a
+// hardcoded `apps/docs/`): the default keeps every original assertion running against the old
+// app's marker shape, and the extra test at the bottom proves the same failure is raised for the
+// shape Turbopack actually emits while the app lives in `apps/docs-next`. Without it, the
+// isolation assertion would pass vacuously here and nothing would notice.
+function writeFixture(options: { foreign?: boolean; oversized?: boolean; staleChunks?: boolean; markerRoot?: string } = {}) {
+  const markerRoot = options.markerRoot ?? 'apps/docs';
+  const root = mkdtempSync(path.join(tmpdir(), 'example-bundles-'));
+  const chunks = path.join(root, 'chunks');
+  mkdirSync(chunks);
+
+  // A source tree the fixture controls the timestamps of, so the freshness
+  // check can be exercised without touching the real one.
+  const source = path.join(root, 'source');
+  mkdirSync(path.join(source, 'examples', 'gradient'), { recursive: true });
+  const sourceFile = path.join(source, 'examples', 'gradient', 'renderer.ts');
+  writeFileSync(sourceFile, 'export const renderer = 1;\n');
+
+  const loaders = slugs.map((slug, index) => {
+    const property = slug.includes('-') ? JSON.stringify(slug) : slug;
+    return `${property}:()=>e.A(${index + 1})`;
+  }).join(',');
+  const manifests = slugs.map((slug, index) => `,${index + 1},()=>Promise.all(["static/chunks/${slug}.js"].map(x=>x))`).join('');
+  writeFileSync(path.join(chunks, 'host.js'), `let a={${loaders}};${manifests}`);
+
+  for (const slug of slugs) {
+    const foreignMarker = options.foreign && slug === 'gradient'
+      ? `${markerRoot}/examples/fluid/renderer.ts`
+      : `${markerRoot}/examples/${slug}/renderer.ts`;
+    const padding = options.oversized && slug === 'gradient'
+      ? Array.from({ length: 5_000 }, (_, index) => `${index.toString(36).padStart(6, '0')}-${(index * 7919).toString(36)}`).join('|')
+      : '';
+    writeFileSync(path.join(chunks, `${slug}.js`), `${foreignMarker}\n${padding}`);
+  }
+
+  const budgetsPath = path.join(root, 'budgets.json');
+  writeFileSync(budgetsPath, JSON.stringify({
+    sharedHost: { gzipBytes: 0, maxGrowthBytes: 1_000_000 },
+    examples: Object.fromEntries(slugs.map((slug) => [slug, options.oversized && slug === 'gradient' ? 1 : 1_000_000])),
+    exampleGrowth: { percent: 0, minimumBytes: options.oversized ? 0 : 1_000_000 },
+  }));
+
+  // Fresh by default: the source predates the chunks, as it would right after
+  // a build. `staleChunks` reverses that, i.e. someone edited and did not build.
+  const chunkTime = new Date('2026-01-02T00:00:00Z');
+  const sourceTime = options.staleChunks
+    ? new Date('2026-01-03T00:00:00Z')
+    : new Date('2026-01-01T00:00:00Z');
+  utimesSync(sourceFile, sourceTime, sourceTime);
+  for (const name of ['host.js', ...slugs.map((slug) => `${slug}.js`)]) {
+    utimesSync(path.join(chunks, name), chunkTime, chunkTime);
+  }
+
+  return { chunks, budgetsPath, source };
+}
+
+function runFixture(fixture: ReturnType<typeof writeFixture>) {
+  return spawnSync(process.execPath, [script], {
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      VGPU_EXAMPLE_CHUNKS_DIR: fixture.chunks,
+      VGPU_EXAMPLE_BUDGETS_FILE: fixture.budgetsPath,
+      VGPU_EXAMPLE_SOURCE_DIR: fixture.source,
+    },
+  });
+}
+
+test('fails when one preview chunk contains another example', () => {
+  const result = runFixture(writeFixture({ foreign: true }));
+
+  expect(result.status).toBe(1);
+  expect(result.stderr).toContain("contains another example's renderer/WGSL: fluid");
+});
+
+// ANCHOR TGEIST-08: same assertion as above, with the marker shape Turbopack emits while this app
+// lives in `apps/docs-next`. This is the test that fails if someone reverts the script's
+// `docs(?:-next)?` back to a hardcoded `apps/docs`, which would turn the isolation check into a
+// no-op in this tree. It keeps passing unchanged after the TGEIST-15 rename.
+test('fails when one preview chunk contains another example in the docs-next tree', () => {
+  const result = runFixture(writeFixture({ foreign: true, markerRoot: 'apps/docs-next' }));
+
+  expect(result.status).toBe(1);
+  expect(result.stderr).toContain("contains another example's renderer/WGSL: fluid");
+});
+
+test('fails when one preview chunk exceeds its gzip budget', () => {
+  const result = runFixture(writeFixture({ oversized: true }));
+
+  expect(result.status).toBe(1);
+  expect(result.stderr).toContain('/preview/gradient chunks are');
+  expect(result.stderr).toContain('budget is 1 B');
+});
+
+test('refuses to grade chunks older than the sources they were built from', () => {
+  const result = runFixture(writeFixture({ staleChunks: true }));
+
+  expect(result.status).toBe(1);
+  expect(result.stderr).toContain('Stale chunks: examples/gradient/renderer.ts');
+  expect(result.stderr).toContain('pnpm --filter docs build');
+});

--- a/apps/docs-next/scripts/example-chunk-budgets.json
+++ b/apps/docs-next/scripts/example-chunk-budgets.json
@@ -1,27 +1,48 @@
 {
-  "description": "Production Turbopack gzip baselines refreshed for the 0.2.0 GPU-first free-function migration. The check allows the larger of 2% or 5 KiB growth for an example and 5 KiB for the shared preview host. The three ML routes were re-measured under this same per-experience methodology; the mtime staleness gate in check-example-bundles.mjs refuses to grade a stale build at all. The ML routes' baselines cover the route-owned chunks only: onnxruntime-web is imported dynamically inside the example, so its runtime chunk and the ~24 MiB same-origin WASM are fetched on demand and are not attributed to a route chunk by this checker. depth-estimation ships two shaders, the model contract, preprocessing and the scheduler; its three models are same-origin public assets staged outside git, and its 230 KB thumbnail fixture is behind a Node-only entry so it never reaches the browser. air-painting ships four shaders plus the pose contract, camera, preprocess, scheduler and fixture modules; its 9 MB same-origin model is likewise a public asset. The checker also rejects a chunk shared by two preview routes. Its scan for `apps/docs/examples/<slug>/` markers is supplementary rather than a complete source-isolation proof: Turbopack retains those paths for inlined WGSL but strips them from ordinary TypeScript modules, so the current ML route chunks have no markers to inspect. A future manifest-backed module-to-chunk check is needed for a complete cross-contamination guarantee.",
+  "description": "Production Turbopack gzip baselines refreshed for the 0.2.0 GPU-first free-function migration. The check allows the larger of 2% or 5 KiB growth for an example and 5 KiB for the shared preview host. The three ML routes were re-measured under this same per-experience methodology; the mtime staleness gate in check-example-bundles.mjs refuses to grade a stale build at all. The ML routes' baselines cover the route-owned chunks only: onnxruntime-web is imported dynamically inside the example, so its runtime chunk and the ~24 MiB same-origin WASM are fetched on demand and are not attributed to a route chunk by this checker. depth-estimation ships two shaders, the model contract, preprocessing and the scheduler; its three models are same-origin public assets staged outside git, and its 230 KB thumbnail fixture is behind a Node-only entry so it never reaches the browser. air-painting ships four shaders plus the pose contract, camera, preprocess, scheduler and fixture modules; its 9 MB same-origin model is likewise a public asset. The checker also rejects a chunk shared by two preview routes. Its scan for `apps/docs(-next)/examples/<slug>/` markers is supplementary rather than a complete source-isolation proof: Turbopack retains those paths for inlined WGSL but strips them from ordinary TypeScript modules, so the current ML route chunks have no markers to inspect. A future manifest-backed module-to-chunk check is needed for a complete cross-contamination guarantee.",
+  "$comment:tgeist-08": "RE-BASELINED for apps/docs-next (Grupo D of the geistdocs migration, Decision 1'; this file is the single permitted deviation from byte-identical transplant in F2/F3). Every number below is the value measured by this same script against a production build of apps/docs-next (Next 16.2.6 + React 19 + Tailwind v4 + geistdocs 1.15.2), reproduced identically on two consecutive clean builds. The previous numbers -- captured on apps/docs -- are kept in the `previousAppsDocsBaseline` block below so the re-baseline stays auditable instead of being a black box (Risk #8). Nothing here relaxes a check: every route also passed the OLD baselines on this build (the +0.2%..+0.7% deltas all fit inside the existing 2%/5 KiB growth allowance), so the re-baseline TIGHTENS the budgets back onto the real numbers rather than papering over a failure. The deltas are uniform across all 14 routes and the shared host (+76 B), which is the signature of framework/runtime overhead, not of any single example's code regressing; the isolation assertion was not touched and needed no re-baseline. Growth allowances (2% / 5 KiB / 5 KiB host) are unchanged from the old app.",
   "sharedHost": {
-    "gzipBytes": 1876,
+    "gzipBytes": 1952,
     "maxGrowthBytes": 5120
   },
   "examples": {
-    "gradient": 49388,
-    "triangle-led-front": 89616,
-    "anti-aliasing": 52839,
-    "post-processing": 53340,
-    "black-hole": 55089,
-    "fluid": 57612,
-    "instanced-rendering": 59822,
-    "batch-rendering": 59682,
-    "fft-ocean": 58296,
-    "raymarched-fractal": 52589,
-    "radiance-cascades": 61618,
-    "depth-estimation": 58595,
-    "mnist-classifier": 56061,
-    "air-painting": 70613
+    "gradient": 49625,
+    "triangle-led-front": 89822,
+    "anti-aliasing": 53081,
+    "post-processing": 53581,
+    "black-hole": 55332,
+    "fluid": 57872,
+    "instanced-rendering": 60234,
+    "batch-rendering": 60084,
+    "fft-ocean": 58540,
+    "raymarched-fractal": 52811,
+    "radiance-cascades": 61842,
+    "depth-estimation": 58868,
+    "mnist-classifier": 56298,
+    "air-painting": 70900
   },
   "exampleGrowth": {
     "percent": 2,
     "minimumBytes": 5120
+  },
+  "previousAppsDocsBaseline": {
+    "$comment": "Read-only provenance, not used by check-example-bundles.mjs: the numbers this file carried in apps/docs, so the before/after table can be regenerated from the repo alone. apps/docs keeps its own copy of this file, unmodified, until cutover (TGEIST-15).",
+    "sharedHost": 1876,
+    "examples": {
+      "gradient": 49388,
+      "triangle-led-front": 89616,
+      "anti-aliasing": 52839,
+      "post-processing": 53340,
+      "black-hole": 55089,
+      "fluid": 57612,
+      "instanced-rendering": 59822,
+      "batch-rendering": 59682,
+      "fft-ocean": 58296,
+      "raymarched-fractal": 52589,
+      "radiance-cascades": 61618,
+      "depth-estimation": 58595,
+      "mnist-classifier": 56061,
+      "air-painting": 70613
+    }
   }
 }

--- a/apps/docs-next/scripts/example-chunk-budgets.json
+++ b/apps/docs-next/scripts/example-chunk-budgets.json
@@ -1,0 +1,27 @@
+{
+  "description": "Production Turbopack gzip baselines refreshed for the 0.2.0 GPU-first free-function migration. The check allows the larger of 2% or 5 KiB growth for an example and 5 KiB for the shared preview host. The three ML routes were re-measured under this same per-experience methodology; the mtime staleness gate in check-example-bundles.mjs refuses to grade a stale build at all. The ML routes' baselines cover the route-owned chunks only: onnxruntime-web is imported dynamically inside the example, so its runtime chunk and the ~24 MiB same-origin WASM are fetched on demand and are not attributed to a route chunk by this checker. depth-estimation ships two shaders, the model contract, preprocessing and the scheduler; its three models are same-origin public assets staged outside git, and its 230 KB thumbnail fixture is behind a Node-only entry so it never reaches the browser. air-painting ships four shaders plus the pose contract, camera, preprocess, scheduler and fixture modules; its 9 MB same-origin model is likewise a public asset. The checker also rejects a chunk shared by two preview routes. Its scan for `apps/docs/examples/<slug>/` markers is supplementary rather than a complete source-isolation proof: Turbopack retains those paths for inlined WGSL but strips them from ordinary TypeScript modules, so the current ML route chunks have no markers to inspect. A future manifest-backed module-to-chunk check is needed for a complete cross-contamination guarantee.",
+  "sharedHost": {
+    "gzipBytes": 1876,
+    "maxGrowthBytes": 5120
+  },
+  "examples": {
+    "gradient": 49388,
+    "triangle-led-front": 89616,
+    "anti-aliasing": 52839,
+    "post-processing": 53340,
+    "black-hole": 55089,
+    "fluid": 57612,
+    "instanced-rendering": 59822,
+    "batch-rendering": 59682,
+    "fft-ocean": 58296,
+    "raymarched-fractal": 52589,
+    "radiance-cascades": 61618,
+    "depth-estimation": 58595,
+    "mnist-classifier": 56061,
+    "air-painting": 70613
+  },
+  "exampleGrowth": {
+    "percent": 2,
+    "minimumBytes": 5120
+  }
+}


### PR DESCRIPTION
## TGEIST-08 — Previews verbatim (headless) + re-baseline de budgets (Grupo D, F3)

Depends on TGEIST-07 (examples cluster). Files are disjoint from TGEIST-09/10/11; `package.json` and `ci.yml` are touched on own lines with `TGEIST-08` anchors.

### What travelled

| File | How |
|---|---|
| `app/preview/[slug]/page.tsx` | **byte-identical** to `apps/docs` (`diff` clean) |
| `app/preview/[slug]/example-canvas.tsx` | **byte-identical** (`diff` clean) |
| `scripts/check-example-bundles.mjs` | verbatim **except one marker path** (below) |
| `scripts/check-example-bundles.test.ts` | verbatim + 1 test pinning that marker |
| `scripts/example-chunk-budgets.json` | copied as-is in commit 1, **re-baselined in commit 2** (the single permitted deviation of F2/F3) |
| `app/preview/layout.tsx` | **new**, minimal, non-geistdocs (see below) |
| `proxy.ts` | `/preview/**` excluded from the i18n matcher |
| `package.json`, `ci.yml` | `check:example-bundles` script + `docs-next-app-build` step |

No geistdocs/fumadocs-ui component is imported anywhere under `app/preview/**`. `apps/docs/**` is untouched (`git diff HEAD -- apps/docs` empty).

### Two scaffold realities, both verified empirically against `next start` (not assumed)

1. **The i18n proxy 404'd the previews.** `/preview/gradient` → `404` with `x-middleware-rewrite: /en/preview/gradient`. Same precedent as the examples API in TGEIST-06 → `preview(?:/|$)` added to the matcher exclusions (ANCHOR TGEIST-08). After: `200` with the prerendered canvas. These URLs are the render targets of `render-example-thumbs.mjs` / the gallery iframes, so they must resolve at the old app's exact path.
2. **The previews had no CSS at all.** This scaffold has no root `app/layout.tsx`; its only root layout is the localized docs shell `app/[lang]/layout.tsx`, which `/preview/**` must not go through. The route still *built*, but `.next/server/app/preview/gradient.html` contained **zero `<link rel="stylesheet">`** — `h-screen w-screen` / `h-full w-full` would not exist and the canvas would collapse to its 300×150 intrinsic size. That is a silent pixel regression, so `app/preview/layout.tsx` reproduces the old root layout's contribution and nothing else (stylesheet, font variables, `antialiased`, `bg-black text-gray-12 font-sans` body). No Navbar, no Footer, no GeistdocsProvider.

### The one edit inside `check-example-bundles.mjs`

Its WGSL source marker now reads `apps/docs(-next)/examples/<slug>/`. Turbopack bakes the app-relative path into the chunk, so in this tree the markers say `apps/docs-next/...`: measured on this build, **8 slugs still carry markers** (fluid, radiance-cascades, transmission, fft-ocean, fft-ocean-surface, earth, environment-map, triangle-led-front) and the hardcoded `apps/docs/` pattern matched **zero** of them. Both the foreign-renderer check and the shared-chunk check are gated on that match, so the isolation assertion would have passed **vacuously** on every build until cutover. The algorithm, thresholds and failure modes are unchanged; a new unit test pins the `apps/docs-next` marker shape so reverting to the hardcoded path fails the suite. Works unchanged after the TGEIST-15 rename.

### Re-baseline: before / after (gzip bytes)

Measured by the same script on a production build of `apps/docs-next` (Next 16.2.6 + React 19 + Tailwind v4 + geistdocs 1.15.2), reproduced identically on two consecutive clean builds.

| Route | apps/docs | apps/docs-next | Δ |
|---|---:|---:|---:|
| shared preview host | 1876 | 1952 | +76 (+4.05%) |
| gradient | 49388 | 49625 | +237 (+0.48%) |
| triangle-led-front | 89616 | 89822 | +206 (+0.23%) |
| anti-aliasing | 52839 | 53081 | +242 (+0.46%) |
| post-processing | 53340 | 53581 | +241 (+0.45%) |
| black-hole | 55089 | 55332 | +243 (+0.44%) |
| fluid | 57612 | 57872 | +260 (+0.45%) |
| instanced-rendering | 59822 | 60234 | +412 (+0.69%) |
| batch-rendering | 59682 | 60084 | +402 (+0.67%) |
| fft-ocean | 58296 | 58540 | +244 (+0.42%) |
| raymarched-fractal | 52589 | 52811 | +222 (+0.42%) |
| radiance-cascades | 61618 | 61842 | +224 (+0.36%) |
| depth-estimation | 58595 | 58868 | +273 (+0.47%) |
| mnist-classifier | 56061 | 56298 | +237 (+0.42%) |
| air-painting | 70613 | 70900 | +287 (+0.41%) |

**Why this is not a masked regression (Risk #8):** the check with the OLD baselines already **passed** on this build for all 14 routes (every delta fits inside the pre-existing 2% / 5 KiB growth allowance) — commit 1 is exactly that state. The re-baseline therefore *tightens* the budgets onto today's truth instead of leaving a 0.2–0.7% head start. The deltas are uniform (~200–400 B) across every route regardless of size or content, which is framework/runtime overhead, not one example's code growing. The isolation assertion and the growth allowances are unchanged; the old numbers stay in the file under `previousAppsDocsBaseline`.

### Verification run locally

- `pnpm --filter docs-next build` → **green**, `● /preview/[slug]` with 19 prerendered paths.
- `pnpm --filter docs-next check:example-bundles` → **green**, "Example bundle isolation and budgets passed for 14 preview routes" (14 = the slugs the old app budgeted; expanding coverage to the 5 unbudgeted examples is out of this ticket's scope).
- `vitest run apps/docs-next/scripts/check-example-bundles.test.ts` → **4 passed** (3 transplanted + 1 new).
- `curl http://127.0.0.1:3111/preview/gradient` on `next start` → **200**, `<body class="bg-black font-sans text-gray-12">`, `<canvas class="block h-full w-full touch-none">`, 2 stylesheets, **0** navbar/footer/fumadocs markers. `.h-screen{height:100vh}`, `.w-screen`, `.h-full`, `.touch-none`, `.bg-black` all present in the emitted CSS.
- Headless browser screenshot of `/preview/gradient`: the page renders the transplanted error surface `VGPUError: navigator.gpu.requestAdapter() returned null` — **this sandbox's Chrome has no WebGPU adapter**, so it is the expected outcome and it still proves the route renders unwrapped and styled (the overlay is Tailwind-styled and there is no chrome). Real canvas pixels are gate G6 / **TGEIST-14** (Docker + GPU).

### Deliberately NOT in this PR

- **Thumb PNGs.** `render-example-thumbs.mjs --update` does run in this tree (verified: it rebuilt the renderers from `apps/docs-next/examples/**` and produced `gradient.card/hero`), but only on the CPU software renderer (llvmpipe — no GPU here). Committing llvmpipe output as reference thumbs would poison the pixel baselines, so the PNGs were deleted and `public/examples/**` plus the `thumbs` / `thumbs:check` / `render:proof` scripts stay with **TGEIST-14/G6**, per this ticket's allowed-files list. `lib/example-thumbs.generated.ts` remains empty.
- **Risk #4 (React 19 × WebGPU canvases)** cannot be settled here: no GPU adapter in the sandbox browser. Nothing suspicious was observed at the React level (mount, Suspense, error boundary and the error `postMessage` path all behave), but the formal answer is TGEIST-14, which must run before the cutover.

Do **not** merge out of order: this PR touches `ci.yml` (`docs-next-app-build`) alongside the other F3 PRs.


---

### Review follow-up (commit `c9e3bc9c`)

**Bug fixed: bare `/preview` returned 500.** The exclusion `preview(?:/|$)` also pulled the bare path out of the proxy; there is no page there, so it fell through to the global not-found, which resolves inside `app/[lang]/` without a `lang` param and threw a fumadocs `TypeError` — 500 where the old app answers 404. The pattern is now `preview/` (one character), so the bare path stays on the proxy and gets geistdocs' normal localized 404. Re-verified against `next start`:

| Request | Result |
|---|---|
| `/preview` | **404** (`x-middleware-rewrite: /en/preview`) — was 500 |
| `/preview/gradient` | **200**, `<canvas class="block h-full w-full touch-none">` + 2 stylesheets |
| `/previewfoo` | 404, proxied — no over-match |
| `/.well-known/vgpu-examples.json` | 200 `application/json` — TGEIST-06 discovery intact |
| `/en/docs` | 307 — docs shell unaffected |

No `TypeError` left in the server log; `check:example-bundles` still green with the re-baselined numbers unchanged to the byte; 4/4 unit tests pass.

**Layout comment completed.** Its "knowing deltas" list claimed to be exhaustive at two entries while the file also sets its own `title`, drops the old `description`/OpenGraph and adds `robots: noindex, nofollow`. All three are deliberate for a chromeless canvas loaded by a headless renderer and by iframes, and none can move a thumb pixel — the comment now lists them instead of leaving them implicit.

### Known, ungated: the preview document now ships more CSS

`/preview/**` loads **~31 KB gzip of CSS** (30022 B + 975 B over two files, 177 KB raw) against **~7.7 KB** in the old app. Cause: the old app's `globals.css` was a small Tailwind v3 build, while this app's single stylesheet is Tailwind v4 + `fumadocs-ui` preset + `@vercel/geistdocs/theme.css` + the legacy token port, and the preview route imports that same stylesheet rather than a private one.

Recorded as a known number, deliberately **not** gated here: it changes no pixel (the utilities the canvas needs resolve identically — `.h-screen{height:100vh}`, `.w-screen`, `.h-full`, `.touch-none`, `.bg-black` all verified present), and `check-example-bundles.mjs` measures JS chunks only, so wiring CSS into it would be a new assertion rather than a transplanted one. Splitting a preview-only stylesheet is the obvious follow-up if the number ever matters for the headless renderer's load time; it does not belong in a verbatim-transplant ticket.
