### PR TITLE
fix(docs): light mode on the landing page (theme-aware tokens + hero invert)

### DIFF
--- a/apps/docs/app/[lang]/(home)/components/docs-links-section.tsx
+++ b/apps/docs/app/[lang]/(home)/components/docs-links-section.tsx
@@ -12,18 +12,18 @@ const docLinks: [href: string, title: string, description: string][] = [
 export function DocsLinksSection() {
   return (
     <section className="mb-24">
-      <h2 className="mb-10 text-2xl text-gray-12 md:text-3xl">Explore the Docs</h2>
+      <h2 className="mb-10 text-2xl text-gray-1000 md:text-3xl">Explore the Docs</h2>
       <div className="grid gap-4 md:grid-cols-2">
         {docLinks.map(([href, title, description]) => (
           <DynamicLink
             key={href}
             href={`/[lang]${href}`}
-            className="group rounded-lg border border-gray-4 bg-gray-1 p-6 transition-all hover:border-gray-5"
+            className="group rounded-lg border border-gray-200 bg-gray-100 p-6 transition-all hover:border-gray-300"
           >
             <div className="mb-2 flex items-center justify-between">
-              <h3 className="text-gray-12 transition-colors group-hover:text-blue-9">{title} →</h3>
+              <h3 className="text-gray-1000 transition-colors group-hover:text-blue-900">{title} →</h3>
             </div>
-            <p className="text-sm text-gray-9">
+            <p className="text-sm text-gray-900">
               <InlineCode text={description} />
             </p>
           </DynamicLink>

--- a/apps/docs/app/[lang]/(home)/components/example-card.tsx
+++ b/apps/docs/app/[lang]/(home)/components/example-card.tsx
@@ -17,7 +17,7 @@ export function ExampleCard({ example }: ExampleCardProps) {
   return (
     <DynamicLink
       href={`/[lang]/examples/${example.slug}`}
-      className="group block overflow-hidden rounded-lg border border-gray-4 bg-gray-1 transition-all hover:border-gray-5 hover:bg-gray-2"
+      className="group block overflow-hidden rounded-lg border border-gray-200 bg-gray-100 transition-all hover:border-gray-300 hover:bg-gray-200"
     >
       <div className="relative aspect-video bg-black">
         {example.thumbnail ? (
@@ -34,10 +34,10 @@ export function ExampleCard({ example }: ExampleCardProps) {
         )}
       </div>
       <div className="p-4">
-        <h3 className="mb-2 text-lg font-semibold text-gray-12 transition-colors group-hover:text-blue-9">
+        <h3 className="mb-2 text-lg font-semibold text-gray-1000 transition-colors group-hover:text-blue-900">
           {example.title}
         </h3>
-        <p className="line-clamp-2 text-sm leading-relaxed text-gray-9">{example.description}</p>
+        <p className="line-clamp-2 text-sm leading-relaxed text-gray-900">{example.description}</p>
       </div>
     </DynamicLink>
   );

--- a/apps/docs/app/[lang]/(home)/components/examples-section.tsx
+++ b/apps/docs/app/[lang]/(home)/components/examples-section.tsx
@@ -15,10 +15,10 @@ export function ExamplesSection() {
   return (
     <section className="mb-24 mt-24">
       <div className="mb-10 flex items-center justify-between gap-4">
-        <h2 className="text-2xl text-gray-12 md:text-3xl">Examples</h2>
+        <h2 className="text-2xl text-gray-1000 md:text-3xl">Examples</h2>
         <DynamicLink
           href="/[lang]/examples"
-          className="text-sm text-gray-9 transition-colors hover:text-gray-12"
+          className="text-sm text-gray-900 transition-colors hover:text-gray-1000"
         >
           View all →
         </DynamicLink>

--- a/apps/docs/app/[lang]/(home)/components/hero.tsx
+++ b/apps/docs/app/[lang]/(home)/components/hero.tsx
@@ -1,5 +1,6 @@
 import { HeroBlackHole } from '@/components/hero/hero-black-hole';
 import { HeroTabs } from './hero-tabs';
+import '../hero-light-invert.css';
 
 /**
  * Landing hero.
@@ -12,7 +13,10 @@ import { HeroTabs } from './hero-tabs';
  */
 export function Hero() {
   return (
-    <section className="relative min-h-svh overflow-hidden bg-black">
+    <section
+      data-hero-invert
+      className="relative min-h-svh overflow-hidden bg-black"
+    >
       <HeroBlackHole />
 
       {/* Legibility scrim. Matches the Figma ellipse: a band centred on the

--- a/apps/docs/app/[lang]/(home)/components/pillars-section.tsx
+++ b/apps/docs/app/[lang]/(home)/components/pillars-section.tsx
@@ -31,16 +31,16 @@ const pillars = [
 export function PillarsSection() {
   return (
     <section className="mb-24">
-      <h2 className="mb-10 text-2xl text-gray-12 md:text-3xl">Why vgpu</h2>
+      <h2 className="mb-10 text-2xl text-gray-1000 md:text-3xl">Why vgpu</h2>
       <div className="grid gap-4 md:grid-cols-3">
         {pillars.map((pillar) => (
           <Card key={pillar.title} className="overflow-hidden rounded-lg py-0">
             <CardHeader className="border-b px-5 py-4">
-              <CardTitle className="text-sm font-normal text-gray-12">{pillar.title}</CardTitle>
+              <CardTitle className="text-sm font-normal text-gray-1000">{pillar.title}</CardTitle>
             </CardHeader>
             <CardContent className="p-5">
-              <p className="text-sm leading-relaxed text-gray-9">{pillar.description}</p>
-              <div className="mt-5 whitespace-normal break-words rounded-md border border-gray-4 bg-black px-3 py-2 font-mono text-sm text-gray-10">
+              <p className="text-sm leading-relaxed text-gray-900">{pillar.description}</p>
+              <div className="mt-5 whitespace-normal break-words rounded-md border border-gray-200 bg-gray-100 px-3 py-2 font-mono text-sm text-gray-900">
                 {pillar.code}
               </div>
             </CardContent>

--- a/apps/docs/app/[lang]/(home)/hero-light-invert.css
+++ b/apps/docs/app/[lang]/(home)/hero-light-invert.css
@@ -1,0 +1,13 @@
+/* Hero light-mode treatment.
+   Minimal, per owner directive: invert the whole composited hero section
+   (shader canvas + gradient scrims + white copy) as one unit in light mode.
+   Because a CSS `filter` rasterizes the element's rendered subtree before
+   compositing, relative contrast inside the section is preserved
+   automatically — no shader/WebGPU changes and no edits to hero-tabs.tsx or
+   hero-black-hole.tsx are needed.
+
+   Scoped to this file per the hero-solo.css convention (only imported by the
+   landing page) rather than added to the shared app/styles/geistdocs.css. */
+html.light [data-hero-invert] {
+  filter: invert(1) hue-rotate(180deg);
+}


### PR DESCRIPTION
## Problem

On `/` the landing sections were invisible/unthemed in light mode: the three section headings (**Examples**, **Why vgpu**, **Explore the Docs**) rendered as `#eeeeee` text on a white page, and the cards kept a dark surface.

Root cause: those components were written against the legacy `@theme static` block in `apps/docs/app/styles/legacy-vgpu-tokens.css` (`text-gray-12`, `text-gray-9`, `text-gray-10`, `border-gray-4/5`, `bg-gray-1/2`, `text-blue-9`). That block is **not** `.dark`-scoped, so every one of those utilities resolves to a single fixed hex regardless of the theme class on `<html>`.

## Fix

Migrate the *consumers* to the theme-aware new-scale tokens already shipped by `@vercel/geistdocs/theme.css` (defined in `:root`, overridden in `.dark`):

| legacy | new-scale |
| --- | --- |
| `text-gray-12` | `text-gray-1000` |
| `text-gray-9` / `text-gray-10` | `text-gray-900` |
| `border-gray-4` / `border-gray-5` | `border-gray-200` / `border-gray-300` |
| `bg-gray-1` / `bg-gray-2` | `bg-gray-100` / `bg-gray-200` |
| `text-blue-9` | `text-blue-900` |

The hero gets the minimal treatment agreed with the owner: a `data-hero-invert` hook on the hero `<section>` plus a small scoped stylesheet (`hero-light-invert.css`, same convention as the existing `hero-solo.css`) that applies `filter: invert(1) hue-rotate(180deg)` in light mode only. A CSS `filter` rasterizes the element's whole rendered subtree as one unit before compositing, so the shader canvas, the gradient scrims and the `text-white` copy invert **together** and relative contrast is preserved automatically. **No WebGPU/shader changes** — `components/hero/hero-black-hole.tsx` and `hero-tabs.tsx` are untouched.

## Files changed (6)

- `app/[lang]/(home)/components/pillars-section.tsx` — h2, card title, body copy, code chip
- `app/[lang]/(home)/components/docs-links-section.tsx` — h2, card surface/border/hover, link title + hover blue, description
- `app/[lang]/(home)/components/examples-section.tsx` — h2, "View all" link + hover
- `app/[lang]/(home)/components/example-card.tsx` (landing variant) — card surface/border/hover, title + hover blue, description. The `bg-black` thumbnail wrapper and the `to-black` placeholder gradient are intentionally left alone: those thumbnails are real canvas renders and are dark by design.
- `app/[lang]/(home)/components/hero.tsx` — additive only: `data-hero-invert` attribute + the CSS import
- `app/[lang]/(home)/hero-light-invert.css` — **new**, 13 lines

## Verification

- `pnpm --filter docs build` — passes.
- `next start` on the production build, driven with a headless browser, theme forced via `localStorage.setItem('theme', …)` + reload. Screenshots captured for `/` in both themes (viewport + full page).
  - **Light:** all three `<h2>`s are near-black and readable (`getComputedStyle` on the "Examples" h2 → `lab(7.78 …)`, i.e. **not** `rgb(238,238,238)`); card surfaces are light (`lab(95.5)`) with light borders (`lab(93.0)`); `getComputedStyle(section).filter === "invert(1) hue-rotate(180deg)"` on the hero.
  - **Dark:** visually unchanged vs. the pre-fix baseline — headings light (`lab(93.7)`), cards dark, hero `filter: none`.
- `git diff --stat` is confined to the 6 files above: **zero** diff under `app/preview/`, `examples/`, `components/hero/`, `app/styles/legacy-vgpu-tokens.css`, `components/example-*.tsx`, `lib/shiki.ts`. No `.mdx`, no `docs/url-inventory.json`, no `examples-api.md`, no `CHANGELOG`, no `package.json` version.

### Why the `/preview/**` pixel contract is safe

`app/preview/layout.tsx` renders its own `<html>` with no theme class and styles itself with `bg-black`/`text-gray-12`, which resolve through the legacy `@theme static` definitions. This PR does not touch `legacy-vgpu-tokens.css` (nor `examples/**`, which is live-rendered inside `/preview/[slug]`), so preview output is byte-identical.

## Follow-ups (not in this PR)

- The examples code viewer is still dark-only in light mode (`lib/shiki.ts` hardcodes `github-dark`) — handled in a separate PR.
- The `hue-rotate` half of the hero invert does not perfectly restore warm tones; accepted as-is per owner directive ("just invert the colors for now"), flagged for design as a possible follow-up.
- FYI: the geistdocs theme-toggle button did not visibly flip the class in a headless session during the audit. `ThemeToggle` lives entirely inside `@vercel/geistdocs` (`dist/controls.js`, plain `next-themes` `setTheme`), so it is not fixable from this app; most likely a headless hydration-timing artifact. Worth a re-test in a headed browser.
