### PR TITLE
fix(docs-next): stabilize /examples/[slug] container width

### DIFF
--- a/apps/docs-next/app/[lang]/examples/[slug]/page.tsx
+++ b/apps/docs-next/app/[lang]/examples/[slug]/page.tsx
@@ -38,7 +38,7 @@ const ExampleDetailPage = async ({ params }: ExampleDetailPageProps) => {
   if (!example) notFound();
 
   return (
-    <main className="mx-auto max-w-[880px] px-4 pt-12 pb-32 sm:px-6">
+    <main className="mx-auto w-full max-w-[880px] px-4 pt-12 pb-32 sm:px-6">
       <div className="mb-6 flex flex-wrap items-end justify-between gap-4">
         <div>
           <h1 className="font-medium! text-heading-32 text-gray-1000 tracking-tighter sm:text-heading-40">


### PR DESCRIPTION
## Problem

On `/examples/[slug]` (apps/docs-next), the preview iframe + code viewer
container width visibly varied between examples (found during smoke
testing of the geistdocs migration).

## Root cause

The `<main>` wrapping the preview + code viewer used:

```
mx-auto max-w-[880px] px-4 pt-12 pb-32 sm:px-6
```

`<main>` is a direct child of the fumadocs `DocsLayout` CSS Grid
(`#nd-docs-layout`, 3 named columns: `sidebar main toc`). It has no
explicit `width`, only `mx-auto` (auto margins) + `max-w-[880px]`.

Per CSS Grid alignment rules, a grid item with **auto margins in the
inline axis does not stretch to fill its grid area** — the auto
margins absorb the leftover space and the box instead shrink-to-fits
to its own **max-content** width (capped at `max-w-[880px]`).

So the actual rendered width of `<main>` depended on each example's
own intrinsic content width:
- `gradient` (short title/description, 3 files) → max-content ≈ 759px, so `main` rendered at **759px** (never reaching the 880px cap).
- `triangle-led-front` (longer description, 15 files) → max-content ≥ 880px, so `main` rendered at the full **880px** cap.

Measured live with `getBoundingClientRect()` on the dev server before the fix:

| Example | main width |
|---|---|
| gradient | 759px |
| triangle-led-front | 880px |

Everything downstream (`ExamplePreview` iframe, `ExampleSourceViewerTabs`)
is `w-full` inside that flow, so the whole preview + code viewer block
inherited whatever width `<main>` happened to shrink-to-fit to.

## Fix

Add `w-full` alongside the existing `mx-auto max-w-[880px]` so the
item has a definite preferred width (100% of its grid area) instead of
an auto one — the grid stretch behavior then applies normally and the
box reliably fills up to the 880px cap for every example, regardless
of content:

```diff
- <main className="mx-auto max-w-[880px] px-4 pt-12 pb-32 sm:px-6">
+ <main className="mx-auto w-full max-w-[880px] px-4 pt-12 pb-32 sm:px-6">
```

Single line change, `app/[lang]/examples/[slug]/page.tsx` only. No
changes to the sidebar (TGEIST-09b), the code viewer (#295), or
`preview/`/`content/docs`/`proxy.ts`.

## Verification

Measured `document.querySelector('main').getBoundingClientRect()` via
agent-browser across 7 examples with very different content shapes
(short/simple, many source files, image-heavy, long description) on
both `next dev` and a production `next build && next start`:

| Example | Before | After |
|---|---|---|
| gradient | w=759 x=403 | w=880 x=342.5 |
| triangle-led-front | w=880 x=343 | w=880 x=342.5 |
| depth-estimation | w=880 x=343 | w=880 x=342.5 |
| fluid | w=880 x=343 | w=880 x=342.5 |
| post-processing | w=880 x=343 | w=880 x=342.5 |
| black-hole | — | w=880 x=342.5 |
| earth | — | w=880 x=342.5 |

`next build` is green (672/672 static pages generated, no errors).

Screenshots (before/after) available on request — visually the preview
+ code viewer box now lines up identically across examples.