### PR TITLE
TGEIST-09b: sidebar en /examples (feedback usuario post smoke test)

### DIFF
--- a/apps/docs-next/app/[lang]/examples/layout.tsx
+++ b/apps/docs-next/app/[lang]/examples/layout.tsx
@@ -1,10 +1,15 @@
 import type { Metadata } from "next";
+import { DocsLayout } from "@/components/geistdocs/docs-layout";
+import { buildExamplesPageTree } from "@/lib/examples-page-tree";
 
-// TGEIST-09: metadata-only wrapper -- chrome (Navbar/Footer) already comes
-// from `app/[lang]/layout.tsx`; `/examples` does not get a bespoke sidebar
-// like the old app's `ExamplesSidebar` (Decision 1': chrome rehecho with
-// geistdocs primitives, same as the `/templates`-style top-level sections in
-// the reference geistdocs deployment).
+// TGEIST-09b: restores a sidebar for `/examples`, replicating (within what
+// geistdocs' sidebar component supports) the old app's `ExamplesSidebar`:
+// a flat list of all examples with a small thumbnail + title, and the
+// active item highlighted. Reuses the same `DocsLayout` wrapper /docs uses
+// (`components/geistdocs/docs-layout.tsx`) with a *synthetic* page tree
+// built from `examplesMetadata` (verbatim data, TGEIST-07) instead of a
+// `content/docs/**` + `meta.json` source -- this route still isn't part of
+// the docs content pipeline, it just borrows its chrome.
 export const metadata: Metadata = {
   title: {
     default: "Examples",
@@ -14,5 +19,9 @@ export const metadata: Metadata = {
 };
 
 export default function ExamplesLayout({ children }: { children: React.ReactNode }) {
-  return children;
+  return (
+    <div className="bg-background-200">
+      <DocsLayout tree={buildExamplesPageTree()}>{children}</DocsLayout>
+    </div>
+  );
 }

--- a/apps/docs-next/lib/examples-page-tree.tsx
+++ b/apps/docs-next/lib/examples-page-tree.tsx
@@ -1,0 +1,37 @@
+import type * as PageTree from "fumadocs-core/page-tree";
+// TGEIST-09b: verbatim data source (TGEIST-07), unmodified -- this file only
+// projects it into a synthetic fumadocs page tree so `/examples` can reuse
+// the same `DocsLayout`/sidebar chrome as `/docs`, replicating the old
+// app's `ExamplesSidebar` (flat list, thumbnail + title, active state)
+// within what the geistdocs sidebar component actually supports:
+// per-item `icon` (rendered at icon size, not a big aspect-video thumb) and
+// URL-based active-state highlighting. There is no grouping here because
+// the old `ExamplesSidebar` had none either (plain flat list).
+import { examplesMetadata } from "@/lib/examples-metadata";
+
+function ExampleSidebarThumb({ thumbnail }: { thumbnail?: string }) {
+  if (thumbnail) {
+    // eslint-disable-next-line @next/next/no-img-element -- sidebar icon
+    // slot, not a Next-optimized hero image; also unauthenticated static
+    // asset so no benefit from next/image here.
+    return <img alt="" className="size-5 shrink-0 rounded-sm object-cover" src={thumbnail} />;
+  }
+  return (
+    <span
+      aria-hidden
+      className="block size-5 shrink-0 rounded-sm bg-gradient-to-br from-blue-700/50 via-purple-700/30 to-black"
+    />
+  );
+}
+
+export function buildExamplesPageTree(): PageTree.Root {
+  return {
+    name: "Examples",
+    children: examplesMetadata.map((example) => ({
+      type: "page",
+      name: example.title,
+      url: `/examples/${example.slug}`,
+      icon: <ExampleSidebarThumb thumbnail={example.thumbnail} />,
+    })),
+  };
+}


### PR DESCRIPTION
## TGEIST-09b — sidebar en `/examples` (feedback directo del usuario)

Tras el smoke test de TGEIST-09 (PR #284), el usuario notó que `/examples` había perdido el menú lateral que tenía la app vieja. Este PR lo restaura, replicando lo que el framework geistdocs/fumadocs permite con esfuerzo razonable.

### Qué permite el framework (investigación)
- `GeistdocsDocsLayout` (nuestro wrapper `components/geistdocs/docs-layout.tsx`, ya usado por `/docs`) **hardcodea** su propio componente de sidebar (`GeistdocsSidebar`, interno del paquete `@vercel/geistdocs`). **No expone** el `sidebar.components` override que sí ofrece `fumadocs-ui`'s `DocsLayout` nativo — por lo tanto **no se puede** inyectar un renderer de item 100% custom (p.ej. la miniatura grande `aspect-video` que tenía el `ExamplesSidebar` viejo) sin bypassear `GeistdocsDocsLayout` entero y reimplementar todo su chrome (sheet mobile, grupos de sección, badges, navegación en dos paneles root/drill-in). Eso sí sería el hack frágil que se pidió evitar.
- Lo que **sí** soporta: cada nodo del page tree (`fumadocs-core` `PageTree.Item`) acepta un campo `icon?: ReactNode`, que el sidebar renderiza junto al nombre (a tamaño ícono ~20px, no aspect-video) — y resalta automáticamente el item activo por URL vía `useTreeContext`/`usePathname`. Sin folders/separators en la raíz del tree, la lista se renderiza **plana** — que es exactamente la estructura del `ExamplesSidebar` viejo (lista plana, sin agrupar, confirmado leyendo `apps/docs/components/examples-sidebar.tsx`).
- `eve/apps/docs` (geistdocs 1.15.2 en producción) no tiene ningún sidebar no-`/docs` para comparar — no hay otro precedente vivo.

**Conclusión**: se puede replicar fielmente la estructura (lista, thumbnail, título, activo) dentro de las limitaciones de tamaño del ícono del framework. No se fuerza nada frágil.

### Implementación
- `apps/docs-next/lib/examples-page-tree.tsx` (nuevo): construye un `PageTree.Root` **sintético** desde `examplesMetadata` (TGEIST-07, verbatim, sin editar) — un item de página por ejemplo, `icon` = thumbnail de 20px (o placeholder degradado si `example.thumbnail` es `undefined`, que es el caso de los 19 hoy porque `example-thumbs.generated.ts` sigue vacío — entran solos cuando TGEIST-14 genere los PNGs). Sin agrupación por tags: el viejo sidebar tampoco agrupaba.
- `apps/docs-next/app/[lang]/examples/layout.tsx`: envuelve `children` con el mismo `DocsLayout` wrapper que usa `/docs`, pasándole el tree sintético en vez de `source.pageTree[lang]`. Sigue sin tocar `content/docs/**` ni `meta.json` — el tree vive enteramente en memoria.

### Verificación
- `next build` verde: `/[lang]/examples` y `/[lang]/examples/[slug]` siguen generando 19 ejemplos × 2 langs sin error.
- `next start` + curl: `/examples` y `/examples/gradient` → 200, 19 `href="/examples/<slug>"` presentes.
- Screenshots (agent-browser) adjuntos: sidebar fijo a la izquierda con los 19 ejemplos (thumbnail placeholder + título), item activo resaltado en `/examples/anti-aliasing`, navegación entre ejemplos sin volver a la galería.
- No se tocó `app/preview/**`, `content/docs/**`, la API de examples, ni `package.json`.

**NO mergear** — abierto para revisión.