### PR TITLE
TGEIST-13 — G4: examples API deployment parity verifier (prod vs preview, byte-for-byte)

### DIFF
--- a/.github/workflows/examples-api-deploy-parity.yml
+++ b/.github/workflows/examples-api-deploy-parity.yml
@@ -1,0 +1,117 @@
+# TGEIST-13 — G4/G5 of the geistdocs migration (Decision 1'): byte-for-byte deployment parity of
+# the examples API.
+#
+# Why a workflow of its own instead of a job in ci.yml: this gate is not a per-PR check. It needs a
+# LIVE deployment URL (the old production site, a preview of apps/docs-next, or both), which no
+# pull_request event can supply, so it is `workflow_dispatch` only — the same shape and the same
+# reason as publish-examples-api.yml. Keeping it out of ci.yml also keeps ci.yml free of a
+# workflow_dispatch trigger with inputs that would be meaningless for its 11 other jobs (and out of
+# the way of the other migration tickets that all edit that file).
+#
+# It is a de-facto prerequisite of the cutover PR (TGEIST-15), not a blocking status check:
+#   G4 — before the cutover: run it against the old production deployment AND against the
+#        apps/docs-next preview, and require both to pass with an empty A/B diff.
+#   G5 — minutes after the cutover deploy: run it once against production again.
+#
+# The script is dependency-free (pure Node, no imports outside node:*), so this workflow needs no
+# pnpm install and no build: checkout + node.
+#
+# OPERATIONAL RULE (Risk #5 of the design): this only READS a deployment over HTTP. Never "simplify"
+# verifying a preview by pointing the production domain at it — the only path to the production
+# domain is the cutover PR itself.
+name: Examples API deployment parity
+
+on:
+  workflow_dispatch:
+    inputs:
+      base_url:
+        description: "Deployment A (e.g. https://vgpu.sh, or a docs-next preview URL)"
+        required: true
+        type: string
+      compare_url:
+        description: "Deployment B — optional; when set, A and B must serve the same tree byte for byte"
+        required: false
+        type: string
+      local_tree:
+        description: "Also cross-check the served bytes against a generated tree in this checkout"
+        required: false
+        default: "apps/docs/generated/examples-api"
+        type: choice
+        options:
+          - "apps/docs/generated/examples-api"
+          - "apps/docs-next/generated/examples-api"
+          - "none"
+      require_local:
+        description: "Fail (not just warn) if the checkout's tree revision differs from the deployment's"
+        required: false
+        default: false
+        type: boolean
+      verbose:
+        description: "Print one line per artifact (248 today) instead of failures only"
+        required: false
+        default: false
+        type: boolean
+
+concurrency:
+  # Read-only, but serialised so two runs never interleave their reports in the same artifact name.
+  group: examples-api-deploy-parity-${{ inputs.base_url }}
+  cancel-in-progress: false
+
+jobs:
+  verify:
+    runs-on: ubuntu-24.04-arm
+    permissions:
+      contents: read
+    env:
+      # Set this secret to reach a preview that has Vercel Deployment Protection enabled
+      # (Project Settings -> Deployment Protection -> Protection Bypass for Automation). Without it
+      # a protected preview answers 401 and the script exits 75 = BLOCKED, which is explicitly NOT
+      # a parity failure.
+      VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      - name: Verify the examples API artifact tree against the deployment(s)
+        env:
+          BASE_URL: ${{ inputs.base_url }}
+          COMPARE_URL: ${{ inputs.compare_url }}
+          LOCAL_TREE: ${{ inputs.local_tree }}
+          REQUIRE_LOCAL: ${{ inputs.require_local }}
+          VERBOSE: ${{ inputs.verbose }}
+        run: |
+          set -o pipefail
+          arguments=("$BASE_URL")
+          if [ -n "$COMPARE_URL" ]; then arguments+=("$COMPARE_URL"); fi
+          if [ "$LOCAL_TREE" != "none" ]; then arguments+=("--local=$LOCAL_TREE"); fi
+          if [ "$REQUIRE_LOCAL" = "true" ]; then arguments+=("--require-local"); fi
+          if [ "$VERBOSE" = "true" ]; then arguments+=("--verbose"); fi
+          arguments+=("--json" "examples-api-deployment-parity.json")
+          set +e
+          node scripts/verify-examples-api-deployment.mjs "${arguments[@]}" | tee report.txt
+          status=$?
+          set -e
+          {
+            echo "### Examples API deployment parity"
+            echo
+            echo '```'
+            cat report.txt
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+          # 75 = the deployment could not be interrogated at all (Vercel bot mitigation, Deployment
+          # Protection, network). Surfaced as a distinct annotation so it is never mistaken for a
+          # byte-parity failure — and still fails the run, because an unverified gate is not a green
+          # gate.
+          if [ "$status" = "75" ]; then
+            echo "::error title=BLOCKED::The deployment could not be interrogated (bot mitigation / deployment protection / network). This is NOT a parity failure — re-run."
+          fi
+          exit "$status"
+      - name: Upload the machine-readable parity report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: examples-api-deployment-parity
+          path: examples-api-deployment-parity.json
+          if-no-files-found: warn

--- a/scripts/verify-examples-api-deployment.mjs
+++ b/scripts/verify-examples-api-deployment.mjs
@@ -1,0 +1,872 @@
+#!/usr/bin/env node
+/**
+ * TGEIST-13 — G4: byte-for-byte deployment parity for the examples API.
+ *
+ * WHAT THIS IS
+ * ------------
+ * `apps/docs/scripts/generate-examples-api.mjs:38-60` already embeds a deployment verifier
+ * (`verifyDeployed`, the `beforeLatest` hook of `--publish`): it fetches THREE artifacts
+ * (index + one manifest + one file, all for `raymarched-fractal`) from `VERCEL_DEPLOYMENT_URL`
+ * and compares `content-type`, byte length and `sha256` before the latest pointer is advanced.
+ * That is a pre-pointer smoke test of a publish transaction, not a parity gate, and it can only
+ * ever run inside the generator.
+ *
+ * This script is that verifier extracted and generalised to the WHOLE artifact tree
+ * (discovery + latest + revision manifest + index + every manifest + every source file — 248
+ * objects today), runnable against any deployment URL, with a per-file report and an aggregate
+ * verdict. It is gate G4 of Decision 1' of the geistdocs migration: run it against the OLD
+ * production deployment and against the NEW `apps/docs-next` preview and require identical
+ * results before the cutover (TGEIST-15), then again minutes after the cutover deploy (G5).
+ *
+ * The generator is deliberately NOT refactored to import this file: it stays byte-frozen for the
+ * whole dual-run window (its copy under `apps/docs-next` is compared to it by G2,
+ * `check-examples-api-transplant`). The duplication is 20 lines and is the cheap side of that
+ * trade.
+ *
+ * WHAT IT CHECKS
+ * --------------
+ * It walks the deployment the way a real client does — discovery -> latest -> revision manifest
+ * -> index -> per-example manifests -> source files — and for every object asserts:
+ *   - HTTP 200 with no redirect (`redirect: 'error'`, `cache: 'no-store'`),
+ *   - `content-type` exactly as declared by the revision manifest (`; charset=utf-8` appended to
+ *     `text/*`, exactly as `artifact-store.ts#withCharset` does),
+ *   - `content-length` header == received body length == declared `size`,
+ *   - `sha256(body)` == declared `sha256`,
+ *   - `etag` == `"<sha256>"` and `cache-control` == the value the route is supposed to set
+ *     (immutable for revision objects, `max-age=60, must-revalidate` for the two mutable ones),
+ *   - graph closure: every URL referenced by index/manifests exists in the revision manifest, and
+ *     every object of the revision manifest is referenced (no orphans, nothing missing).
+ * Plus HEAD + conditional-GET (`If-None-Match` -> 304) probes on the three entry artifacts, and an
+ * optional cross-check against the generated tree committed in the checkout (`--local`).
+ *
+ * USAGE
+ * -----
+ *   node scripts/verify-examples-api-deployment.mjs <baseUrl>                  # one deployment
+ *   node scripts/verify-examples-api-deployment.mjs <baseUrlA> <baseUrlB>      # A/B parity
+ *   node scripts/verify-examples-api-deployment.mjs <baseUrl> --compare <baseUrlB>
+ *
+ * Options:
+ *   --compare <url>     second deployment; equivalent to passing a second positional URL.
+ *   --local[=<dir>]     also cross-check against a generated tree in this checkout
+ *                       (default `apps/docs/generated/examples-api`). A revision mismatch is a
+ *                       warning unless --require-local is given.
+ *   --require-local     turn a local-tree revision mismatch / missing tree into a failure.
+ *   --json <file>       write the machine-readable report (A/B writes `{a, b, comparison}`).
+ *   --concurrency <n>   parallel requests per deployment (default 8).
+ *   --timeout <ms>      per-request timeout (default 30000).
+ *   --retries <n>       retries per request for transient failures (default 4).
+ *   --head-all          send a HEAD for every artifact, not just the three entry ones.
+ *   --verbose           print one line per artifact (default: failures + summary only).
+ *   --help
+ *
+ * Environment:
+ *   VERCEL_AUTOMATION_BYPASS_SECRET  sent as `x-vercel-protection-bypass` so the script can reach
+ *                                    a preview deployment that has Vercel Deployment Protection
+ *                                    enabled (the alternative — disabling protection — is worse).
+ *
+ * Exit codes: 0 pass · 1 parity/integrity failure · 2 usage error · 75 BLOCKED (inconclusive:
+ * bot mitigation, deployment protection or the network — never reported as a parity failure).
+ *
+ * OPERATIONAL RULE (Risk #5 of the migration design): this script only READS a deployment over
+ * HTTP. Verifying a preview must never be "simplified" by promoting it to the production domain;
+ * the only path to the production domain is the cutover PR (F5/TGEIST-15).
+ */
+
+import { createHash } from 'node:crypto';
+import { readdir, readFile, writeFile } from 'node:fs/promises';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const repoRoot = join(here, '..');
+
+// Mirrors apps/docs/lib/examples-api/route-config.ts. Duplicated on purpose: that module is
+// TypeScript inside an app this ticket may not touch or import, and this script must stay
+// dependency-free so it can run from a bare checkout (or from `npx`-style one-shot CI steps).
+export const DISCOVERY_ARTIFACT_KEY = '.well-known/vgpu-examples.json';
+export const LATEST_ARTIFACT_KEY = 'examples/v1/latest.json';
+export const CONTRACT_ID = 'vgpu-examples/v1';
+export const MUTABLE_CACHE_CONTROL = 'public, max-age=60, must-revalidate';
+export const IMMUTABLE_CACHE_CONTROL = 'public, max-age=31536000, immutable';
+export const DEFAULT_LOCAL_TREE = 'apps/docs/generated/examples-api';
+export const JSON_CONTENT_TYPE = 'application/json; charset=utf-8';
+
+export const EXIT_PASS = 0;
+export const EXIT_FAIL = 1;
+export const EXIT_USAGE = 2;
+/** EX_TEMPFAIL: the run is inconclusive, NOT a parity failure. */
+export const EXIT_BLOCKED = 75;
+
+const SHA256_HEX = /^[a-f0-9]{64}$/;
+
+/** Raised when the deployment cannot be interrogated at all (bot mitigation, SSO, network). */
+export class BlockedError extends Error {
+  constructor(message, detail) {
+    super(message);
+    this.name = 'BlockedError';
+    this.detail = detail ?? {};
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Pure helpers (unit-tested in verify-examples-api-deployment.test.ts)
+// ---------------------------------------------------------------------------
+
+export function sha256(bytes) {
+  return createHash('sha256').update(bytes).digest('hex');
+}
+
+/**
+ * Artifact key -> request path. The discovery document is served from the site root
+ * (`app/.well-known/vgpu-examples.json/route.ts`); everything else lives under `/api`
+ * (`app/api/examples/v1/...`), which is exactly the `'/api/' + key` convention `verifyDeployed`
+ * uses in the generator.
+ */
+export function artifactPathForKey(key) {
+  return key === DISCOVERY_ARTIFACT_KEY ? `/${key}` : `/api/${key}`;
+}
+
+/** Inverse of artifactPathForKey; returns undefined for a path outside the artifact namespace. */
+export function keyForArtifactPath(path) {
+  if (path === `/${DISCOVERY_ARTIFACT_KEY}`) return DISCOVERY_ARTIFACT_KEY;
+  if (path.startsWith('/api/')) return path.slice('/api/'.length);
+  return undefined;
+}
+
+/** Mirrors `withCharset` in apps/docs/lib/examples-api/artifact-store.ts. */
+export function expectedContentType(declared) {
+  return declared.startsWith('text/') && !declared.includes(';') ? `${declared}; charset=utf-8` : declared;
+}
+
+/** Revision objects are immutable; discovery and the latest pointer are not. */
+export function expectedCacheControl(key) {
+  return key === DISCOVERY_ARTIFACT_KEY || key === LATEST_ARTIFACT_KEY
+    ? MUTABLE_CACHE_CONTROL
+    : IMMUTABLE_CACHE_CONTROL;
+}
+
+/** `W/"abc"` and `"abc"` both normalise to `abc`, so a CDN weakening the ETag is not a diff. */
+export function normalizeEtag(value) {
+  if (typeof value !== 'string') return undefined;
+  return value.trim().replace(/^W\//i, '').replace(/^"(.*)"$/, '$1');
+}
+
+export function revisionArtifactKeyPrefix(revision) {
+  return `examples/v1/revisions/${revision}`;
+}
+
+/** Classifies an artifact for the report, purely from its key. */
+export function artifactKind(key) {
+  if (key === DISCOVERY_ARTIFACT_KEY) return 'discovery';
+  if (key === LATEST_ARTIFACT_KEY) return 'latest';
+  if (key.endsWith('/revision.json')) return 'revision';
+  if (key.endsWith('/index.json')) return 'index';
+  if (key.endsWith('/manifest.json')) return 'manifest';
+  return 'file';
+}
+
+/**
+ * Vercel's transient anti-bot mitigation answers 403 with `x-vercel-mitigated: challenge`, and
+ * Deployment Protection answers 401 with an SSO HTML page. Neither means "the bytes are wrong";
+ * conflating them with a parity failure is how a green migration gets blocked by a red herring.
+ */
+export function detectBlock(status, headers) {
+  const get = (name) => (typeof headers?.get === 'function' ? headers.get(name) : headers?.[name]) ?? undefined;
+  const mitigated = get('x-vercel-mitigated');
+  if (mitigated) return { blocked: true, reason: 'bot-mitigation', detail: `x-vercel-mitigated: ${mitigated}` };
+  if (status === 401 || status === 407) {
+    return { blocked: true, reason: 'deployment-protection', detail: `HTTP ${status} (Vercel Deployment Protection / SSO)` };
+  }
+  if (status === 403 && /text\/html/i.test(get('content-type') ?? '')) {
+    return { blocked: true, reason: 'bot-mitigation', detail: 'HTTP 403 with an HTML body (challenge page)' };
+  }
+  return { blocked: false };
+}
+
+export function isRetriableStatus(status) {
+  return status === 408 || status === 425 || status === 429 || (status >= 500 && status <= 599);
+}
+
+export function backoffDelayMs(attempt, base = 500, cap = 8000) {
+  return Math.min(cap, base * 2 ** attempt);
+}
+
+export function parseArguments(argv) {
+  const options = {
+    urls: [],
+    localTree: undefined,
+    requireLocal: false,
+    jsonPath: undefined,
+    concurrency: 8,
+    timeoutMs: 30_000,
+    retries: 4,
+    headAll: false,
+    verbose: false,
+    help: false,
+  };
+  const numeric = (raw, name) => {
+    const value = Number(raw);
+    if (!Number.isFinite(value) || value < 0) throw new Error(`Invalid value for ${name}: ${raw}`);
+    return value;
+  };
+  for (let index = 0; index < argv.length; index += 1) {
+    const argument = argv[index];
+    const next = () => {
+      const value = argv[index + 1];
+      if (value === undefined) throw new Error(`Missing value for ${argument}`);
+      index += 1;
+      return value;
+    };
+    if (argument === '--help' || argument === '-h') options.help = true;
+    else if (argument === '--compare') options.urls.push(next());
+    else if (argument === '--local') options.localTree = DEFAULT_LOCAL_TREE;
+    else if (argument.startsWith('--local=')) options.localTree = argument.slice('--local='.length);
+    else if (argument === '--require-local') {
+      options.requireLocal = true;
+      options.localTree ??= DEFAULT_LOCAL_TREE;
+    } else if (argument === '--json') options.jsonPath = next();
+    else if (argument === '--concurrency') options.concurrency = numeric(next(), '--concurrency');
+    else if (argument === '--timeout') options.timeoutMs = numeric(next(), '--timeout');
+    else if (argument === '--retries') options.retries = numeric(next(), '--retries');
+    else if (argument === '--head-all') options.headAll = true;
+    else if (argument === '--verbose') options.verbose = true;
+    else if (argument.startsWith('-')) throw new Error(`Unknown option: ${argument}`);
+    else options.urls.push(argument);
+  }
+  if (!options.help) {
+    if (options.urls.length === 0) throw new Error('Missing <baseUrl>');
+    if (options.urls.length > 2) throw new Error('At most two deployment URLs can be compared');
+    options.urls = options.urls.map(normalizeBaseUrl);
+    if (options.urls.length === 2 && options.urls[0] === options.urls[1]) {
+      throw new Error('A/B mode needs two different deployment URLs');
+    }
+  }
+  options.concurrency = Math.max(1, Math.trunc(options.concurrency));
+  return options;
+}
+
+/** Accepts `vgpu.sh`, `https://vgpu.sh`, `https://vgpu.sh/` and normalises to an origin+path base. */
+export function normalizeBaseUrl(value) {
+  const withScheme = /^https?:\/\//i.test(value) ? value : `https://${value}`;
+  let url;
+  try {
+    url = new URL(withScheme);
+  } catch {
+    throw new Error(`Invalid deployment URL: ${value}`);
+  }
+  if (url.search || url.hash) throw new Error(`Deployment URL must not carry a query or hash: ${value}`);
+  return `${url.origin}${url.pathname.replace(/\/+$/, '')}`;
+}
+
+/** The fields a deployment is allowed to be compared on — everything else is transport noise. */
+export function comparableArtifact(artifact) {
+  return {
+    key: artifact.key,
+    kind: artifact.kind,
+    status: artifact.status,
+    contentType: artifact.contentType,
+    contentLength: artifact.contentLength,
+    bytes: artifact.bytes,
+    sha256: artifact.sha256,
+    etag: artifact.etag,
+    cacheControl: artifact.cacheControl,
+    ok: artifact.ok,
+  };
+}
+
+/**
+ * A/B parity: two reports must describe the same tree, byte for byte. `baseUrl` and every
+ * timing/telemetry field are excluded by construction (they are not part of `comparableArtifact`),
+ * which is exactly the "diff of the two JSON reports is empty except for baseUrl" criterion.
+ */
+export function compareReports(a, b) {
+  const differences = [];
+  if (a.revision !== b.revision) {
+    differences.push({ scope: 'revision', a: a.revision, b: b.revision });
+  }
+  const byKey = (report) => new Map(report.artifacts.map((artifact) => [artifact.key, artifact]));
+  const artifactsA = byKey(a);
+  const artifactsB = byKey(b);
+  for (const key of artifactsA.keys()) {
+    if (!artifactsB.has(key)) differences.push({ scope: 'missing-in-b', key });
+  }
+  for (const key of artifactsB.keys()) {
+    if (!artifactsA.has(key)) differences.push({ scope: 'missing-in-a', key });
+  }
+  for (const [key, artifactA] of artifactsA) {
+    const artifactB = artifactsB.get(key);
+    if (!artifactB) continue;
+    const left = comparableArtifact(artifactA);
+    const right = comparableArtifact(artifactB);
+    for (const field of Object.keys(left)) {
+      if (JSON.stringify(left[field]) !== JSON.stringify(right[field])) {
+        differences.push({ scope: 'artifact', key, field, a: left[field], b: right[field] });
+      }
+    }
+  }
+  return { equal: differences.length === 0, differences };
+}
+
+// ---------------------------------------------------------------------------
+// HTTP
+// ---------------------------------------------------------------------------
+
+function createFetcher(baseUrl, options) {
+  const bypass = process.env.VERCEL_AUTOMATION_BYPASS_SECRET;
+  const baseHeaders = {
+    // The API is a machine contract; asking for identity keeps `content-length` comparable with
+    // the declared byte size instead of a compressed transfer size.
+    'accept-encoding': 'identity',
+    'user-agent': 'vgpu-verify-examples-api-deployment/1',
+    ...(bypass ? { 'x-vercel-protection-bypass': bypass, 'x-vercel-set-bypass-cookie': 'false' } : {}),
+  };
+
+  return async function request(path, { method = 'GET', headers = {} } = {}) {
+    const url = `${baseUrl}${path}`;
+    let lastError;
+    for (let attempt = 0; attempt <= options.retries; attempt += 1) {
+      if (attempt > 0) await sleep(backoffDelayMs(attempt - 1));
+      let response;
+      try {
+        response = await fetch(url, {
+          method,
+          headers: { ...baseHeaders, ...headers },
+          redirect: 'error',
+          cache: 'no-store',
+          signal: AbortSignal.timeout(options.timeoutMs),
+        });
+      } catch (error) {
+        lastError = error;
+        continue;
+      }
+      const block = detectBlock(response.status, response.headers);
+      if (block.blocked) {
+        await response.arrayBuffer().catch(() => undefined);
+        lastError = new BlockedError(`${block.reason}: ${block.detail}`, { ...block, url });
+        // Mitigation/SSO clears on its own (or never); back off harder before giving up.
+        if (attempt < options.retries) await sleep(backoffDelayMs(attempt, 2000, 15_000));
+        continue;
+      }
+      if (isRetriableStatus(response.status) && attempt < options.retries) {
+        await response.arrayBuffer().catch(() => undefined);
+        lastError = new Error(`HTTP ${response.status}`);
+        continue;
+      }
+      const body = method === 'HEAD' ? new Uint8Array() : new Uint8Array(await response.arrayBuffer());
+      return { url, status: response.status, headers: response.headers, body };
+    }
+    if (lastError instanceof BlockedError) throw lastError;
+    throw new BlockedError(
+      `Unreachable after ${options.retries + 1} attempts: ${url} (${lastError?.message ?? 'unknown error'})`,
+      { reason: 'network', url },
+    );
+  };
+}
+
+const sleep = (ms) => new Promise((done) => setTimeout(done, ms));
+
+async function mapWithConcurrency(items, limit, worker) {
+  const results = new Array(items.length);
+  let cursor = 0;
+  const runners = Array.from({ length: Math.min(limit, items.length) }, async () => {
+    for (;;) {
+      const index = cursor;
+      cursor += 1;
+      if (index >= items.length) return;
+      results[index] = await worker(items[index], index);
+    }
+  });
+  await Promise.all(runners);
+  return results;
+}
+
+// ---------------------------------------------------------------------------
+// Artifact probing
+// ---------------------------------------------------------------------------
+
+/**
+ * Fetches one artifact and grades it against `expected` (from the revision manifest) or, when the
+ * artifact is one of the three self-describing entry documents, against the invariants the route
+ * itself must satisfy.
+ */
+async function probeArtifact(request, key, expected) {
+  const path = artifactPathForKey(key);
+  const response = await request(path);
+  const problems = [];
+  const header = (name) => response.headers.get(name) ?? undefined;
+  const contentType = header('content-type');
+  const contentLengthHeader = header('content-length');
+  const contentLength = contentLengthHeader === undefined ? undefined : Number(contentLengthHeader);
+  const digest = sha256(response.body);
+
+  if (response.status !== 200) problems.push(`expected HTTP 200, got ${response.status}`);
+  const wantedContentType = expected?.contentType ? expectedContentType(expected.contentType) : JSON_CONTENT_TYPE;
+  if (contentType !== wantedContentType) {
+    problems.push(`content-type ${JSON.stringify(contentType ?? null)} != ${JSON.stringify(wantedContentType)}`);
+  }
+  if (contentLength === undefined || Number.isNaN(contentLength)) {
+    problems.push('missing content-length header');
+  } else if (contentLength !== response.body.byteLength) {
+    problems.push(`content-length ${contentLength} != received ${response.body.byteLength} bytes`);
+  }
+  if (expected?.size !== undefined && response.body.byteLength !== expected.size) {
+    problems.push(`size ${response.body.byteLength} != declared ${expected.size}`);
+  }
+  if (expected?.sha256 !== undefined && digest !== expected.sha256) {
+    problems.push(`sha256 ${digest} != declared ${expected.sha256}`);
+  }
+  const etag = normalizeEtag(header('etag'));
+  if (etag !== digest) problems.push(`etag ${JSON.stringify(etag ?? null)} != sha256 of the body`);
+  const cacheControl = header('cache-control');
+  const wantedCacheControl = expectedCacheControl(key);
+  if (cacheControl !== wantedCacheControl) {
+    problems.push(`cache-control ${JSON.stringify(cacheControl ?? null)} != ${JSON.stringify(wantedCacheControl)}`);
+  }
+  if (header('access-control-allow-origin') !== '*') problems.push('missing CORS allow-origin: *');
+  if (header('x-content-type-options') !== 'nosniff') problems.push('missing x-content-type-options: nosniff');
+
+  return {
+    key,
+    path,
+    kind: artifactKind(key),
+    status: response.status,
+    contentType: contentType ?? null,
+    contentLength: contentLength ?? null,
+    bytes: response.body.byteLength,
+    sha256: digest,
+    etag: etag ?? null,
+    cacheControl: cacheControl ?? null,
+    declared: expected ? { size: expected.size ?? null, sha256: expected.sha256 ?? null, contentType: expected.contentType ?? null } : null,
+    anchoredBy: expected?.anchoredBy ?? 'self',
+    ok: problems.length === 0,
+    problems,
+    body: response.body,
+  };
+}
+
+function parseJsonBody(artifact) {
+  try {
+    return JSON.parse(new TextDecoder('utf-8', { fatal: true }).decode(artifact.body));
+  } catch (error) {
+    artifact.ok = false;
+    artifact.problems.push(`invalid JSON: ${error instanceof Error ? error.message : String(error)}`);
+    return undefined;
+  }
+}
+
+/** URLs inside the documents carry the BAKED origin (https://vgpu.sh), so only the path travels. */
+function keyFromReferencedUrl(value, problems, label) {
+  if (typeof value !== 'string') {
+    problems.push(`${label}: not a string`);
+    return undefined;
+  }
+  let parsed;
+  try {
+    parsed = new URL(value);
+  } catch {
+    problems.push(`${label}: not an absolute URL (${value})`);
+    return undefined;
+  }
+  const key = keyForArtifactPath(parsed.pathname);
+  if (!key) problems.push(`${label}: path outside the artifact namespace (${parsed.pathname})`);
+  return key;
+}
+
+// ---------------------------------------------------------------------------
+// Local tree cross-check
+// ---------------------------------------------------------------------------
+
+async function loadLocalTree(directory) {
+  const root = resolve(repoRoot, directory);
+  const entries = new Map();
+  const walk = async (current, prefix) => {
+    let listing;
+    try {
+      listing = await readdir(current, { withFileTypes: true });
+    } catch (error) {
+      throw new Error(`Cannot read local tree ${root}: ${error instanceof Error ? error.message : String(error)}`);
+    }
+    for (const entry of listing) {
+      const key = prefix ? `${prefix}/${entry.name}` : entry.name;
+      if (entry.isDirectory()) await walk(join(current, entry.name), key);
+      else if (entry.isFile()) {
+        const bytes = await readFile(join(current, entry.name));
+        entries.set(key, { size: bytes.byteLength, sha256: sha256(bytes) });
+      }
+    }
+  };
+  await walk(root, '');
+  return { root, entries };
+}
+
+function crossCheckLocalTree(tree, report, requireLocal) {
+  const mismatches = [];
+  const served = new Map(report.artifacts.map((artifact) => [artifact.key, artifact]));
+  for (const [key, local] of tree.entries) {
+    const artifact = served.get(key);
+    if (!artifact) {
+      mismatches.push({ key, problem: 'present in the checkout, not served by the deployment' });
+      continue;
+    }
+    if (artifact.sha256 !== local.sha256) {
+      mismatches.push({ key, problem: `sha256 differs (deployment ${artifact.sha256}, checkout ${local.sha256})` });
+    } else if (artifact.bytes !== local.size) {
+      mismatches.push({ key, problem: `size differs (deployment ${artifact.bytes}, checkout ${local.size})` });
+    }
+  }
+  for (const key of served.keys()) {
+    if (!tree.entries.has(key)) mismatches.push({ key, problem: 'served by the deployment, absent from the checkout' });
+  }
+  const localRevisionKey = [...tree.entries.keys()].find((key) => key.endsWith('/revision.json'));
+  const localRevision = localRevisionKey?.split('/').at(-2);
+  const sameRevision = localRevision === report.revision;
+  return {
+    root: tree.root,
+    revision: localRevision ?? null,
+    sameRevision,
+    // A checkout that predates the deployment is a stale workspace, not a broken deployment: it is
+    // only fatal when the caller says the checkout IS the expected source of truth.
+    fatal: requireLocal ? mismatches.length > 0 || !sameRevision : sameRevision && mismatches.length > 0,
+    mismatches,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Full-tree verification of one deployment
+// ---------------------------------------------------------------------------
+
+export async function verifyDeployment(baseUrl, options = {}) {
+  const settings = {
+    concurrency: 8,
+    timeoutMs: 30_000,
+    retries: 4,
+    headAll: false,
+    localTree: undefined,
+    requireLocal: false,
+    onArtifact: undefined,
+    ...options,
+  };
+  const request = settings.request ?? createFetcher(baseUrl, settings);
+  const startedAt = new Date();
+  const problems = [];
+  const artifacts = [];
+  // Declared up here (not at the probe step) so the early returns below can build a report.
+  let probes = [];
+  const record = (artifact) => {
+    artifacts.push(artifact);
+    settings.onArtifact?.(artifact);
+    return artifact;
+  };
+
+  // 1. Discovery: the only entry point a client is allowed to hardcode.
+  const discovery = record(await probeArtifact(request, DISCOVERY_ARTIFACT_KEY));
+  const discoveryDocument = parseJsonBody(discovery);
+  let latestKey = LATEST_ARTIFACT_KEY;
+  if (discoveryDocument) {
+    if (discoveryDocument.protocol !== 'vgpu-examples') problems.push(`discovery.protocol != "vgpu-examples"`);
+    const contract = Array.isArray(discoveryDocument.contracts)
+      ? discoveryDocument.contracts.find((entry) => entry?.id === CONTRACT_ID)
+      : undefined;
+    if (!contract) problems.push(`discovery does not advertise the ${CONTRACT_ID} contract`);
+    else {
+      if (contract.status !== 'active') problems.push(`discovery contract status is ${contract.status}, not "active"`);
+      const key = keyFromReferencedUrl(contract.indexUrl, problems, 'discovery.contracts[].indexUrl');
+      if (key) latestKey = key;
+      if (key && key !== LATEST_ARTIFACT_KEY) problems.push(`discovery points at ${key}, expected ${LATEST_ARTIFACT_KEY}`);
+    }
+  }
+
+  // 2. Latest pointer -> revision + the index digest that anchors the whole tree.
+  const latest = record(await probeArtifact(request, latestKey));
+  const latestDocument = parseJsonBody(latest);
+  const revision = typeof latestDocument?.revision === 'string' ? latestDocument.revision : undefined;
+  if (!revision || !SHA256_HEX.test(revision)) {
+    problems.push(`latest.json has no valid revision (${JSON.stringify(latestDocument?.revision ?? null)})`);
+    return finish();
+  }
+  if (latestDocument.contractId !== CONTRACT_ID) problems.push(`latest.contractId != ${CONTRACT_ID}`);
+  const prefix = revisionArtifactKeyPrefix(revision);
+  const indexKeyFromLatest = keyFromReferencedUrl(latestDocument.indexUrl, problems, 'latest.indexUrl');
+  if (indexKeyFromLatest && indexKeyFromLatest !== `${prefix}/index.json`) {
+    problems.push(`latest.indexUrl points at ${indexKeyFromLatest}, expected ${prefix}/index.json`);
+  }
+
+  // 3. Revision manifest: the declared size/sha256/content-type of every object in the tree.
+  const revisionKey = `${prefix}/revision.json`;
+  const revisionArtifact = record(await probeArtifact(request, revisionKey));
+  const revisionDocument = parseJsonBody(revisionArtifact);
+  if (revisionDocument?.revision !== revision) problems.push(`revision.json declares ${revisionDocument?.revision}, latest says ${revision}`);
+  const objects = Array.isArray(revisionDocument?.objects) ? revisionDocument.objects : [];
+  if (objects.length === 0) {
+    problems.push('revision.json declares no objects');
+    return finish();
+  }
+  const declared = new Map();
+  for (const object of objects) {
+    if (!object || typeof object.key !== 'string' || !SHA256_HEX.test(object.sha256 ?? '') ||
+        !Number.isSafeInteger(object.size) || typeof object.contentType !== 'string') {
+      problems.push(`revision.json has an invalid object entry: ${JSON.stringify(object)}`);
+      continue;
+    }
+    if (!object.key.startsWith(`${prefix}/`)) problems.push(`revision.json object outside the revision prefix: ${object.key}`);
+    declared.set(object.key, { size: object.size, sha256: object.sha256, contentType: object.contentType, anchoredBy: 'revision.json' });
+  }
+
+  // 4. Index: doubly anchored (revision.json AND latest.indexSha256).
+  const indexKey = `${prefix}/index.json`;
+  if (!declared.has(indexKey)) problems.push(`revision.json does not declare ${indexKey}`);
+  const index = record(await probeArtifact(request, indexKey, declared.get(indexKey)));
+  if (typeof latestDocument.indexSha256 === 'string' && latestDocument.indexSha256 !== index.sha256) {
+    index.ok = false;
+    index.problems.push(`sha256 ${index.sha256} != latest.indexSha256 ${latestDocument.indexSha256}`);
+  }
+  const indexDocument = parseJsonBody(index);
+  if (indexDocument && indexDocument.revision !== revision) problems.push(`index.revision != ${revision}`);
+
+  // 5. Manifests, then every file they reference. Fetched in dependency order so a manifest's
+  //    declarations are cross-checked against the revision manifest before the files are pulled.
+  const referenced = new Set([indexKey]);
+  const manifestKeys = [];
+  for (const entry of Array.isArray(indexDocument?.examples) ? indexDocument.examples : []) {
+    const key = keyFromReferencedUrl(entry?.manifestUrl, problems, `index.examples[${entry?.id}].manifestUrl`);
+    if (!key) continue;
+    if (!declared.has(key)) problems.push(`index references an undeclared manifest: ${key}`);
+    manifestKeys.push(key);
+    referenced.add(key);
+  }
+  if (manifestKeys.length === 0) problems.push('index.json lists no examples');
+
+  const manifests = await mapWithConcurrency(manifestKeys, settings.concurrency, (key) =>
+    probeArtifact(request, key, declared.get(key)),
+  );
+  const fileKeys = [];
+  for (const manifest of manifests) {
+    record(manifest);
+    const document = parseJsonBody(manifest);
+    for (const file of Array.isArray(document?.files) ? document.files : []) {
+      const key = keyFromReferencedUrl(file?.url, problems, `${manifest.key}.files[].url`);
+      if (!key) continue;
+      const declaration = declared.get(key);
+      if (!declaration) {
+        problems.push(`${manifest.key} references an undeclared file: ${key}`);
+      } else {
+        // The manifest and the revision manifest are two independent declarations of the same
+        // bytes; if they disagree, no fetch can be trusted.
+        if (file.sha256 !== declaration.sha256) problems.push(`${key}: manifest sha256 != revision.json sha256`);
+        if (file.size !== declaration.size) problems.push(`${key}: manifest size != revision.json size`);
+      }
+      fileKeys.push(key);
+      referenced.add(key);
+    }
+  }
+
+  const files = await mapWithConcurrency(fileKeys, settings.concurrency, (key) =>
+    probeArtifact(request, key, declared.get(key)),
+  );
+  for (const file of files) record(file);
+
+  // 6. Closure: nothing declared may be unreachable, nothing served may be undeclared.
+  for (const key of declared.keys()) {
+    if (!referenced.has(key)) problems.push(`revision.json declares an object no document references: ${key}`);
+  }
+
+  // 7. Contract probes on the entry documents: HEAD and conditional GET are part of the published
+  //    contract (`Access-Control-Allow-Methods: GET, HEAD, OPTIONS`), and a deployment that serves
+  //    the right bytes but breaks caching is not at parity.
+  const probeKeys = settings.headAll ? artifacts.map((artifact) => artifact.key) : [DISCOVERY_ARTIFACT_KEY, latestKey, indexKey];
+  const byKey = new Map(artifacts.map((artifact) => [artifact.key, artifact]));
+  probes = await mapWithConcurrency(probeKeys, settings.concurrency, async (key) => {
+    const artifact = byKey.get(key);
+    const path = artifactPathForKey(key);
+    const problemsForProbe = [];
+    const head = await request(path, { method: 'HEAD' });
+    if (head.status !== 200) problemsForProbe.push(`HEAD ${path}: HTTP ${head.status}`);
+    if (Number(head.headers.get('content-length')) !== artifact.bytes) {
+      problemsForProbe.push(`HEAD ${path}: content-length ${head.headers.get('content-length')} != ${artifact.bytes}`);
+    }
+    if (head.headers.get('content-type') !== artifact.contentType) {
+      problemsForProbe.push(`HEAD ${path}: content-type differs from GET`);
+    }
+    const conditional = await request(path, { method: 'GET', headers: { 'if-none-match': `"${artifact.sha256}"` } });
+    if (conditional.status !== 304) problemsForProbe.push(`If-None-Match ${path}: expected 304, got ${conditional.status}`);
+    return { key, ok: problemsForProbe.length === 0, problems: problemsForProbe };
+  });
+  for (const probe of probes) {
+    if (!probe.ok) problems.push(...probe.problems);
+  }
+
+  return finish();
+
+  function finish() {
+    for (const artifact of artifacts) delete artifact.body;
+    artifacts.sort((left, right) => (left.key < right.key ? -1 : left.key > right.key ? 1 : 0));
+    const finishedAt = new Date();
+    const failed = artifacts.filter((artifact) => !artifact.ok);
+    const report = {
+      tool: 'verify-examples-api-deployment',
+      reportVersion: 1,
+      baseUrl,
+      revision: revision ?? null,
+      contractId: CONTRACT_ID,
+      startedAt: startedAt.toISOString(),
+      finishedAt: finishedAt.toISOString(),
+      durationMs: finishedAt.getTime() - startedAt.getTime(),
+      counts: {
+        total: artifacts.length,
+        ok: artifacts.length - failed.length,
+        failed: failed.length,
+        byKind: countByKind(artifacts),
+      },
+      artifacts,
+      probes: typeof probes === 'undefined' ? [] : probes,
+      problems,
+      localTree: null,
+      ok: failed.length === 0 && problems.length === 0,
+    };
+    return report;
+  }
+}
+
+function countByKind(artifacts) {
+  const counts = {};
+  for (const artifact of artifacts) counts[artifact.kind] = (counts[artifact.kind] ?? 0) + 1;
+  return counts;
+}
+
+// ---------------------------------------------------------------------------
+// Reporting
+// ---------------------------------------------------------------------------
+
+export function formatArtifactLine(artifact) {
+  const status = artifact.ok ? 'ok  ' : 'FAIL';
+  const size = String(artifact.bytes).padStart(8);
+  return `  ${status} ${size}B  ${artifact.sha256.slice(0, 12)}  ${artifact.path}`;
+}
+
+export function formatReport(report, { verbose = false } = {}) {
+  const lines = [];
+  lines.push(`# ${report.baseUrl}`);
+  lines.push(`  revision   ${report.revision ?? '(none)'}`);
+  lines.push(`  artifacts  ${report.counts.total} (${JSON.stringify(report.counts.byKind)})`);
+  for (const artifact of report.artifacts) {
+    if (verbose || !artifact.ok) lines.push(formatArtifactLine(artifact));
+    if (!artifact.ok) for (const problem of artifact.problems) lines.push(`         - ${problem}`);
+  }
+  for (const problem of report.problems) lines.push(`  ! ${problem}`);
+  if (report.localTree) {
+    lines.push(`  local tree ${report.localTree.root}`);
+    lines.push(`             revision ${report.localTree.revision ?? '(none)'} — ${report.localTree.sameRevision ? 'same as the deployment' : 'DIFFERENT from the deployment'}`);
+    for (const mismatch of report.localTree.mismatches) lines.push(`         - ${mismatch.key}: ${mismatch.problem}`);
+  }
+  lines.push(`  verdict    ${report.ok ? 'PASS' : 'FAIL'} — ${report.counts.ok}/${report.counts.total} artifacts verified byte-for-byte`);
+  return lines.join('\n');
+}
+
+export function formatComparison(comparison, a, b) {
+  const lines = [];
+  lines.push('# A/B parity');
+  lines.push(`  A  ${a.baseUrl}`);
+  lines.push(`  B  ${b.baseUrl}`);
+  for (const difference of comparison.differences.slice(0, 50)) {
+    lines.push(`  ! ${JSON.stringify(difference)}`);
+  }
+  if (comparison.differences.length > 50) lines.push(`  ! ... and ${comparison.differences.length - 50} more differences`);
+  lines.push(`  verdict    ${comparison.equal ? 'PASS' : 'FAIL'} — ${comparison.equal ? 'both deployments serve the same tree, byte for byte' : `${comparison.differences.length} differences`}`);
+  return lines.join('\n');
+}
+
+const USAGE = `Usage:
+  node scripts/verify-examples-api-deployment.mjs <baseUrl> [<baseUrlB>] [options]
+
+Verifies every artifact of the vgpu examples API served by a deployment (discovery, latest
+pointer, revision manifest, index, every example manifest and every source file) against the
+sizes, content types and sha256 digests the deployment itself declares, and — with two URLs —
+that both deployments serve exactly the same tree.
+
+Options:
+  --compare <url>     second deployment (same as a second positional URL)
+  --local[=<dir>]     cross-check against a generated tree in the checkout
+                      (default ${DEFAULT_LOCAL_TREE})
+  --require-local     a local-tree revision mismatch becomes a failure
+  --json <file>       write the machine-readable report
+  --concurrency <n>   parallel requests (default 8)
+  --timeout <ms>      per-request timeout (default 30000)
+  --retries <n>       retries for transient failures (default 4)
+  --head-all          send HEAD + conditional GET probes for every artifact
+  --verbose           one line per artifact
+  --help
+
+Exit codes: 0 pass, 1 parity/integrity failure, 2 usage error, 75 BLOCKED (inconclusive).`;
+
+// ---------------------------------------------------------------------------
+// CLI
+// ---------------------------------------------------------------------------
+
+async function main(argv) {
+  let options;
+  try {
+    options = parseArguments(argv);
+  } catch (error) {
+    console.error(`verify-examples-api-deployment: ${error instanceof Error ? error.message : String(error)}\n\n${USAGE}`);
+    return EXIT_USAGE;
+  }
+  if (options.help) {
+    console.log(USAGE);
+    return EXIT_PASS;
+  }
+
+  const tree = options.localTree ? await loadLocalTree(options.localTree) : undefined;
+  const reports = [];
+  for (const baseUrl of options.urls) {
+    console.log(`verify-examples-api-deployment: walking ${baseUrl} ...`);
+    const report = await verifyDeployment(baseUrl, options);
+    if (tree) {
+      report.localTree = crossCheckLocalTree(tree, report, options.requireLocal);
+      if (report.localTree.fatal) report.ok = false;
+    }
+    reports.push(report);
+    console.log(formatReport(report, { verbose: options.verbose }));
+  }
+
+  const comparison = reports.length === 2 ? compareReports(reports[0], reports[1]) : undefined;
+  if (comparison) console.log(formatComparison(comparison, reports[0], reports[1]));
+
+  if (options.jsonPath) {
+    const document = comparison
+      ? { mode: 'ab', a: reports[0], b: reports[1], comparison }
+      : { mode: 'single', ...reports[0] };
+    await writeFile(resolve(process.cwd(), options.jsonPath), `${JSON.stringify(document, null, 2)}\n`);
+    console.log(`verify-examples-api-deployment: report written to ${options.jsonPath}`);
+  }
+
+  const passed = reports.every((report) => report.ok) && (comparison ? comparison.equal : true);
+  console.log(`verify-examples-api-deployment: ${passed ? 'PASS' : 'FAIL'}`);
+  return passed ? EXIT_PASS : EXIT_FAIL;
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  try {
+    process.exitCode = await main(process.argv.slice(2));
+  } catch (error) {
+    if (error instanceof BlockedError) {
+      const advice = {
+        'deployment-protection':
+          'The deployment is behind Vercel Deployment Protection. Set VERCEL_AUTOMATION_BYPASS_SECRET\n' +
+          '(Project Settings -> Deployment Protection -> Protection Bypass for Automation) and re-run.\n',
+        'bot-mitigation':
+          "Vercel's anti-bot mitigation is transient and unrelated to the artifact bytes: wait a few\n" +
+          'minutes and re-run (the script already backs off), or re-run from a different network.\n',
+        network: 'The URL was unreachable (DNS, TLS, timeout or a closed port). Check the URL and the network.\n',
+      };
+      console.error(
+        `verify-examples-api-deployment: BLOCKED — ${error.message}\n` +
+          'This is NOT a parity failure: the deployment could not be interrogated.\n' +
+          (advice[error.detail?.reason] ?? ''),
+      );
+      process.exitCode = EXIT_BLOCKED;
+    } else {
+      console.error(`verify-examples-api-deployment: ${error instanceof Error ? error.stack : String(error)}`);
+      process.exitCode = EXIT_FAIL;
+    }
+  }
+}

--- a/scripts/verify-examples-api-deployment.mjs
+++ b/scripts/verify-examples-api-deployment.mjs
@@ -337,6 +337,14 @@ function createFetcher(baseUrl, options) {
         });
       } catch (error) {
         lastError = error;
+        // `redirect: 'error'` rejects with a bare TypeError, indistinguishable from a DNS or TLS
+        // failure — and the difference is the difference between the two verdicts this script is
+        // careful to keep apart. A redirect is a real, deployment-side defect: the CLI fetches with
+        // `redirect: 'error'` too, so an apex→www rewrite takes the API down for every client
+        // (apps/docs/examples-api.md § Production setup). An unreachable host is inconclusive.
+        // Re-probe once without following redirects to tell them apart.
+        const redirected = await probeRedirect(url, method, { ...baseHeaders, ...headers }, options.timeoutMs);
+        if (redirected) return redirected;
         continue;
       }
       const block = detectBlock(response.status, response.headers);
@@ -360,6 +368,31 @@ function createFetcher(baseUrl, options) {
       `Unreachable after ${options.retries + 1} attempts: ${url} (${lastError?.message ?? 'unknown error'})`,
       { reason: 'network', url },
     );
+  };
+}
+
+/**
+ * Second opinion after a rejected fetch: was it a redirect this script refused to follow? Returns a
+ * synthetic response (so the artifact is graded, and fails, like any other wrong answer) or
+ * `undefined` when the host is simply unreachable — in which case the caller keeps retrying and
+ * ends at BLOCKED. A mitigation challenge that redirects stays BLOCKED too, on purpose.
+ */
+async function probeRedirect(url, method, headers, timeoutMs) {
+  let response;
+  try {
+    response = await fetch(url, { method, headers, redirect: 'manual', cache: 'no-store', signal: AbortSignal.timeout(timeoutMs) });
+  } catch {
+    return undefined;
+  }
+  await response.arrayBuffer().catch(() => undefined);
+  const isRedirect = response.status >= 300 && response.status < 400;
+  if (!isRedirect || response.headers.get('x-vercel-mitigated')) return undefined;
+  return {
+    url,
+    status: response.status,
+    headers: response.headers,
+    body: new Uint8Array(),
+    redirectedTo: response.headers.get('location') ?? '(no Location header)',
   };
 }
 
@@ -400,6 +433,12 @@ async function probeArtifact(request, key, expected) {
   const digest = sha256(response.body);
 
   if (response.status !== 200) problems.push(`expected HTTP 200, got ${response.status}`);
+  if (response.redirectedTo !== undefined) {
+    problems.push(
+      `unexpected redirect to ${response.redirectedTo} — the CLI fetches with redirect: 'error', ` +
+        'so any redirect on this host (an apex→www rewrite, a trailing-slash rule) fails every client',
+    );
+  }
   const wantedContentType = expected?.contentType ? expectedContentType(expected.contentType) : JSON_CONTENT_TYPE;
   if (contentType !== wantedContentType) {
     problems.push(`content-type ${JSON.stringify(contentType ?? null)} != ${JSON.stringify(wantedContentType)}`);
@@ -627,10 +666,14 @@ export async function verifyDeployment(baseUrl, options = {}) {
   //    declarations are cross-checked against the revision manifest before the files are pulled.
   const referenced = new Set([indexKey]);
   const manifestKeys = [];
+  // The index carries its own hash and file count for every manifest, independently of
+  // revision.json — a third anchor, so keep it.
+  const indexAnchors = new Map();
   for (const entry of Array.isArray(indexDocument?.examples) ? indexDocument.examples : []) {
     const key = keyFromReferencedUrl(entry?.manifestUrl, problems, `index.examples[${entry?.id}].manifestUrl`);
     if (!key) continue;
     if (!declared.has(key)) problems.push(`index references an undeclared manifest: ${key}`);
+    indexAnchors.set(key, { manifestSha256: entry?.manifestSha256, fileCount: entry?.fileCount });
     manifestKeys.push(key);
     referenced.add(key);
   }
@@ -643,6 +686,16 @@ export async function verifyDeployment(baseUrl, options = {}) {
   for (const manifest of manifests) {
     record(manifest);
     const document = parseJsonBody(manifest);
+    const anchor = indexAnchors.get(manifest.key);
+    if (typeof anchor?.manifestSha256 === 'string' && anchor.manifestSha256 !== manifest.sha256) {
+      manifest.ok = false;
+      manifest.problems.push(`sha256 ${manifest.sha256} != index.manifestSha256 ${anchor.manifestSha256}`);
+    }
+    const fileCount = Array.isArray(document?.files) ? document.files.length : undefined;
+    if (Number.isSafeInteger(anchor?.fileCount) && anchor.fileCount !== fileCount) {
+      problems.push(`${manifest.key}: index says fileCount ${anchor.fileCount}, the manifest lists ${fileCount}`);
+    }
+    if (document && document.revision !== revision) problems.push(`${manifest.key}: revision != ${revision}`);
     for (const file of Array.isArray(document?.files) ? document.files : []) {
       const key = keyFromReferencedUrl(file?.url, problems, `${manifest.key}.files[].url`);
       if (!key) continue;

--- a/scripts/verify-examples-api-deployment.test.ts
+++ b/scripts/verify-examples-api-deployment.test.ts
@@ -16,6 +16,7 @@ import { createServer, type Server } from "node:http";
 import type { AddressInfo } from "node:net";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
+import { gzipSync } from "node:zlib";
 import { afterEach, expect, test } from "vitest";
 // @ts-expect-error -- dependency-free .mjs script, intentionally untyped (see the file header).
 import * as verifier from "./verify-examples-api-deployment.mjs";
@@ -168,7 +169,16 @@ test("compareReports ignores baseUrl and timings but not bytes", () => {
 // Full-tree crawl against a replay of the committed artifact tree
 // ---------------------------------------------------------------------------
 
-type Mutation = (key: string, bytes: Buffer) => { bytes?: Buffer; contentType?: string; status?: number } | undefined;
+/**
+ * One-thing-at-a-time break. `headers` values overwrite the header the route would have sent;
+ * `null` removes it. Header mutations are what keep the verifier honest in the OTHER direction:
+ * they fail only while the corresponding assertion still exists in the script, so deleting an
+ * assertion turns one of these tests red.
+ */
+type Mutation = (
+  key: string,
+  bytes: Buffer,
+) => { bytes?: Buffer; status?: number; headers?: Record<string, string | null> } | undefined;
 
 function loadTree(): Map<string, Buffer> {
   const files = new Map<string, Buffer>();
@@ -218,14 +228,20 @@ async function startReplayServer(mutate?: Mutation): Promise<string> {
       "access-control-allow-origin": "*",
       "x-content-type-options": "nosniff",
       "cache-control": expectedCacheControl(key),
-      "content-type": override.contentType ?? contentTypeFor(key),
+      "content-type": contentTypeFor(key),
       etag: `"${digest}"`,
     };
+    for (const [name, value] of Object.entries(override.headers ?? {})) {
+      if (value === null) delete headers[name];
+      else headers[name] = value;
+    }
+    // The real route derives the ETag from the bytes, so conditional GET keeps working even when a
+    // mutation lies about the ETag header.
     if (request.headers["if-none-match"] === `"${digest}"`) {
       response.writeHead(304, headers).end();
       return;
     }
-    headers["content-length"] = String(bytes.byteLength);
+    headers["content-length"] ??= String(bytes.byteLength);
     response.writeHead(200, headers).end(request.method === "HEAD" ? undefined : bytes);
   });
   await new Promise<void>((ready) => server.listen(0, "127.0.0.1", ready));
@@ -260,15 +276,276 @@ test("one flipped byte in one source file turns the verdict red", async () => {
   expect(failed[0].problems.join(" ")).toMatch(/sha256 .* != declared/);
 }, 60_000);
 
+test("a truncated file is reported as both a size and a hash mismatch", async () => {
+  // Length and hash are separate declarations, so both assertions must exist: a mutant that dropped
+  // the size check would otherwise hide behind sha256.
+  const target = [...tree.keys()].find((key) => key.endsWith("renderer.ts.raw"))!;
+  const baseUrl = await startReplayServer((key, bytes) => (key === target ? { bytes: bytes.subarray(0, bytes.length - 3) } : undefined));
+  const report = await verifyDeployment(baseUrl, runOptions);
+  expect(report.ok).toBe(false);
+  const failed = report.artifacts.filter((artifact: { ok: boolean }) => !artifact.ok);
+  expect(failed.map((artifact: { key: string }) => artifact.key)).toEqual([target]);
+  expect(failed[0].problems.join(" ")).toMatch(/size \d+ != declared \d+/);
+  expect(failed[0].problems.join(" ")).toMatch(/sha256 .* != declared/);
+}, 60_000);
+
 test("a wrong content-type on a source file is caught even when the bytes are right", async () => {
   const target = [...tree.keys()].find((key) => key.endsWith("shader.wgsl.raw"))!;
-  const baseUrl = await startReplayServer((key) => (key === target ? { contentType: "text/plain; charset=utf-8" } : undefined));
+  const baseUrl = await startReplayServer((key) =>
+    key === target ? { headers: { "content-type": "text/plain; charset=utf-8" } } : undefined,
+  );
   const report = await verifyDeployment(baseUrl, runOptions);
   expect(report.ok).toBe(false);
   expect(report.artifacts.find((artifact: { key: string }) => artifact.key === target).problems.join(" ")).toMatch(
     /content-type .*text\/plain/,
   );
 }, 60_000);
+
+// The tests above break the SERVER; a verifier that dropped an assertion would still pass them
+// as long as sha256 stayed. These break the server in ways only ONE assertion can see, so removing
+// that assertion from the script turns exactly one of them red (mutation testing, per review).
+
+test("an ETag that is not the sha256 of the body is caught, with the right bytes served", async () => {
+  const target = [...tree.keys()].find((key) => key.endsWith("shader.wgsl.raw"))!;
+  const baseUrl = await startReplayServer((key) => (key === target ? { headers: { etag: `"${"c".repeat(64)}"` } } : undefined));
+  const report = await verifyDeployment(baseUrl, runOptions);
+  expect(report.ok).toBe(false);
+  const failed = report.artifacts.filter((artifact: { ok: boolean }) => !artifact.ok);
+  expect(failed).toHaveLength(1);
+  expect(failed[0].key).toBe(target);
+  expect(failed[0].problems.join(" ")).toMatch(/etag .* != sha256 of the body/);
+}, 60_000);
+
+test("an immutable revision object served with the mutable cache-control is caught", async () => {
+  const target = [...tree.keys()].find((key) => key.endsWith("index.json"))!;
+  const baseUrl = await startReplayServer((key) =>
+    key === target ? { headers: { "cache-control": MUTABLE_CACHE_CONTROL } } : undefined,
+  );
+  const report = await verifyDeployment(baseUrl, runOptions);
+  expect(report.ok).toBe(false);
+  const failed = report.artifacts.filter((artifact: { ok: boolean }) => !artifact.ok);
+  expect(failed).toHaveLength(1);
+  expect(failed[0].problems.join(" ")).toMatch(/cache-control .*max-age=60.* != .*immutable/);
+}, 60_000);
+
+test("a missing CORS allow-origin is caught — the CLI is a cross-origin client", async () => {
+  const target = LATEST_ARTIFACT_KEY;
+  const baseUrl = await startReplayServer((key) =>
+    key === target ? { headers: { "access-control-allow-origin": null } } : undefined,
+  );
+  const report = await verifyDeployment(baseUrl, runOptions);
+  expect(report.ok).toBe(false);
+  const failed = report.artifacts.filter((artifact: { ok: boolean }) => !artifact.ok);
+  expect(failed).toHaveLength(1);
+  expect(failed[0].key).toBe(target);
+  expect(failed[0].problems).toContain("missing CORS allow-origin: *");
+}, 60_000);
+
+test("a missing x-content-type-options is caught", async () => {
+  const target = DISCOVERY_ARTIFACT_KEY;
+  const baseUrl = await startReplayServer((key) =>
+    key === target ? { headers: { "x-content-type-options": null } } : undefined,
+  );
+  const report = await verifyDeployment(baseUrl, runOptions);
+  expect(report.ok).toBe(false);
+  const failed = report.artifacts.filter((artifact: { ok: boolean }) => !artifact.ok);
+  expect(failed).toHaveLength(1);
+  expect(failed[0].key).toBe(target);
+  expect(failed[0].problems).toContain("missing x-content-type-options: nosniff");
+}, 60_000);
+
+// --- graph closure, one branch per test ------------------------------------
+// All three serve a tree where every object is individually perfect: only the relationship between
+// the documents is wrong. Nothing but the closure checks can see them.
+
+const revisionKey = [...tree.keys()].find((key) => key.endsWith("/revision.json"))!;
+
+/** Rewrites revision.json's `objects` array; every other artifact stays byte-perfect. */
+function withRevisionObjects(transform: (objects: { key: string }[]) => { key: string }[]): Mutation {
+  return (key, bytes) => {
+    if (key !== revisionKey) return undefined;
+    const document = JSON.parse(bytes.toString("utf8"));
+    return { bytes: Buffer.from(JSON.stringify({ ...document, objects: transform(document.objects) })) };
+  };
+}
+
+test("a manifest the index references but revision.json does not declare is caught", async () => {
+  const orphanedManifest = [...tree.keys()].find((key) => key.endsWith("/manifest.json"))!;
+  const baseUrl = await startReplayServer(
+    withRevisionObjects((objects) => objects.filter((object) => object.key !== orphanedManifest)),
+  );
+  const report = await verifyDeployment(baseUrl, runOptions);
+  expect(report.ok).toBe(false);
+  expect(report.problems).toContain(`index references an undeclared manifest: ${orphanedManifest}`);
+  // Every object still serves perfect bytes: only the relationship is broken.
+  expect(report.artifacts.filter((artifact: { ok: boolean }) => !artifact.ok)).toEqual([]);
+}, 60_000);
+
+test("a source file a manifest references but revision.json does not declare is caught", async () => {
+  const orphanedFile = [...tree.keys()].find((key) => key.endsWith(".raw"))!;
+  const baseUrl = await startReplayServer(
+    withRevisionObjects((objects) => objects.filter((object) => object.key !== orphanedFile)),
+  );
+  const report = await verifyDeployment(baseUrl, runOptions);
+  expect(report.ok).toBe(false);
+  expect(
+    report.problems.some(
+      (problem: string) => problem.includes("manifest.json references an undeclared file:") && problem.endsWith(orphanedFile),
+    ),
+  ).toBe(true);
+  // The file itself still serves perfect bytes, but with nothing declaring it there is no
+  // content-type to grade it against, so it also falls back to the entry-document invariant and
+  // fails there. Both signals point at the same undeclared object, and at no other one.
+  const failed = report.artifacts.filter((artifact: { ok: boolean }) => !artifact.ok);
+  expect(failed.map((artifact: { key: string }) => artifact.key)).toEqual([orphanedFile]);
+  expect(failed[0].declared).toBeNull();
+}, 60_000);
+
+test("an object revision.json declares that no document references is caught", async () => {
+  const ghost = `${revisionKey.replace(/revision\.json$/, "")}examples/ghost/files/ghost.ts.raw`;
+  const baseUrl = await startReplayServer(
+    withRevisionObjects((objects) => [
+      ...objects,
+      { key: ghost, size: 1, sha256: "d".repeat(64), contentType: "text/typescript" } as never,
+    ]),
+  );
+  const report = await verifyDeployment(baseUrl, runOptions);
+  expect(report.ok).toBe(false);
+  expect(report.problems).toContain(`revision.json declares an object no document references: ${ghost}`);
+  // A declared-but-unreachable object must not be silently skipped: the tree is still 248 fetches,
+  // and the failure comes from the closure check, not from a 404.
+  expect(report.counts.total).toBe(tree.size);
+  expect(report.artifacts.filter((artifact: { ok: boolean }) => !artifact.ok)).toEqual([]);
+}, 60_000);
+
+// --- the three independent declarations of the same bytes ------------------
+// revision.json, the index and each manifest all declare hashes. Each pair must be checked, or a
+// deployment that serves a self-consistent-but-wrong tree passes.
+
+test("a content-length that disagrees with the body is caught (a compressed response)", async () => {
+  // The realistic shape of this failure: an edge that gzips despite `accept-encoding: identity`, so
+  // content-length is the compressed size while the decoded body — and its sha256 — are correct.
+  const target = [...tree.keys()].find((key) => key.endsWith("index.json"))!;
+  const baseUrl = await startReplayServer((key, bytes) =>
+    key === target
+      ? {
+          bytes: gzipSync(bytes),
+          headers: { "content-encoding": "gzip", "content-length": String(gzipSync(bytes).byteLength) },
+        }
+      : undefined,
+  );
+  const report = await verifyDeployment(baseUrl, runOptions);
+  expect(report.ok).toBe(false);
+  const failed = report.artifacts.filter((artifact: { ok: boolean }) => !artifact.ok);
+  expect(failed.map((artifact: { key: string }) => artifact.key)).toEqual([target]);
+  expect(failed[0].problems.join(" ")).toMatch(/content-length \d+ != received \d+ bytes/);
+}, 60_000);
+
+test("an index whose hash disagrees with latest.indexSha256 is caught", async () => {
+  const indexKey = [...tree.keys()].find((key) => key.endsWith("index.json"))!;
+  const baseUrl = await startReplayServer((key, bytes) =>
+    key === LATEST_ARTIFACT_KEY
+      ? { bytes: Buffer.from(JSON.stringify({ ...JSON.parse(bytes.toString("utf8")), indexSha256: "b".repeat(64) })) }
+      : undefined,
+  );
+  const report = await verifyDeployment(baseUrl, runOptions);
+  expect(report.ok).toBe(false);
+  const failed = report.artifacts.filter((artifact: { ok: boolean }) => !artifact.ok);
+  expect(failed.map((artifact: { key: string }) => artifact.key)).toEqual([indexKey]);
+  expect(failed[0].problems.join(" ")).toMatch(/!= latest\.indexSha256 b{64}/);
+}, 60_000);
+
+test("a manifest whose file declaration disagrees with revision.json is caught", async () => {
+  // Both documents stay internally consistent (the manifest's own hash in revision.json and in the
+  // index is updated to match its new bytes), so ONLY the manifest-vs-revision.json cross-check can
+  // see it: exactly the mutant that survived before.
+  const manifestKey = [...tree.keys()].find((key) => key.endsWith("/manifest.json"))!;
+  const manifestDocument = JSON.parse(tree.get(manifestKey)!.toString("utf8"));
+  const [victim, ...rest] = manifestDocument.files;
+  const mutatedManifest = Buffer.from(
+    JSON.stringify({ ...manifestDocument, files: [{ ...victim, sha256: "e".repeat(64), size: victim.size + 1 }, ...rest] }),
+  );
+  const mutatedDigest = createHash("sha256").update(mutatedManifest).digest("hex");
+  const baseUrl = await startReplayServer((key, bytes) => {
+    if (key === manifestKey) return { bytes: mutatedManifest };
+    if (key === revisionKey) {
+      const document = JSON.parse(bytes.toString("utf8"));
+      return {
+        bytes: Buffer.from(
+          JSON.stringify({
+            ...document,
+            objects: document.objects.map((object: { key: string }) =>
+              object.key === manifestKey ? { ...object, size: mutatedManifest.byteLength, sha256: mutatedDigest } : object,
+            ),
+          }),
+        ),
+      };
+    }
+    if (key.endsWith("index.json")) {
+      const document = JSON.parse(bytes.toString("utf8"));
+      return {
+        bytes: Buffer.from(
+          JSON.stringify({
+            ...document,
+            examples: document.examples.map((entry: { manifestUrl: string; manifestSha256: string }) =>
+              manifestKey.endsWith(new URL(entry.manifestUrl).pathname.split("/revisions/")[1])
+                ? { ...entry, manifestSha256: mutatedDigest }
+                : entry,
+            ),
+          }),
+        ),
+      };
+    }
+    return undefined;
+  });
+  const report = await verifyDeployment(baseUrl, runOptions);
+  expect(report.ok).toBe(false);
+  const messages = report.problems.join(" ");
+  expect(messages).toMatch(/manifest sha256 != revision\.json sha256/);
+  expect(messages).toMatch(/manifest size != revision\.json size/);
+}, 60_000);
+
+test("a manifest whose bytes disagree with the index's manifestSha256 is caught", async () => {
+  // revision.json is updated to match the new manifest bytes, so the index anchor is the only
+  // remaining witness.
+  const manifestKey = [...tree.keys()].find((key) => key.endsWith("/manifest.json"))!;
+  const mutatedManifest = Buffer.concat([tree.get(manifestKey)!, Buffer.from(" ")]);
+  const mutatedDigest = createHash("sha256").update(mutatedManifest).digest("hex");
+  const baseUrl = await startReplayServer((key, bytes) => {
+    if (key === manifestKey) return { bytes: mutatedManifest };
+    if (key === revisionKey) {
+      const document = JSON.parse(bytes.toString("utf8"));
+      return {
+        bytes: Buffer.from(
+          JSON.stringify({
+            ...document,
+            objects: document.objects.map((object: { key: string }) =>
+              object.key === manifestKey ? { ...object, size: mutatedManifest.byteLength, sha256: mutatedDigest } : object,
+            ),
+          }),
+        ),
+      };
+    }
+    return undefined;
+  });
+  const report = await verifyDeployment(baseUrl, runOptions);
+  expect(report.ok).toBe(false);
+  const failed = report.artifacts.filter((artifact: { ok: boolean }) => !artifact.ok);
+  expect(failed.map((artifact: { key: string }) => artifact.key)).toEqual([manifestKey]);
+  expect(failed[0].problems.join(" ")).toMatch(/!= index\.manifestSha256/);
+}, 60_000);
+
+test("a redirect is a parity failure, not an inconclusive BLOCKED", async () => {
+  const server = createServer((_request, response) => {
+    response.writeHead(308, { location: "https://www.vgpu.sh/.well-known/vgpu-examples.json" }).end();
+  });
+  await new Promise<void>((ready) => server.listen(0, "127.0.0.1", ready));
+  servers.push(server);
+  const report = await verifyDeployment(`http://127.0.0.1:${(server.address() as AddressInfo).port}`, runOptions);
+  expect(report.ok).toBe(false);
+  expect(report.artifacts[0].status).toBe(308);
+  expect(report.artifacts[0].problems.join(" ")).toMatch(/unexpected redirect to https:\/\/www\.vgpu\.sh/);
+}, 30_000);
 
 test("an artifact missing from the deployment is a failure, not a silently shorter tree", async () => {
   const target = [...tree.keys()].find((key) => key.endsWith("manifest.json"))!;

--- a/scripts/verify-examples-api-deployment.test.ts
+++ b/scripts/verify-examples-api-deployment.test.ts
@@ -1,0 +1,329 @@
+/**
+ * TGEIST-13 — tests for the G4 deployment parity verifier.
+ *
+ * The interesting half is not the pure helpers: it is that the crawler actually catches a
+ * deployment that serves ALMOST the right tree. So most of these tests boot a real HTTP server on
+ * 127.0.0.1 that replays the committed artifact tree with the same headers the Next route handlers
+ * produce, and then break exactly one thing at a time (one flipped byte, one wrong content-type, a
+ * missing object, a stale index) and assert the verdict turns red for the right reason.
+ *
+ * No network egress: every request goes to the loopback server, and the A/B mode is exercised by
+ * running two of them.
+ */
+import { createHash } from "node:crypto";
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { createServer, type Server } from "node:http";
+import type { AddressInfo } from "node:net";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, expect, test } from "vitest";
+// @ts-expect-error -- dependency-free .mjs script, intentionally untyped (see the file header).
+import * as verifier from "./verify-examples-api-deployment.mjs";
+
+const {
+  DISCOVERY_ARTIFACT_KEY,
+  LATEST_ARTIFACT_KEY,
+  IMMUTABLE_CACHE_CONTROL,
+  MUTABLE_CACHE_CONTROL,
+  artifactKind,
+  artifactPathForKey,
+  backoffDelayMs,
+  compareReports,
+  detectBlock,
+  expectedCacheControl,
+  expectedContentType,
+  formatReport,
+  isRetriableStatus,
+  keyForArtifactPath,
+  normalizeBaseUrl,
+  normalizeEtag,
+  parseArguments,
+  verifyDeployment,
+} = verifier;
+
+const repoRoot = join(fileURLToPath(new URL(".", import.meta.url)), "..");
+const treeRoot = join(repoRoot, "apps/docs/generated/examples-api");
+
+// ---------------------------------------------------------------------------
+// Pure helpers
+// ---------------------------------------------------------------------------
+
+test("artifact keys map to the paths the two route groups actually serve", () => {
+  expect(artifactPathForKey(DISCOVERY_ARTIFACT_KEY)).toBe("/.well-known/vgpu-examples.json");
+  expect(artifactPathForKey(LATEST_ARTIFACT_KEY)).toBe("/api/examples/v1/latest.json");
+  expect(artifactPathForKey("examples/v1/revisions/abc/index.json")).toBe("/api/examples/v1/revisions/abc/index.json");
+  expect(keyForArtifactPath("/.well-known/vgpu-examples.json")).toBe(DISCOVERY_ARTIFACT_KEY);
+  expect(keyForArtifactPath("/api/examples/v1/latest.json")).toBe(LATEST_ARTIFACT_KEY);
+  expect(keyForArtifactPath("/docs/examples")).toBeUndefined();
+});
+
+test("content-type expectation mirrors withCharset in artifact-store.ts", () => {
+  expect(expectedContentType("text/wgsl")).toBe("text/wgsl; charset=utf-8");
+  expect(expectedContentType("text/typescript")).toBe("text/typescript; charset=utf-8");
+  expect(expectedContentType("application/json; charset=utf-8")).toBe("application/json; charset=utf-8");
+  expect(expectedContentType("text/plain; charset=utf-8")).toBe("text/plain; charset=utf-8");
+});
+
+test("only the two mutable artifacts get the revalidating cache-control", () => {
+  expect(expectedCacheControl(DISCOVERY_ARTIFACT_KEY)).toBe(MUTABLE_CACHE_CONTROL);
+  expect(expectedCacheControl(LATEST_ARTIFACT_KEY)).toBe(MUTABLE_CACHE_CONTROL);
+  expect(expectedCacheControl("examples/v1/revisions/abc/index.json")).toBe(IMMUTABLE_CACHE_CONTROL);
+});
+
+test("artifact kinds classify the whole tree", () => {
+  expect(artifactKind(DISCOVERY_ARTIFACT_KEY)).toBe("discovery");
+  expect(artifactKind(LATEST_ARTIFACT_KEY)).toBe("latest");
+  expect(artifactKind("examples/v1/revisions/a/revision.json")).toBe("revision");
+  expect(artifactKind("examples/v1/revisions/a/index.json")).toBe("index");
+  expect(artifactKind("examples/v1/revisions/a/examples/gradient/manifest.json")).toBe("manifest");
+  expect(artifactKind("examples/v1/revisions/a/examples/gradient/files/shader.wgsl.raw")).toBe("file");
+});
+
+test("a weak ETag is not a parity difference", () => {
+  expect(normalizeEtag('"abc"')).toBe("abc");
+  expect(normalizeEtag('W/"abc"')).toBe("abc");
+  expect(normalizeEtag(undefined)).toBeUndefined();
+});
+
+test("base URLs are normalised, and nonsense is rejected", () => {
+  expect(normalizeBaseUrl("vgpu.sh")).toBe("https://vgpu.sh");
+  expect(normalizeBaseUrl("https://vgpu.sh/")).toBe("https://vgpu.sh");
+  expect(normalizeBaseUrl("http://127.0.0.1:3000/")).toBe("http://127.0.0.1:3000");
+  expect(() => normalizeBaseUrl("https://vgpu.sh/?x=1")).toThrow(/query or hash/);
+  expect(() => normalizeBaseUrl("not a url")).toThrow(/Invalid deployment URL/);
+});
+
+test("Vercel bot mitigation and deployment protection are blocks, not parity failures", () => {
+  expect(detectBlock(403, new Headers({ "x-vercel-mitigated": "challenge" }))).toMatchObject({
+    blocked: true,
+    reason: "bot-mitigation",
+  });
+  expect(detectBlock(401, new Headers({ "content-type": "text/html" }))).toMatchObject({
+    blocked: true,
+    reason: "deployment-protection",
+  });
+  expect(detectBlock(403, new Headers({ "content-type": "text/html; charset=utf-8" }))).toMatchObject({ blocked: true });
+  // A 404 or a 500 from the route itself IS a real failure and must stay one.
+  expect(detectBlock(404, new Headers({ "content-type": "application/json" })).blocked).toBe(false);
+  expect(detectBlock(500, new Headers()).blocked).toBe(false);
+});
+
+test("transient statuses are retried, permanent ones are not", () => {
+  expect([408, 429, 500, 502, 503].every(isRetriableStatus)).toBe(true);
+  expect([200, 304, 400, 404].some(isRetriableStatus)).toBe(false);
+  expect(backoffDelayMs(0)).toBe(500);
+  expect(backoffDelayMs(3)).toBe(4000);
+  expect(backoffDelayMs(10)).toBe(8000);
+});
+
+test("argument parsing covers the single, A/B and local-cross-check shapes", () => {
+  expect(parseArguments(["https://vgpu.sh"]).urls).toEqual(["https://vgpu.sh"]);
+  expect(parseArguments(["vgpu.sh", "docs-next.vercel.app"]).urls).toEqual([
+    "https://vgpu.sh",
+    "https://docs-next.vercel.app",
+  ]);
+  expect(parseArguments(["vgpu.sh", "--compare", "docs-next.vercel.app"]).urls).toHaveLength(2);
+  expect(parseArguments(["vgpu.sh", "--local"]).localTree).toBe("apps/docs/generated/examples-api");
+  expect(parseArguments(["vgpu.sh", "--local=apps/docs-next/generated/examples-api"]).localTree).toBe(
+    "apps/docs-next/generated/examples-api",
+  );
+  expect(parseArguments(["vgpu.sh", "--require-local"]).requireLocal).toBe(true);
+  expect(parseArguments(["vgpu.sh", "--concurrency", "3", "--timeout", "1000", "--retries", "0"])).toMatchObject({
+    concurrency: 3,
+    timeoutMs: 1000,
+    retries: 0,
+  });
+  expect(() => parseArguments([])).toThrow(/Missing <baseUrl>/);
+  expect(() => parseArguments(["a", "b", "c"])).toThrow(/At most two/);
+  expect(() => parseArguments(["vgpu.sh", "vgpu.sh"])).toThrow(/two different/);
+  expect(() => parseArguments(["--nope"])).toThrow(/Unknown option/);
+});
+
+test("compareReports ignores baseUrl and timings but not bytes", () => {
+  const artifact = {
+    key: "examples/v1/latest.json",
+    kind: "latest",
+    status: 200,
+    contentType: "application/json; charset=utf-8",
+    contentLength: 10,
+    bytes: 10,
+    sha256: "a".repeat(64),
+    etag: "a".repeat(64),
+    cacheControl: MUTABLE_CACHE_CONTROL,
+    ok: true,
+  };
+  const a = { baseUrl: "https://vgpu.sh", revision: "r", durationMs: 1, artifacts: [artifact] };
+  const b = { baseUrl: "https://preview.vercel.app", revision: "r", durationMs: 999, artifacts: [{ ...artifact }] };
+  expect(compareReports(a, b)).toEqual({ equal: true, differences: [] });
+
+  const drifted = { ...b, artifacts: [{ ...artifact, sha256: "b".repeat(64) }] };
+  expect(compareReports(a, drifted).equal).toBe(false);
+  expect(compareReports(a, drifted).differences[0]).toMatchObject({ scope: "artifact", field: "sha256" });
+
+  expect(compareReports(a, { ...b, revision: "other" }).differences[0]).toMatchObject({ scope: "revision" });
+  expect(compareReports(a, { ...b, artifacts: [] }).differences[0]).toMatchObject({ scope: "missing-in-b" });
+});
+
+// ---------------------------------------------------------------------------
+// Full-tree crawl against a replay of the committed artifact tree
+// ---------------------------------------------------------------------------
+
+type Mutation = (key: string, bytes: Buffer) => { bytes?: Buffer; contentType?: string; status?: number } | undefined;
+
+function loadTree(): Map<string, Buffer> {
+  const files = new Map<string, Buffer>();
+  const walk = (directory: string, prefix: string) => {
+    for (const entry of readdirSync(directory)) {
+      const absolute = join(directory, entry);
+      const key = prefix ? `${prefix}/${entry}` : entry;
+      if (statSync(absolute).isDirectory()) walk(absolute, key);
+      else files.set(key, readFileSync(absolute));
+    }
+  };
+  walk(treeRoot, "");
+  return files;
+}
+
+const tree = loadTree();
+
+function contentTypeFor(key: string): string {
+  if (key.endsWith(".json")) return "application/json; charset=utf-8";
+  if (key.endsWith(".wgsl.raw")) return "text/wgsl; charset=utf-8";
+  return "text/typescript; charset=utf-8";
+}
+
+const servers: Server[] = [];
+afterEach(() => {
+  for (const server of servers.splice(0)) server.close();
+});
+
+/** Serves the committed tree exactly like the Next route handlers do (headers included). */
+async function startReplayServer(mutate?: Mutation): Promise<string> {
+  const server = createServer((request, response) => {
+    const path = new URL(request.url ?? "/", "http://localhost").pathname;
+    const key = keyForArtifactPath(path);
+    const original = key ? tree.get(key) : undefined;
+    if (!key || !original) {
+      response.writeHead(404, { "content-type": "application/json; charset=utf-8" }).end("{}");
+      return;
+    }
+    const override = mutate?.(key, original) ?? {};
+    const bytes = override.bytes ?? original;
+    if (override.status && override.status !== 200) {
+      response.writeHead(override.status, { "content-type": "application/json; charset=utf-8" }).end("{}");
+      return;
+    }
+    const digest = createHash("sha256").update(bytes).digest("hex");
+    const headers: Record<string, string> = {
+      "access-control-allow-origin": "*",
+      "x-content-type-options": "nosniff",
+      "cache-control": expectedCacheControl(key),
+      "content-type": override.contentType ?? contentTypeFor(key),
+      etag: `"${digest}"`,
+    };
+    if (request.headers["if-none-match"] === `"${digest}"`) {
+      response.writeHead(304, headers).end();
+      return;
+    }
+    headers["content-length"] = String(bytes.byteLength);
+    response.writeHead(200, headers).end(request.method === "HEAD" ? undefined : bytes);
+  });
+  await new Promise<void>((ready) => server.listen(0, "127.0.0.1", ready));
+  servers.push(server);
+  return `http://127.0.0.1:${(server.address() as AddressInfo).port}`;
+}
+
+const runOptions = { concurrency: 16, retries: 0, timeoutMs: 10_000 };
+
+test("a faithful deployment verifies green over the whole tree", async () => {
+  const baseUrl = await startReplayServer();
+  const report = await verifyDeployment(baseUrl, runOptions);
+  expect(report.problems).toEqual([]);
+  expect(report.artifacts.filter((artifact: { ok: boolean }) => !artifact.ok)).toEqual([]);
+  // The whole committed tree, not just the three artifacts the generator's own hook checks.
+  expect(report.counts.total).toBe(tree.size);
+  expect(report.counts.byKind).toMatchObject({ discovery: 1, latest: 1, revision: 1, index: 1 });
+  expect(report.ok).toBe(true);
+  expect(formatReport(report)).toContain("verdict    PASS");
+}, 60_000);
+
+test("one flipped byte in one source file turns the verdict red", async () => {
+  const target = [...tree.keys()].find((key) => key.endsWith("shader.wgsl.raw"))!;
+  const baseUrl = await startReplayServer((key, bytes) =>
+    key === target ? { bytes: Buffer.concat([bytes.subarray(0, bytes.length - 1), Buffer.from("X")]) } : undefined,
+  );
+  const report = await verifyDeployment(baseUrl, runOptions);
+  expect(report.ok).toBe(false);
+  const failed = report.artifacts.filter((artifact: { ok: boolean }) => !artifact.ok);
+  expect(failed).toHaveLength(1);
+  expect(failed[0].key).toBe(target);
+  expect(failed[0].problems.join(" ")).toMatch(/sha256 .* != declared/);
+}, 60_000);
+
+test("a wrong content-type on a source file is caught even when the bytes are right", async () => {
+  const target = [...tree.keys()].find((key) => key.endsWith("shader.wgsl.raw"))!;
+  const baseUrl = await startReplayServer((key) => (key === target ? { contentType: "text/plain; charset=utf-8" } : undefined));
+  const report = await verifyDeployment(baseUrl, runOptions);
+  expect(report.ok).toBe(false);
+  expect(report.artifacts.find((artifact: { key: string }) => artifact.key === target).problems.join(" ")).toMatch(
+    /content-type .*text\/plain/,
+  );
+}, 60_000);
+
+test("an artifact missing from the deployment is a failure, not a silently shorter tree", async () => {
+  const target = [...tree.keys()].find((key) => key.endsWith("manifest.json"))!;
+  const baseUrl = await startReplayServer((key) => (key === target ? { status: 404 } : undefined));
+  const report = await verifyDeployment(baseUrl, runOptions);
+  expect(report.ok).toBe(false);
+  expect(report.artifacts.find((artifact: { key: string }) => artifact.key === target).problems.join(" ")).toMatch(
+    /expected HTTP 200, got 404/,
+  );
+}, 60_000);
+
+test("a latest pointer aimed at a revision the deployment does not carry is caught", async () => {
+  const stale = "0".repeat(64);
+  const baseUrl = await startReplayServer((key, bytes) =>
+    key === LATEST_ARTIFACT_KEY
+      ? {
+          bytes: Buffer.from(
+            JSON.stringify({
+              ...JSON.parse(bytes.toString("utf8")),
+              revision: stale,
+              indexUrl: `https://vgpu.sh/api/examples/v1/revisions/${stale}/index.json`,
+            }),
+          ),
+        }
+      : undefined,
+  );
+  const report = await verifyDeployment(baseUrl, runOptions);
+  expect(report.ok).toBe(false);
+  expect(report.revision).toBe(stale);
+  expect(JSON.stringify(report)).toMatch(/expected HTTP 200, got 404/);
+}, 60_000);
+
+test("A/B parity is green between two identical deployments and red when one drifts", async () => {
+  const [a, b] = await Promise.all([startReplayServer(), startReplayServer()]);
+  const [reportA, reportB] = [await verifyDeployment(a, runOptions), await verifyDeployment(b, runOptions)];
+  expect(compareReports(reportA, reportB)).toEqual({ equal: true, differences: [] });
+
+  const target = [...tree.keys()].find((key) => key.endsWith("shader.wgsl.raw"))!;
+  const drifted = await startReplayServer((key, bytes) =>
+    key === target ? { bytes: Buffer.concat([bytes, Buffer.from("\n")]) } : undefined,
+  );
+  const comparison = compareReports(reportA, await verifyDeployment(drifted, runOptions));
+  expect(comparison.equal).toBe(false);
+  expect(comparison.differences.map((difference: { field?: string }) => difference.field)).toContain("sha256");
+}, 120_000);
+
+test("bot mitigation aborts the run as BLOCKED instead of reporting a parity failure", async () => {
+  const server = createServer((_request, response) => {
+    response.writeHead(403, { "x-vercel-mitigated": "challenge", "content-type": "text/html" }).end("<html>");
+  });
+  await new Promise<void>((ready) => server.listen(0, "127.0.0.1", ready));
+  servers.push(server);
+  const baseUrl = `http://127.0.0.1:${(server.address() as AddressInfo).port}`;
+  await expect(verifyDeployment(baseUrl, runOptions)).rejects.toMatchObject({
+    name: "BlockedError",
+    detail: { reason: "bot-mitigation" },
+  });
+}, 30_000);


### PR DESCRIPTION
## TGEIST-13 — G4: byte-for-byte deployment parity for the examples API

Gate **G4** of Decision 1′ of the geistdocs migration. Extracts the deployment verifier that already exists **embedded** in `apps/docs/scripts/generate-examples-api.mjs:38-60` (`verifyDeployed`, the `beforeLatest` hook of `--publish`) into a standalone tool, and generalises it from three artifacts to the **whole tree**.

The embedded hook fetches `index.json` + one `manifest.json` + one source file for a single example (`raymarched-fractal`) from `VERCEL_DEPLOYMENT_URL`, compares `content-type` / size / `sha256`, and only ever runs inside a publish transaction. G4 needs that same comparison over **every** object, against an arbitrary URL, twice (old prod **and** the `apps/docs-next` preview) with identical results.

Neither app is touched: this tool only reads a deployment over HTTP. The generator is deliberately **not** refactored to import it — it stays byte-frozen for the dual-run window because G2 (`check-examples-api-transplant`) diffs it against its copy in `apps/docs-next`. The duplicated 20 lines are the cheap side of that trade.

### Files

| File | What it is |
|---|---|
| `scripts/verify-examples-api-deployment.mjs` | the verifier (dependency-free, `node:*` only) |
| `scripts/verify-examples-api-deployment.test.ts` | 17 tests; the crawler is exercised against a loopback replay of the committed tree |
| `.github/workflows/examples-api-deploy-parity.yml` | `workflow_dispatch` runner (one URL or an A/B pair) |

### What it verifies

Walks the deployment the way the CLI does — discovery → latest → revision manifest → index → per-example manifests → source files (**248 objects** today) — and for every object asserts:

- HTTP 200 with `redirect: 'error'`, `cache: 'no-store'`;
- `content-type` exactly as the revision manifest declares it, with the same `; charset=utf-8` rule as `artifact-store.ts#withCharset`;
- `content-length` header == received body length == declared `size`;
- `sha256(body)` == declared `sha256`;
- `etag` == `"<sha256>"`, `cache-control` == the value the route is supposed to set (immutable for revision objects, `max-age=60, must-revalidate` for the two mutable ones), `access-control-allow-origin: *`, `x-content-type-options: nosniff`.

Plus, beyond what the embedded hook could do:

- **graph closure** — every URL referenced by index/manifests is declared in `revision.json`, and every declared object is referenced by some document (no orphans, nothing missing);
- **double anchoring** — `index.json` is checked against both `revision.json` and `latest.indexSha256`; every file's size/sha256 is checked against the manifest's declaration *and* the revision manifest's independent one;
- **contract probes** — `HEAD` and `If-None-Match` → `304` on the entry documents (`--head-all` for all 248): a deployment that serves the right bytes but breaks caching is not at parity;
- **`--local[=<dir>]`** — cross-check the served bytes against the generated tree committed in the checkout (a revision mismatch is a warning by default, a failure with `--require-local`).

URLs inside the documents carry the baked `https://vgpu.sh` origin on every deployment, so only their **pathname** travels — which is what makes a preview verifiable at all, and exactly what `verifyDeployed` already did.

### A/B mode

```sh
node scripts/verify-examples-api-deployment.mjs <urlA> <urlB>
```

Runs both and diffs the reports on **bytes only** — `baseUrl` and every timing/telemetry field are excluded by construction (`comparableArtifact`), which is literally the ticket's criterion: *"the diff of the two JSON reports is empty except for `baseUrl`"*.

### Bot mitigation is not a parity failure

`apps/docs/examples-api.md` documents a real incident (2026-07-30): `vgpu.sh` answered `403` + `x-vercel-mitigated: challenge` on every path while the deployment was perfectly healthy. Preview deployments add a second false red: Vercel Deployment Protection answers `401` + an SSO page.

Both are detected, backed off harder than a normal retry, and reported as **exit 75 = BLOCKED** with the remedy printed — never as a byte-parity failure. Exit codes: `0` pass · `1` parity/integrity failure · `2` usage · `75` inconclusive. `VERCEL_AUTOMATION_BYPASS_SECRET` is forwarded as `x-vercel-protection-bypass` when set, so a protected preview can be verified without weakening its protection.

### Real runs

**a) Old production — `https://vgpu.sh`, 2026-08-04 13:55:14 UTC, 6.3 s**

```
# https://vgpu.sh
  revision   baa4b04cb5916ffcd8785ddf06d1b5456653979d95e780901dcfa6e446fbce20
  artifacts  248 ({"discovery":1,"latest":1,"file":225,"manifest":19,"index":1,"revision":1})
  local tree apps/docs/generated/examples-api
             revision baa4b04cb5916ffcd8785ddf06d1b5456653979d95e780901dcfa6e446fbce20 — same as the deployment
  verdict    PASS — 248/248 artifacts verified byte-for-byte
```

248/248 green, 0 mismatches against the committed tree, no mitigation encountered.

**b) A/B, old app vs. new app, both under `next start` — 2026-08-04 13:55:21 UTC**

`apps/docs` (`:3001`) vs `apps/docs-next` (`:3002`), both freshly `next build`-ed from this branch:

```
# http://127.0.0.1:3001   PASS — 248/248 artifacts verified byte-for-byte
# http://127.0.0.1:3002   PASS — 248/248 artifacts verified byte-for-byte
# A/B parity
  verdict    PASS — both deployments serve the same tree, byte for byte
```

Empty diff: same revision, same 248 keys, same sha256, same content-types, same cache-control, same ETags. This is the strongest signal available before the preview project exists — the transplanted routes in the new app (Next 16.2.6 + geistdocs + the i18n proxy) serve the identical tree the old app (Next 16.2.12) serves. It also confirms `proxy.ts`'s matcher really does exclude `/.well-known/vgpu-examples.json` and `/api/**` in a production build, not just in theory.

**c) Tests** — `pnpm exec vitest run scripts/verify-examples-api-deployment.test.ts` → **17 passed**. The crawl tests boot a loopback server that replays the committed tree with the route handlers' headers, then break exactly one thing at a time and assert the verdict turns red *for the right reason*: one flipped byte in a `.wgsl.raw`, a wrong `content-type` on otherwise-correct bytes, one `manifest.json` 404, a `latest.json` pointing at a revision the deployment does not carry, and A/B drift. Bot mitigation is asserted to raise `BlockedError` instead.

**d) `actionlint` 1.7.7** — clean on `.github/workflows/examples-api-deploy-parity.yml`.

### Why a separate workflow instead of a job in `ci.yml`

This gate needs a **live deployment URL**, which no `pull_request` event can supply, so it is `workflow_dispatch`-only — the same shape and the same reason as the existing `publish-examples-api.yml`. Keeping it out of `ci.yml` also avoids putting a `workflow_dispatch` trigger with inputs that are meaningless for its 11 other jobs, and avoids a conflict surface in the file that seven other migration tickets edit. The script imports nothing outside `node:*`, so the job is `checkout` + `setup-node` — no `pnpm install`, no build.

Inputs: `base_url` (required), `compare_url` (optional → A/B), `local_tree` (choice, `apps/docs` / `apps/docs-next` / `none`), `require_local`, `verbose`. The report is written to `$GITHUB_STEP_SUMMARY` and uploaded as a JSON artifact; exit 75 gets its own `::error title=BLOCKED::` annotation.

---

## Infra checklist for the `apps/docs-next` preview (dashboard work)

**Status today: the preview does not exist.** The Vercel project is configured entirely in the dashboard (there is no `vercel.json` anywhere in the repo — fact 18 of the design), and its Root Directory is `apps/docs`. A preview deployment of *this* branch therefore builds the **old** app, not `apps/docs-next`; there is no branch or env var that can redirect it. Run **b)** above exists precisely so this PR is not blocked on that.

1. **Create a second Vercel project** in the same team — suggested name `vgpu-docs-next` — linked to `vercel-labs/vgpu`, with:
   - **Root Directory** `apps/docs-next`, framework preset **Next.js**, Node **22** (the workspace pins `>=22 <23`);
   - install/build left at the monorepo defaults (`pnpm install` at the workspace root, `next build`); the app's own `prebuild` (`build:workspace` + ort/depth assets + `ingest-examples`) runs from its `package.json`.
   - Lighter alternative if a Git-linked project is unwanted: a one-off `vercel deploy` with `--cwd apps/docs-next` from a machine holding a `VERCEL_TOKEN`. Same verification applies; only the URL's lifetime differs.
2. **⚠️ NEVER assign a production domain to it.** Not `vgpu.sh`, not `www.vgpu.sh`, not `vgpu.labs.vercel.dev`. This is Risk #5 of the design: the CLI pins the origin (`assertTrustedUrl`), so pointing a production host at an unverified deployment breaks every installed CLI. The **only** path to the production domain is the cutover PR (F5/TGEIST-15) on the existing project, which is what preserves instant rollback.
3. **Environment variables:** `VGPU_EXAMPLES_ARTIFACT_STORE` and `VGPU_EXAMPLES_VERCEL_BLOB_READ_WRITE_TOKEN` **must be absent** (the `local` store is the default and reads the tree that ships in the deployment; an explicit `blob` value makes it fail closed). Same rule as production, `apps/docs/examples-api.md` § *Production setup*.
4. **Deployment Protection:** previews are protected by default. Either (a) enable **Protection Bypass for Automation** and add its value as the repo secret `VERCEL_AUTOMATION_BYPASS_SECRET` (the workflow already forwards it), or (b) verify from a browser-authenticated session manually. Without either, the script exits **75 BLOCKED**, not red.
5. **Firewall:** mirror the production allow rule on the new project — action **Allow**, ordered above any challenging rule, matching path `/.well-known/vgpu-examples.json` and prefix `/api/examples/` (`apps/docs/examples-api.md` § *Bot protection must never challenge these paths*). Without it, an Attack-Challenge-Mode-style mitigation on the preview shows up as BLOCKED.
6. **Then run G4 for real:** Actions → *Examples API deployment parity* → `base_url = https://vgpu.sh`, `compare_url = <preview URL>`, `local_tree = apps/docs-next/generated/examples-api`. Expected: both PASS with an empty diff. Paste the output into the TGEIST-15 PR as the G4 evidence.
7. **After the cutover:** re-run with `base_url = https://vgpu.sh` alone — that is **G5**, minutes after the deploy, no new code. Then delete the preview project in TGEIST-16.

## Scope

- Adds 3 files, modifies none. `apps/docs/**` and `apps/docs-next/**` untouched.
- Not a per-PR status check by design: G4's execution against live URLs is an operational step and a de-facto prerequisite of TGEIST-15, per the index's *"Otros gates — cuándo se agregan"*.
- The new test file is picked up by the root vitest config's existing `scripts/**/*.test.ts` include; no config change needed.

Refs TGEIST-13. **Do not merge before the orchestrator's review.**
