### PR TITLE
TGEIST-09c: code viewer decente en /examples/[slug] (feedback usuario)

### DIFF
--- a/apps/docs-next/components/copy-button.tsx
+++ b/apps/docs-next/components/copy-button.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import { Check, Copy } from "lucide-react";
+import { useState } from "react";
+
+// TGEIST-09c: ported verbatim (behavior + markup) from
+// `apps/docs/components/copy-button.tsx`, the old code-viewer's copy
+// button, restyled with the ported `gray-*` tokens instead of hardcoded hex.
+interface CopyButtonProps {
+  code: string;
+}
+
+export function CopyButton({ code }: CopyButtonProps) {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = async () => {
+    await navigator.clipboard.writeText(code.trim());
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  return (
+    <button
+      aria-label={copied ? "Copied!" : "Copy code"}
+      className="rounded-md p-1.5 text-gray-9 transition-colors hover:bg-gray-4 hover:text-gray-12"
+      onClick={handleCopy}
+      type="button"
+    >
+      {copied ? <Check className="size-4 text-green-9" /> : <Copy className="size-4" />}
+    </button>
+  );
+}

--- a/apps/docs-next/components/example-source-viewer-tabs.tsx
+++ b/apps/docs-next/components/example-source-viewer-tabs.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import { useState } from "react";
+import { CopyButton } from "@/components/copy-button";
+import { cn } from "@/lib/utils";
+
+// TGEIST-09c: client half of `ExampleSourceViewer` -- tab switching only,
+// no re-highlighting on the client (shiki already ran server-side, see
+// `example-source-viewer.tsx`). Markup/behavior ported from the old app's
+// `apps/docs/components/code-viewer.tsx` (single-row scrollable file tabs +
+// a scroll-capped code pane), swapping its `?file=` query-param/Link
+// navigation for local `useState` since we pre-highlight every file up
+// front instead of only the active one.
+export interface HighlightedSourceFile {
+  readonly name: string;
+  readonly code: string;
+  readonly html: string;
+}
+
+interface ExampleSourceViewerTabsProps {
+  files: readonly HighlightedSourceFile[];
+}
+
+export function ExampleSourceViewerTabs({ files }: ExampleSourceViewerTabsProps) {
+  const [activeName, setActiveName] = useState(files[0]?.name);
+  const active = files.find((file) => file.name === activeName) ?? files[0];
+
+  if (!active) {
+    return null;
+  }
+
+  return (
+    <div className="overflow-hidden rounded-lg border border-gray-4 bg-gray-1">
+      <div className="flex items-center justify-between border-b border-gray-4 bg-gray-2">
+        <div className="flex min-w-0 overflow-x-auto">
+          {files.map((file) => {
+            const isActive = file.name === active.name;
+            return (
+              <button
+                className={cn(
+                  "shrink-0 whitespace-nowrap border-r border-gray-4 px-4 py-2.5 font-mono text-xs transition-colors hover:text-gray-12",
+                  isActive ? "bg-gray-1 text-gray-12" : "text-gray-9",
+                )}
+                key={file.name}
+                onClick={() => setActiveName(file.name)}
+                type="button"
+              >
+                {file.name}
+              </button>
+            );
+          })}
+        </div>
+        <div className="shrink-0 px-2">
+          <CopyButton code={active.code} />
+        </div>
+      </div>
+      <div className="max-h-[70vh] overflow-auto p-4">
+        <div
+          className="text-sm leading-6 [&_code]:!bg-transparent [&_pre]:!m-0 [&_pre]:!bg-transparent [&_pre]:!p-0"
+          dangerouslySetInnerHTML={{ __html: active.html }}
+        />
+      </div>
+    </div>
+  );
+}

--- a/apps/docs-next/components/example-source-viewer.tsx
+++ b/apps/docs-next/components/example-source-viewer.tsx
@@ -1,16 +1,24 @@
-"use client";
+import { ExampleSourceViewerTabs } from "@/components/example-source-viewer-tabs";
+import { highlightCode } from "@/lib/shiki";
 
-import { CodeBlock } from "@vercel/geistdocs/components/code-block";
-import { useState } from "react";
-import { cn } from "@/lib/utils";
-
-// TGEIST-09: reads the example's source files exactly as returned by
-// `getExample()`/`examples-registry.ts` (TGEIST-07, verbatim) and renders
-// them with geistdocs' own `CodeBlock` chrome instead of the old app's
-// custom `CodeViewer`/Shiki setup. A lightweight in-house file switcher is
-// used instead of `CodeBlockTabs` (that helper's bundled types don't line up
-// with a plain array of file tabs), keeping this to geistdocs primitives
-// without fighting an unrelated typing mismatch.
+// TGEIST-09c: replaces the geistdocs `CodeBlock`-based viewer (TGEIST-09).
+// That version passed raw source as plain `<code>` children, which
+// `CodeBlock` does not syntax-highlight on its own (it expects pre-rendered
+// MDX/rehype-pretty-code output) -- so examples with many files (e.g.
+// triangle-led-front) rendered as a giant wrapping button grid on top of
+// unhighlighted black-on-white text. This is a from-scratch replacement
+// modeled on the old app's `apps/docs/components/code-viewer.tsx` (real
+// shiki highlighting server-side, a compact single-row scrollable file
+// tab bar, a copy button, a height-capped scrollable code pane), restyled
+// with the ported `gray-*` tokens (`app/styles/legacy-vgpu-tokens.css`)
+// instead of hardcoded hex so it still lines up with the rest of the
+// migrated chrome.
+//
+// Highlighting runs here (server component) for every file up front --
+// `/examples/[slug]` is fully static (`generateStaticParams`), so this is
+// a one-time build-time cost, not a per-request one. The result is handed
+// to a small client component that only toggles which pre-highlighted
+// file is visible (see `example-source-viewer-tabs.tsx`).
 export interface SourceFile {
   readonly name: string;
   readonly lang: string;
@@ -21,43 +29,41 @@ interface ExampleSourceViewerProps {
   files: readonly SourceFile[];
 }
 
-export function ExampleSourceViewer({ files }: ExampleSourceViewerProps) {
-  const [activeName, setActiveName] = useState(files[0]?.name);
+function languageFor(file: SourceFile) {
+  if (file.lang) {
+    return file.lang;
+  }
+  if (file.name.endsWith(".wgsl")) {
+    return "wgsl";
+  }
+  if (file.name.endsWith(".tsx")) {
+    return "tsx";
+  }
+  if (file.name.endsWith(".ts")) {
+    return "typescript";
+  }
+  if (file.name.endsWith(".json")) {
+    return "json";
+  }
+  return "typescript";
+}
 
+export async function ExampleSourceViewer({ files }: ExampleSourceViewerProps) {
   if (files.length === 0) {
     return (
-      <p className="rounded-lg border border-dashed p-4 text-copy-14 text-gray-900">
+      <p className="rounded-lg border border-dashed border-gray-4 p-4 text-copy-14 text-gray-900">
         No source files available.
       </p>
     );
   }
 
-  const active = files.find((file) => file.name === activeName) ?? files[0];
-
-  return (
-    <div className="flex flex-col gap-3">
-      {files.length > 1 ? (
-        <div className="flex flex-wrap gap-1 overflow-x-auto rounded-sm border bg-background-200 p-1">
-          {files.map((file) => (
-            <button
-              className={cn(
-                "rounded-sm px-3 py-1.5 font-mono text-sm transition-colors",
-                file.name === active.name
-                  ? "bg-background-100 text-gray-1000"
-                  : "text-gray-800 hover:text-gray-1000",
-              )}
-              key={file.name}
-              onClick={() => setActiveName(file.name)}
-              type="button"
-            >
-              {file.name}
-            </button>
-          ))}
-        </div>
-      ) : null}
-      <CodeBlock title={active.name}>
-        <code>{active.code}</code>
-      </CodeBlock>
-    </div>
+  const highlighted = await Promise.all(
+    files.map(async (file) => ({
+      name: file.name,
+      code: file.code,
+      html: await highlightCode(file.code, languageFor(file)),
+    })),
   );
+
+  return <ExampleSourceViewerTabs files={highlighted} />;
 }

--- a/apps/docs-next/lib/shiki.ts
+++ b/apps/docs-next/lib/shiki.ts
@@ -1,0 +1,33 @@
+import { createHighlighter, type Highlighter } from "shiki";
+
+// TGEIST-09c: ported verbatim from `apps/docs/lib/shiki.ts` (the old app's
+// code-viewer highlighter) -- singleton `shiki` highlighter cached on
+// `globalThis` so dev-mode module reloads don't spin up a second WASM
+// instance, `github-dark` theme, WGSL grammar included alongside the usual
+// web languages so example shader source highlights correctly.
+const globalForHighlighter = globalThis as unknown as {
+  highlighterPromise?: Promise<Highlighter>;
+};
+
+export async function getHighlighter() {
+  if (!globalForHighlighter.highlighterPromise) {
+    globalForHighlighter.highlighterPromise = createHighlighter({
+      themes: ["github-dark"],
+      langs: ["typescript", "javascript", "tsx", "jsx", "json", "bash", "html", "css", "wgsl"],
+    });
+  }
+  return globalForHighlighter.highlighterPromise;
+}
+
+export async function highlightCode(code: string, language: string): Promise<string> {
+  const highlighter = await getHighlighter();
+  const html = highlighter.codeToHtml(code.trim(), {
+    lang: language,
+    theme: "github-dark",
+  });
+
+  // Shiki renders blank source lines as an empty `<span class="line"></span>`
+  // with no content, which collapses to zero height in some browsers.
+  // Give it a non-breaking space so blank lines keep their line height.
+  return html.replace(/<span class="line"><\/span>/g, '<span class="line">&nbsp;</span>');
+}


### PR DESCRIPTION
## TGEIST-09c — code viewer en `/examples/[slug]` (feedback directo del usuario)

Feedback tras el smoke test: en `/examples/triangle-led-front` la lista de archivos era gigante (grid de botones que se envolvía en varias filas) y el código no tenía ningún resaltado de sintaxis (texto plano negro/blanco).

### Causa raíz
`example-source-viewer.tsx` (TGEIST-09) pasaba el código crudo como children de `<CodeBlock><code>{code}</code></CodeBlock>` (`@vercel/geistdocs`). Ese componente **no resalta sintaxis por sí solo** — espera HTML ya resaltado por el pipeline de MDX/rehype-pretty-code, que esta ruta no usa (es código React normal, no contenido MDX). Además, el selector de archivos en filas envolventes no escalaba con muchos archivos (triangle-led-front tiene 15+).

### Dirección (decidida por el usuario/orquestador)
Reemplazo completo y custom, inspirado en el code-viewer viejo que nunca se trasplantó: `apps/docs/components/{code-viewer,code-block}.tsx` + `apps/docs/lib/shiki.ts`.

### Implementación
- **`lib/shiki.ts`** (nuevo): highlighter shiki singleton, portado casi verbatim del viejo — tema `github-dark`, gramáticas typescript/javascript/tsx/jsx/json/bash/html/css/**wgsl** (confirmado en `bundledLanguages` de shiki). Cacheado en `globalThis`.
- **`components/copy-button.tsx`** (nuevo): botón de copiar portado del viejo, restyled con los tokens `gray-*` ya portados (`legacy-vgpu-tokens.css`) en vez de hex hardcodeado.
- **`components/example-source-viewer.tsx`** (reescrito): Server Component async que resalta TODOS los archivos con shiki de una (`Promise.all`) — `/examples/[slug]` es 100% estático (`generateStaticParams`), así que es costo de build, no de request.
- **`components/example-source-viewer-tabs.tsx`** (nuevo, cliente): pestañas de archivo en una sola fila con scroll horizontal, pane de código con `max-h-[70vh] overflow-auto`, botón de copiar.

### Bug encontrado y corregido durante la implementación
El primer intento de las pestañas no tenía `shrink-0` en los botones — flexbox comprimía TODOS los botones al mismo ancho (~33px, confirmado con `getBoundingClientRect`) sin importar el largo del nombre, y el texto se desbordaba visualmente encima del siguiente botón (mismo tipo de desastre visual que el bug original, otra causa). Con `shrink-0` cada botón conserva su ancho intrínseco y la fila entera scrollea horizontalmente.

### Verificación
- `next build` verde — 19 ejemplos × 2 langs siguen generando sin error.
- Screenshots con agent-browser (`next start` local):
  - antes (código sin resaltar + grid envuelto de archivos)
  - antes, closeup del bug de superposición de pestañas
  - después, `triangle-led-front` (15+ archivos, fila compacta scrollable, código con colores reales)
  - después, `gradient` (pocos archivos)
- No se tocó el sidebar (TGEIST-09b), `app/preview/**`, `content/docs/**`, la API de examples, ni `package.json`. `example-thumbs.generated.ts` (PR #288, en curso en paralelo) tampoco se tocó.

**NO mergear** — abierto para revisión.