### PR TITLE
TGEIST-12 follow-up — the title anchor stops shifting pages, and gate (d)'s last report-only bucket gets frozen

### DIFF
--- a/apps/docs-next/app/[lang]/docs/[[...slug]]/page.tsx
+++ b/apps/docs-next/app/[lang]/docs/[[...slug]]/page.tsx
@@ -32,11 +32,26 @@ const docsPage = createDocsPage({
   // `titleAnchorId` returns null when a body heading already owns that id (the
   // reference pages open every symbol with an `<h1>`), because two identical ids
   // in one document would shadow the real heading.
+  //
+  // Two things the classes are load-bearing for, both found by measuring the
+  // rendered page rather than by reading it:
+  //   - `absolute` keeps the element out of flow. `article#nd-page` is a flex
+  //     column with `gap-4`, and a `block h-0` span is still a **flex item**, so
+  //     the gap above the title was applied to it and every page's title moved
+  //     down 16px (measured: `h1` top 136 instead of 120). An out-of-flow element
+  //     contributes no flex item and no gap, and its static position — which is
+  //     what `top: auto` resolves to — is still the top of the content box, so it
+  //     is the same scroll target. `-mb-4` would also cancel it, by hardcoding
+  //     the exact gap the package happens to use today.
+  //   - `scroll-m-28` matches what the layout puts on every body heading
+  //     (`h2.scroll-m-28`), so `/docs/cli#cli` lands the title in the same place
+  //     under the sticky header that `#installation-and-usage` lands its heading.
+  //     Without it the fragment scrolled the title *behind* the header.
   renderTop: ({ data }) => {
     const anchor = titleAnchorId({ title: data.title, toc: data.toc });
     return (
       <>
-        {anchor ? <span aria-hidden="true" className="block h-0" id={anchor} /> : null}
+        {anchor ? <span aria-hidden="true" className="absolute h-0 scroll-m-28" id={anchor} /> : null}
         <MobileDocsBar toc={data.toc} />
       </>
     );

--- a/apps/docs-next/scripts/check-url-anchor-parity.mjs
+++ b/apps/docs-next/scripts/check-url-anchor-parity.mjs
@@ -85,7 +85,7 @@
 import { spawn } from "node:child_process";
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { createServer } from "node:net";
-import { dirname, join, resolve } from "node:path";
+import { dirname, join, relative, resolve } from "node:path";
 import process from "node:process";
 import { fileURLToPath } from "node:url";
 
@@ -100,6 +100,7 @@ const REPO_ROOT = resolve(APP_ROOT, "../..");
 const INVENTORY_PATH = join(REPO_ROOT, "docs/url-inventory.json");
 const CONTENT_ROOT = join(APP_ROOT, "content/docs");
 const ALLOWLIST_PATH = join(SCRIPT_DIR, "url-anchor-drift-allowlist.json");
+const DEAD_ANCHORS_PATH = join(SCRIPT_DIR, "redirect-dead-anchors.json");
 const MAX_REDIRECT_HOPS = 5;
 const READY_TIMEOUT_MS = 120_000;
 
@@ -420,6 +421,47 @@ function loadAllowlist() {
   return { entries: Array.isArray(parsed.entries) ? parsed.entries : [] };
 }
 
+/**
+ * The frozen list of redirect destinations whose `#anchor` production did not
+ * serve either — dead deep links inherited from the old app's table.
+ *
+ * Printing that number was not enough, and the review proved it: mutating all 255
+ * symbol destinations to `#<anchor>-MUTANT` kept the gate GREEN, because every
+ * mutated destination just moved from "resolves" into this bucket, whose only
+ * consequence was a counter going 117 → 275. A bucket that absorbs regressions
+ * silently is a hole in the gate, and the fix is the one this suite already uses
+ * twice — for the drift allowlist and for the nav curation snapshot: freeze the
+ * expected set, fail on the diff. Growth means a destination stopped resolving
+ * (repointed rule, or a heading that disappeared); shrinkage means one got fixed
+ * and the list has to shrink with it, in the same PR.
+ */
+function loadDeadAnchors() {
+  if (!existsSync(DEAD_ANCHORS_PATH)) return null;
+  const parsed = JSON.parse(readFileSync(DEAD_ANCHORS_PATH, "utf8"));
+  return { entries: Array.isArray(parsed.entries) ? parsed.entries : [] };
+}
+
+function writeDeadAnchors(preexisting) {
+  const payload = {
+    $comment: [
+      "TGEIST-12, gate (d). Redirect destinations whose `#anchor` production did not serve",
+      "either: the manifest's `record.anchor` never matched a heading on the destination page,",
+      "so these deep links were already landing at the top of the page before the migration.",
+      "Frozen because the bucket used to be report-only, and a report-only bucket absorbs",
+      "regressions: repointing all 255 symbol destinations at nonexistent anchors kept the gate",
+      "green while this number went 117 → 275. Now any addition fails (a destination stopped",
+      "resolving) and any entry that no longer applies fails as stale (it got fixed — shrink the",
+      "list in the same PR). Fixing one for real means fixing `record.anchor` in the generator,",
+      "or the heading it should point at. Regenerate with",
+      "`node scripts/check-url-anchor-parity.mjs --write-allowlist` and review the diff.",
+    ].join(" "),
+    entries: preexisting
+      .map(({ source, path, anchor }) => ({ source, destination: `${path}#${anchor}` }))
+      .sort((a, b) => a.source.localeCompare(b.source) || a.destination.localeCompare(b.destination)),
+  };
+  writeFileSync(DEAD_ANCHORS_PATH, `${JSON.stringify(payload, null, 2)}\n`);
+}
+
 function writeAllowlist(drifts) {
   const payload = {
     $comment: [
@@ -495,8 +537,17 @@ async function main() {
          * Every id the page really renders that can be an anchor target: heading
          * ids **and** the Decision 2.3 page-title anchor, which lives on a
          * zero-height element rather than on the `<h1>` (see
-         * `lib/title-anchor.mjs`). Framework ids (`nd-*`, `radix-*`, `_R*`) are
-         * dropped: they are per-render and no link points at them.
+         * `lib/title-anchor.mjs`).
+         *
+         * Exactly that, nothing else. An earlier revision filtered a blocklist of
+         * framework prefixes (`nd-*`, `radix-*`, `_R*`) out of *all* ids instead,
+         * which let fumadocs' 56 `sidebar-*` ids per page through — 5389 of the
+         * report's 6609 ids were navigation chrome, and the report weighed 472 KB.
+         * Nothing pointed at them, so no fragment passed on one, but
+         * `check-doc-links.mjs` verifies fragments against this set, and a set
+         * that contains ids no heading owns is a set that can say yes for the
+         * wrong reason. Allowlisting the two things that *are* anchor targets
+         * cannot.
          *
          * Written to the `--json` report so `check-doc-links.mjs` can validate
          * every `#fragment` in the corpus against ids observed in HTML instead of
@@ -511,7 +562,12 @@ async function main() {
         const title = extractTitle(resolved.html);
         const headings = extractHeadings(resolved.html);
         const headingIds = headings.map((heading) => heading.id);
-        entry.anchorIds = [...ids].filter((id) => !/^(?:nd-|radix-|_R)/u.test(id)).sort();
+        // headings ∪ {the page-title anchor}, which is the one anchor target that
+        // is not a heading. It is whichever legacy slug of the title the app
+        // actually rendered — `titleAnchorId` suppresses it on collision, and then
+        // the id is a heading's anyway.
+        const titleAnchor = title ? [...title.legacySlugs].filter((slug) => ids.has(slug)) : [];
+        entry.anchorIds = [...new Set([...headingIds, ...titleAnchor])].sort();
         entry.duplicateIds = duplicateAnchorIds(resolved.html, headingIds, title);
         idsByPath.set(resolved.finalPath, ids);
         for (const anchor of frozenAnchors) {
@@ -565,7 +621,17 @@ async function main() {
   if (options.writeAllowlist) {
     writeAllowlist(allDrifts);
     console.log(`wrote ${allDrifts.length} drift entries to ${ALLOWLIST_PATH}`);
+    writeDeadAnchors(destinations.preexisting);
+    console.log(`wrote ${destinations.preexisting.length} dead destination anchors to ${DEAD_ANCHORS_PATH}`);
   }
+
+  // --- dead-destination bookkeeping: the bucket is frozen, not just printed ----
+  const frozenDead = loadDeadAnchors();
+  const currentDead = new Set(destinations.preexisting.map((entry) => `${entry.source} → ${entry.path}#${entry.anchor}`));
+  const recordedDead = new Set((frozenDead?.entries ?? []).map((entry) => `${entry.source} → ${entry.destination}`));
+  const newDead = [...currentDead].filter((key) => !recordedDead.has(key)).sort();
+  const staleDead = [...recordedDead].filter((key) => !currentDead.has(key)).sort();
+  const deadListMissing = frozenDead === null;
 
   // --- drift bookkeeping: unrecorded, changed and stale entries all fail -----
   const allowlist = loadAllowlist();
@@ -602,7 +668,7 @@ async function main() {
   );
   console.log(
     `  targets ${destinations.resolved}/${destinations.total} redirect destinations land on an existing id` +
-      ` (${destinations.preexisting.length} already dead in production · ${destinations.regressions.length} regressions)`,
+      ` (${destinations.preexisting.length} already dead in production, ${recordedDead.size} recorded · ${destinations.regressions.length} regressions)`,
   );
 
   if (viaRedirect.length > 0) {
@@ -630,6 +696,9 @@ async function main() {
               total: destinations.total,
               resolved: destinations.resolved,
               deadInProduction: destinations.preexisting.length,
+              deadRecorded: recordedDead.size,
+              deadUnrecorded: newDead.length,
+              deadStale: staleDead.length,
               regressions: destinations.regressions.length,
             },
           },
@@ -643,16 +712,10 @@ async function main() {
     console.log(`\n  report written to ${options.json}`);
   }
 
-  if (destinations.preexisting.length > 0) {
+  if (destinations.preexisting.length > 0 && newDead.length === 0 && staleDead.length === 0) {
     console.log(
-      `\n  ${destinations.preexisting.length} redirect destination(s) point at an anchor production did not serve either —\n  dead deep links inherited from the old app's table (the manifest's \`record.anchor\` never\n  matched a heading on the destination page). Reported, not failed; the fix is the generator's:`,
+      `\n  ${destinations.preexisting.length} redirect destination(s) point at an anchor production did not serve either —\n  dead deep links inherited from the old app's table (the manifest's \`record.anchor\` never\n  matched a heading on the destination page), all of them recorded in\n  ${relative(APP_ROOT, DEAD_ANCHORS_PATH)}. Fixing one for real means fixing that anchor in the generator.`,
     );
-    for (const entry of destinations.preexisting.slice(0, 12)) {
-      console.log(`    ${entry.source} → ${entry.path}#${entry.anchor}`);
-    }
-    if (destinations.preexisting.length > 12) {
-      console.log(`    … ${destinations.preexisting.length - 12} more (full list in the --json report)`);
-    }
   }
 
   const failed =
@@ -661,6 +724,9 @@ async function main() {
     missingTitles.length > 0 ||
     duplicates.length > 0 ||
     destinations.regressions.length > 0 ||
+    newDead.length > 0 ||
+    staleDead.length > 0 ||
+    deadListMissing ||
     unrecordedDrifts.length > 0 ||
     changedDrifts.length > 0 ||
     staleAllowlistEntries.length > 0 ||
@@ -668,7 +734,7 @@ async function main() {
 
   if (!failed) {
     console.log(
-      `\n✓ gate (d): every URL production serves resolves here, every anchor it serves is either identical\n  or a recorded slugger rename whose heading is still present, no anchor id is ambiguous, and every\n  redirect destination lands on an id that exists (bar the ${destinations.preexisting.length} already dead in production).`,
+      `\n✓ gate (d): every URL production serves resolves here, every anchor it serves is either identical\n  or a recorded slugger rename whose heading is still present, no anchor id is ambiguous, and every\n  redirect destination lands on an id that exists (bar the ${destinations.preexisting.length} recorded as already dead in production).`,
     );
     return;
   }

--- a/apps/docs-next/scripts/redirect-dead-anchors.json
+++ b/apps/docs-next/scripts/redirect-dead-anchors.json
@@ -1,0 +1,397 @@
+{
+  "$comment": "TGEIST-12, gate (d). Redirect destinations whose `#anchor` production did not serve either: the manifest's `record.anchor` never matched a heading on the destination page, so these deep links were already landing at the top of the page before the migration. Frozen because the bucket used to be report-only, and a report-only bucket absorbs regressions: repointing all 255 symbol destinations at nonexistent anchors kept the gate green while this number went 117 → 275. Now any addition fails (a destination stopped resolving) and any entry that no longer applies fails as stale (it got fixed — shrink the list in the same PR). Fixing one for real means fixing `record.anchor` in the generator, or the heading it should point at. Regenerate with `node scripts/check-url-anchor-parity.mjs --write-allowlist` and review the diff.",
+  "entries": [
+    {
+      "source": "/packages/vgpu-core/bind",
+      "destination": "/docs/reference/vgpu-core/bind#bind"
+    },
+    {
+      "source": "/packages/vgpu-core/BufferOptions",
+      "destination": "/docs/reference/vgpu-core/buffer#bufferoptions"
+    },
+    {
+      "source": "/packages/vgpu-core/createBindGroup",
+      "destination": "/docs/reference/vgpu-core/bind#createbindgroup"
+    },
+    {
+      "source": "/packages/vgpu-core/createBindGroupLayout",
+      "destination": "/docs/reference/vgpu-core/bind#createbindgrouplayout"
+    },
+    {
+      "source": "/packages/vgpu-core/CreateDeviceOptions",
+      "destination": "/docs/reference/vgpu-core/device#createdeviceoptions"
+    },
+    {
+      "source": "/packages/vgpu-core/createPipelineLayout",
+      "destination": "/docs/reference/vgpu-core/bind#createpipelinelayout"
+    },
+    {
+      "source": "/packages/vgpu-core/createSampler",
+      "destination": "/docs/reference/vgpu-core/bind#createsampler"
+    },
+    {
+      "source": "/packages/vgpu-core/DeviceOptions",
+      "destination": "/docs/reference/vgpu-core/device#deviceoptions"
+    },
+    {
+      "source": "/packages/vgpu-core/RenderBundleOptions",
+      "destination": "/docs/reference/vgpu-core/render-bundle#renderbundleoptions"
+    },
+    {
+      "source": "/packages/vgpu-core/RenderBundleRecorder",
+      "destination": "/docs/reference/vgpu-core/render-bundle#renderbundlerecorder"
+    },
+    {
+      "source": "/packages/vgpu-core/ScalarUniformType",
+      "destination": "/docs/reference/vgpu-core/structured-uniform#scalaruniformtype"
+    },
+    {
+      "source": "/packages/vgpu-core/StorageBufferOptions",
+      "destination": "/docs/reference/vgpu-core/storage-buffer#storagebufferoptions"
+    },
+    {
+      "source": "/packages/vgpu-core/StructuredUniformOptions",
+      "destination": "/docs/reference/vgpu-core/structured-uniform#structureduniformoptions"
+    },
+    {
+      "source": "/packages/vgpu-core/TextureOptions",
+      "destination": "/docs/reference/vgpu-core/texture#textureoptions"
+    },
+    {
+      "source": "/packages/vgpu-core/UniformField",
+      "destination": "/docs/reference/vgpu-core/structured-uniform#uniformfield"
+    },
+    {
+      "source": "/packages/vgpu-core/UniformLayout",
+      "destination": "/docs/reference/vgpu-core/uniform-pool#uniformlayout"
+    },
+    {
+      "source": "/packages/vgpu-core/UniformLayoutInfo",
+      "destination": "/docs/reference/vgpu-core/structured-uniform#uniformlayoutinfo"
+    },
+    {
+      "source": "/packages/vgpu-core/UniformOptions",
+      "destination": "/docs/reference/vgpu-core/uniform#uniformoptions"
+    },
+    {
+      "source": "/packages/vgpu-core/UniformPoolOptions",
+      "destination": "/docs/reference/vgpu-core/uniform-pool#uniformpooloptions"
+    },
+    {
+      "source": "/packages/vgpu-core/UniformSlot",
+      "destination": "/docs/reference/vgpu-core/uniform-pool#uniformslot"
+    },
+    {
+      "source": "/packages/vgpu-core/UniformValues",
+      "destination": "/docs/reference/vgpu-core/structured-uniform#uniformvalues"
+    },
+    {
+      "source": "/packages/vgpu-core/ValidationError",
+      "destination": "/docs/reference/vgpu-core/vgpu-error#validationerror"
+    },
+    {
+      "source": "/packages/vgpu-core/VectorUniformInput",
+      "destination": "/docs/reference/vgpu-core/structured-uniform#vectoruniforminput"
+    },
+    {
+      "source": "/packages/vgpu-core/WgslUniformType",
+      "destination": "/docs/reference/vgpu-core/structured-uniform#wgsluniformtype"
+    },
+    {
+      "source": "/packages/vgpu-render-inspect/NormalDebugMaterialSpec",
+      "destination": "/docs/reference/render/normal-debug-material#normaldebugmaterialspec"
+    },
+    {
+      "source": "/packages/vgpu-render-inspect/WireframeMaterialSpec",
+      "destination": "/docs/reference/render/wireframe-material#wireframematerialspec"
+    },
+    {
+      "source": "/packages/vgpu-render-inspect/WireframeMesh",
+      "destination": "/docs/reference/render/mesh-to-wireframe#wireframemesh"
+    },
+    {
+      "source": "/packages/vgpu-render-utils/CanvasResolution",
+      "destination": "/docs/reference/render/canvas-resolution#canvasresolution-2"
+    },
+    {
+      "source": "/packages/vgpu-render-utils/FrameClock",
+      "destination": "/docs/reference/render/frame-clock#frameclock-2"
+    },
+    {
+      "source": "/packages/vgpu-scene/OrbitOptions",
+      "destination": "/docs/reference/vgpu-scene/orbit#orbitoptions"
+    },
+    {
+      "source": "/packages/vgpu-scene/OrthographicCameraOptions",
+      "destination": "/docs/reference/vgpu-scene/orthographic-camera#orthographiccameraoptions"
+    },
+    {
+      "source": "/packages/vgpu-scene/PerspectiveCamera",
+      "destination": "/docs/reference/vgpu-scene/perspective-camera#perspectivecamera-2"
+    },
+    {
+      "source": "/packages/vgpu-scene/PerspectiveCameraOptions",
+      "destination": "/docs/reference/vgpu-scene/perspective-camera#perspectivecameraoptions"
+    },
+    {
+      "source": "/packages/vgpu-wgsl-loader-vite/transformWgsl",
+      "destination": "/docs/reference/wgsl/loader-vite#transformwgsl"
+    },
+    {
+      "source": "/packages/vgpu-wgsl-loader-vite/ViteLoadResult",
+      "destination": "/docs/reference/wgsl/loader-vite#viteloadresult"
+    },
+    {
+      "source": "/packages/vgpu-wgsl-loader-vite/wgslVitePlugin",
+      "destination": "/docs/reference/wgsl/loader-vite#wgslviteplugin"
+    },
+    {
+      "source": "/packages/vgpu-wgsl-runtime/ResolvedShader",
+      "destination": "/docs/reference/wgsl/resolve-shader#resolvedshader"
+    },
+    {
+      "source": "/packages/vgpu-wgsl-runtime/ResolveOptions",
+      "destination": "/docs/reference/wgsl/resolve-shader#resolveoptions"
+    },
+    {
+      "source": "/packages/vgpu-wgsl-runtime/SourceMap",
+      "destination": "/docs/reference/wgsl/resolve-shader#sourcemap"
+    },
+    {
+      "source": "/packages/vgpu-wgsl-runtime/WGSLAst",
+      "destination": "/docs/reference/wgsl/resolve-shader#wgslast"
+    },
+    {
+      "source": "/packages/vgpu-wgsl-runtime/WGSLModule",
+      "destination": "/docs/reference/wgsl/resolve-shader#wgslmodule"
+    },
+    {
+      "source": "/packages/vgpu-wgsl-std-color/applyExposure",
+      "destination": "/docs/reference/wgsl-std/color#applyexposure"
+    },
+    {
+      "source": "/packages/vgpu-wgsl-std-color/luminance",
+      "destination": "/docs/reference/wgsl-std/color#luminance"
+    },
+    {
+      "source": "/packages/vgpu-wgsl-std-color/luminanceThreshold",
+      "destination": "/docs/reference/wgsl-std/color#luminancethreshold"
+    },
+    {
+      "source": "/packages/vgpu-wgsl-std-color/tonemapAces",
+      "destination": "/docs/reference/wgsl-std/color#tonemapaces"
+    },
+    {
+      "source": "/packages/vgpu-wgsl-std-color/tonemapReinhard",
+      "destination": "/docs/reference/wgsl-std/color#tonemapreinhard"
+    },
+    {
+      "source": "/packages/vgpu-wgsl-std-fullscreen/fullscreenTriangleClip",
+      "destination": "/docs/reference/wgsl-std/fullscreen#fullscreentriangleclip"
+    },
+    {
+      "source": "/packages/vgpu-wgsl-std-fullscreen/fullscreenTriangleUv",
+      "destination": "/docs/reference/wgsl-std/fullscreen#fullscreentriangleuv"
+    },
+    {
+      "source": "/packages/vgpu-wgsl-std-hash/hash1",
+      "destination": "/docs/reference/wgsl-std/hash#hash1"
+    },
+    {
+      "source": "/packages/vgpu-wgsl-std-hash/hash2",
+      "destination": "/docs/reference/wgsl-std/hash#hash2"
+    },
+    {
+      "source": "/packages/vgpu-wgsl-std-hash/hash3",
+      "destination": "/docs/reference/wgsl-std/hash#hash3"
+    },
+    {
+      "source": "/packages/vgpu-wgsl-std-hash/hashU32",
+      "destination": "/docs/reference/wgsl-std/hash#hashu32"
+    },
+    {
+      "source": "/packages/vgpu-wgsl-std-hash/pcg2d",
+      "destination": "/docs/reference/wgsl-std/hash#pcg2d"
+    },
+    {
+      "source": "/packages/vgpu-wgsl-std-hash/pcg3d",
+      "destination": "/docs/reference/wgsl-std/hash#pcg3d"
+    },
+    {
+      "source": "/packages/vgpu-wgsl-std-hash/unitFloat",
+      "destination": "/docs/reference/wgsl-std/hash#unitfloat"
+    },
+    {
+      "source": "/packages/vgpu-wgsl-std-noise-perlin/fbmPerlin2d",
+      "destination": "/docs/reference/wgsl-std/perlin#fbmperlin2d"
+    },
+    {
+      "source": "/packages/vgpu-wgsl-std-noise-perlin/fbmPerlin3d",
+      "destination": "/docs/reference/wgsl-std/perlin#fbmperlin3d"
+    },
+    {
+      "source": "/packages/vgpu-wgsl-std-noise-perlin/perlin2d",
+      "destination": "/docs/reference/wgsl-std/perlin#perlin2d"
+    },
+    {
+      "source": "/packages/vgpu-wgsl-std-noise-perlin/perlin3d",
+      "destination": "/docs/reference/wgsl-std/perlin#perlin3d"
+    },
+    {
+      "source": "/packages/vgpu-wgsl-std-noise-simplex/fbmSimplex2d",
+      "destination": "/docs/reference/wgsl-std/simplex#fbmsimplex2d"
+    },
+    {
+      "source": "/packages/vgpu-wgsl-std-noise-simplex/fbmSimplex3d",
+      "destination": "/docs/reference/wgsl-std/simplex#fbmsimplex3d"
+    },
+    {
+      "source": "/packages/vgpu-wgsl-std-noise-simplex/simplex2d",
+      "destination": "/docs/reference/wgsl-std/simplex#simplex2d"
+    },
+    {
+      "source": "/packages/vgpu-wgsl-std-noise-simplex/simplex3d",
+      "destination": "/docs/reference/wgsl-std/simplex#simplex3d"
+    },
+    {
+      "source": "/packages/vgpu-wgsl-std-noise/voronoi2d",
+      "destination": "/docs/reference/wgsl-std/noise#voronoi2d"
+    },
+    {
+      "source": "/packages/vgpu-wgsl-std-noise/voronoi3d",
+      "destination": "/docs/reference/wgsl-std/noise#voronoi3d"
+    },
+    {
+      "source": "/packages/vgpu-wgsl-std-noise/VoronoiSample2",
+      "destination": "/docs/reference/wgsl-std/noise#voronoisample2"
+    },
+    {
+      "source": "/packages/vgpu-wgsl-std-noise/VoronoiSample3",
+      "destination": "/docs/reference/wgsl-std/noise#voronoisample3"
+    },
+    {
+      "source": "/packages/vgpu-wgsl/ResolvedShader",
+      "destination": "/docs/reference/wgsl/resolved-shader#resolvedshader"
+    },
+    {
+      "source": "/packages/vgpu-wgsl/SourceMap",
+      "destination": "/docs/reference/wgsl/resolved-shader#sourcemap"
+    },
+    {
+      "source": "/packages/vgpu-wgsl/WGSLAst",
+      "destination": "/docs/reference/wgsl/resolved-shader#wgslast"
+    },
+    {
+      "source": "/packages/vgpu-wgsl/WGSLSource",
+      "destination": "/docs/reference/wgsl/resolved-shader#wgslsource"
+    },
+    {
+      "source": "/packages/vgpu/BundleOptions",
+      "destination": "/docs/reference/vgpu/bundle#bundleoptions"
+    },
+    {
+      "source": "/packages/vgpu/BundleRecorder",
+      "destination": "/docs/reference/vgpu/bundle#bundlerecorder"
+    },
+    {
+      "source": "/packages/vgpu/Clock",
+      "destination": "/docs/reference/vgpu/clock#clock-2"
+    },
+    {
+      "source": "/packages/vgpu/ComputeOptions",
+      "destination": "/docs/reference/vgpu/compute#computeoptions"
+    },
+    {
+      "source": "/packages/vgpu/DrawCallOptions",
+      "destination": "/docs/reference/vgpu/draw#drawcalloptions"
+    },
+    {
+      "source": "/packages/vgpu/DrawLayoutOptions",
+      "destination": "/docs/reference/vgpu/draw#drawlayoutoptions"
+    },
+    {
+      "source": "/packages/vgpu/DrawOptions",
+      "destination": "/docs/reference/vgpu/draw#drawoptions"
+    },
+    {
+      "source": "/packages/vgpu/EffectOptions",
+      "destination": "/docs/reference/vgpu/effect#effectoptions"
+    },
+    {
+      "source": "/packages/vgpu/FrameLoopHandle",
+      "destination": "/docs/reference/vgpu/frame#frameloophandle"
+    },
+    {
+      "source": "/packages/vgpu/FramePass",
+      "destination": "/docs/reference/vgpu/frame#framepass"
+    },
+    {
+      "source": "/packages/vgpu/FramePassOptions",
+      "destination": "/docs/reference/vgpu/frame#framepassoptions"
+    },
+    {
+      "source": "/packages/vgpu/FrameRunner",
+      "destination": "/docs/reference/vgpu/frame#framerunner"
+    },
+    {
+      "source": "/packages/vgpu/GeometryLike",
+      "destination": "/docs/reference/vgpu/draw#geometrylike"
+    },
+    {
+      "source": "/packages/vgpu/InitOptions",
+      "destination": "/docs/reference/vgpu/init#initoptions"
+    },
+    {
+      "source": "/packages/vgpu/PassOptions",
+      "destination": "/docs/reference/vgpu/effect#effectoptions"
+    },
+    {
+      "source": "/packages/vgpu/PingPongStorage",
+      "destination": "/docs/reference/vgpu/target#pingpongstorage"
+    },
+    {
+      "source": "/packages/vgpu/PingPongTargets",
+      "destination": "/docs/reference/vgpu/target#pingpongtargets"
+    },
+    {
+      "source": "/packages/vgpu/StorageAccess",
+      "destination": "/docs/reference/vgpu/compute#storageaccess"
+    },
+    {
+      "source": "/packages/vgpu/StorageBuffer",
+      "destination": "/docs/reference/vgpu/compute#storagebuffer"
+    },
+    {
+      "source": "/packages/vgpu/SurfaceOptions",
+      "destination": "/docs/reference/vgpu/surface#surfaceoptions"
+    },
+    {
+      "source": "/packages/vgpu/SurfaceResizeEvent",
+      "destination": "/docs/reference/vgpu/surface#surfaceresizeevent"
+    },
+    {
+      "source": "/packages/vgpu/TargetOptions",
+      "destination": "/docs/reference/vgpu/target#targetoptions"
+    },
+    {
+      "source": "/packages/vgpu/TargetTextureOptions",
+      "destination": "/docs/reference/vgpu/target#targettextureoptions"
+    },
+    {
+      "source": "/packages/vgpu/TimerSpan",
+      "destination": "/docs/reference/vgpu/timer#timerspan"
+    },
+    {
+      "source": "/packages/vgpu/UniformOptions",
+      "destination": "/docs/reference/vgpu/uniform#uniformoptions"
+    },
+    {
+      "source": "/packages/vgpu/VisibilityOptions",
+      "destination": "/docs/reference/vgpu/visibility#visibilityoptions"
+    },
+    {
+      "source": "/packages/vgpu/VisibilityQuery",
+      "destination": "/docs/reference/vgpu/visibility#visibilityquery"
+    }
+  ]
+}


### PR DESCRIPTION
The three LOWs from the review of #291, all of them in the machinery that PR added. Baselined on main *after* #293, so every number here is measured on the tree with the four section index pages in it.

## 1 · The title anchor moved every page down 16px

`article#nd-page` is a flex column with `gap-4`, and the `block h-0` span #291 added is still a **flex item** — so the gap above the title was applied to it. Measured on `/docs/cli`: `h1` top **136** where it should be 120, on every page in the tree.

`absolute` takes it out of flow: no flex item, no gap, and its static position (what `top: auto` resolves to) is still the top of the content box, so it is the same scroll target. `-mb-4` would also have worked, by hardcoding the exact gap the package happens to use today.

| page | before | after |
|---|---|---|
| `/docs/cli` | `h1` top 136 | **120** |
| `/docs/reference/vgpu/gpu` | `h1` top 172 | **156** |

While measuring, a second thing surfaced: the span had **no scroll margin**, where every body heading carries `scroll-m-28`. So `/docs/cli#cli` scrolled the title *behind* the sticky header — the anchor worked and the thing it pointed at was invisible. Now it matches the headings, verified by navigating to both:

```
#cli                     → scrollY 8    h1 top 112
#installation-and-usage  → scrollY 308  heading top 112
```

## 2 · `anchorIds` was wider than its own docstring

It filtered a blocklist of framework prefixes (`nd-*`, `radix-*`, `_R*`) out of *all* page ids, which let fumadocs' ~56 `sidebar-*` ids per page through: **5389 of the report's 6609 ids were navigation chrome**, and the `--json` report weighed 472 KB.

Nothing in the corpus points at a sidebar id, so nothing passed for the wrong reason today — but `check-doc-links.mjs` verifies every corpus fragment against this set, and a set full of ids no heading owns is a set that can say yes for the wrong reason tomorrow. It is now headings ∪ {the page-title anchor} by construction, which is exactly what the docstring always claimed:

| | before | after |
|---|---|---|
| ids in report | 6609 (5389 `sidebar-*`) | **1220 (0 `sidebar-*`)** |
| report size | 472 KB | **101 KB** |
| fragments verified | 45 | 45 |

## 3 · The dead-in-production bucket absorbed regressions

Gate (d) grades all 276 `#anchor` redirect destinations, and the ones production never served either were **report-only**. The review proved what that costs: repointing all 255 symbol destinations at `#<anchor>-MUTANT` kept the gate **green**, with the counter going 117 → 275 as the only trace.

So the expected set is frozen in `scripts/redirect-dead-anchors.json` — the same lesson as the drift allowlist and the nav curation snapshot, third place it applies here. Growth fails (a destination stopped resolving: a repointed rule, or a heading that disappeared). An entry that no longer applies fails as stale, so fixing one for real has to shrink the list in the same PR. `--write-allowlist` regenerates both reviewed lists.

**#293 already shrank it:** its section index pages resolve 19 of these deep links for real (`/docs/reference#render` and friends now have a page carrying those ids), so the frozen list is **98**, not the 117 this branch started with, and destinations went 159/276 → **178/276**. The four section-root redirects are gone with it: 100 URLs resolve directly now, 7 via redirect.

## Baseline on the rebased tree

```
URLs    107/107 resolve  (100 direct · 7 via redirect)
anchors 1104/1198 identical · 94 slugger drift (94 recorded) · 0 missing page-title · 0 lost
targets 178/276 redirect destinations land on an existing id (98 dead in production, 98 recorded · 0 regressions)
links   100 pages · 95 internal · 45 fragments verified · 0 broken
```

Rest of the suite, same tree: schemas 100 frontmatters + 14 `meta.json` · (b) 92 pages / 636 635 bytes verbatim · (c) mdast parity ✓ · (a) build ✓ · drift (skills + manifest + `content/docs`, 106 files) ✓ · nav coverage ✓ · nav curation 101 entries ✓.

## Mutations

19/19 land on the gate that owns them, including **m8b — the probe that used to pass green** (255 destinations pointing at nothing) and m10 (dropping `titleAnchorId`'s collision guard → duplicate ids). Re-checked `baseline`, `m4b` and `m8b` after the rebase onto #293.

## One thing worth knowing

The new report line used `relative` without importing it, so the gate **crashed after printing a green summary** — the exit code was the only evidence, and my own first check masked it by piping into `grep`. Fixed, and every number above was re-measured after the fix.