### PR TITLE
fix(docs): make examples code viewer theme-aware in light mode

### DIFF
--- a/apps/docs/components/example-card.tsx
+++ b/apps/docs/components/example-card.tsx
@@ -29,7 +29,7 @@ export function ExampleCard({ example }: ExampleCardProps) {
               src={example.thumbnail}
             />
           ) : (
-            <div className="absolute inset-0 bg-gradient-to-br from-blue-700/40 via-purple-700/20 to-black" />
+            <div className="absolute inset-0 bg-gradient-to-br from-blue-700/40 via-purple-700/20 to-gray-1000" />
           )}
         </div>
         <CardHeader className="px-4 pt-4">

--- a/apps/docs/components/example-source-viewer-tabs.tsx
+++ b/apps/docs/components/example-source-viewer-tabs.tsx
@@ -30,16 +30,16 @@ export function ExampleSourceViewerTabs({ files }: ExampleSourceViewerTabsProps)
   }
 
   return (
-    <div className="overflow-hidden rounded-lg border border-gray-4 bg-gray-1">
-      <div className="flex items-center justify-between border-b border-gray-4 bg-gray-2">
+    <div className="overflow-hidden rounded-lg border border-gray-200 bg-gray-100">
+      <div className="flex items-center justify-between border-b border-gray-200 bg-gray-200">
         <div className="flex min-w-0 overflow-x-auto">
           {files.map((file) => {
             const isActive = file.name === active.name;
             return (
               <button
                 className={cn(
-                  "shrink-0 whitespace-nowrap border-r border-gray-4 px-4 py-2.5 font-mono text-xs transition-colors hover:text-gray-12",
-                  isActive ? "bg-gray-1 text-gray-12" : "text-gray-9",
+                  "shrink-0 whitespace-nowrap border-r border-gray-200 px-4 py-2.5 font-mono text-xs transition-colors hover:text-gray-1000",
+                  isActive ? "bg-gray-100 text-gray-1000" : "text-gray-900",
                 )}
                 key={file.name}
                 onClick={() => setActiveName(file.name)}

--- a/apps/docs/components/example-source-viewer.tsx
+++ b/apps/docs/components/example-source-viewer.tsx
@@ -51,7 +51,7 @@ function languageFor(file: SourceFile) {
 export async function ExampleSourceViewer({ files }: ExampleSourceViewerProps) {
   if (files.length === 0) {
     return (
-      <p className="rounded-lg border border-dashed border-gray-4 p-4 text-copy-14 text-gray-900">
+      <p className="rounded-lg border border-dashed border-gray-200 p-4 text-copy-14 text-gray-900">
         No source files available.
       </p>
     );

--- a/apps/docs/lib/shiki.ts
+++ b/apps/docs/lib/shiki.ts
@@ -1,10 +1,25 @@
-import { createHighlighter, type Highlighter } from "shiki";
+import { geistShikiTheme } from "@vercel/geistdocs/shiki-theme";
+import { createHighlighter, type Highlighter, type ThemeRegistrationAny } from "shiki";
 
-// TGEIST-09c: ported verbatim from `apps/docs/lib/shiki.ts` (the old app's
-// code-viewer highlighter) -- singleton `shiki` highlighter cached on
-// `globalThis` so dev-mode module reloads don't spin up a second WASM
-// instance, `github-dark` theme, WGSL grammar included alongside the usual
-// web languages so example shader source highlights correctly.
+// TGEIST-09c: ported from `apps/docs/lib/shiki.ts` (the old app's code-viewer
+// highlighter) -- singleton `shiki` highlighter cached on `globalThis` so
+// dev-mode module reloads don't spin up a second WASM instance, WGSL grammar
+// included alongside the usual web languages so example shader source
+// highlights correctly.
+//
+// Theme: `geistShikiTheme` from `@vercel/geistdocs/shiki-theme`, the exact
+// same theme object geistdocs' own MDX pipeline registers for both the
+// `light` and `dark` keys (`@vercel/geistdocs/dist/source-config.js`). It is
+// a css-variables theme -- every token color is emitted as
+// `var(--shiki-token-*)` instead of a literal hex -- and those variables are
+// defined theme-aware in `@vercel/geistdocs/theme.css` (`:root` values that
+// flip under `.dark`), which the app already loads site-wide via
+// `app/styles/geistdocs.css`. Previously this hardcoded `github-dark`, which
+// baked literal dark-mode hex into the build-time HTML and left the example
+// code viewer stuck dark in light mode. Referencing the registered theme by
+// `name` ("geist") keeps `codeToHtml` on the pre-loaded theme path.
+const theme = geistShikiTheme as ThemeRegistrationAny;
+
 const globalForHighlighter = globalThis as unknown as {
   highlighterPromise?: Promise<Highlighter>;
 };
@@ -12,7 +27,7 @@ const globalForHighlighter = globalThis as unknown as {
 export async function getHighlighter() {
   if (!globalForHighlighter.highlighterPromise) {
     globalForHighlighter.highlighterPromise = createHighlighter({
-      themes: ["github-dark"],
+      themes: [theme],
       langs: ["typescript", "javascript", "tsx", "jsx", "json", "bash", "html", "css", "wgsl"],
     });
   }
@@ -23,7 +38,7 @@ export async function highlightCode(code: string, language: string): Promise<str
   const highlighter = await getHighlighter();
   const html = highlighter.codeToHtml(code.trim(), {
     lang: language,
-    theme: "github-dark",
+    theme: geistShikiTheme.name,
   });
 
   // Shiki renders blank source lines as an empty `<span class="line"></span>`


### PR DESCRIPTION
## Problem

The example source viewer on `/examples/[slug]` was **stuck dark in light mode** (audit finding 6.1).

Root cause: `apps/docs/lib/shiki.ts` hardcoded shiki's `github-dark` theme, so **literal hex colors were baked into the highlighted HTML at build time** — completely disconnected from the CSS-variable theme system. This is also why the *visually identical* MDX code blocks on `/docs/**` already adapt correctly but this one didn't: geistdocs' own MDX pipeline registers `geistShikiTheme` (public export at `@vercel/geistdocs/shiki-theme`) for **both** its `light` and `dark` keys — it's a css-variables theme that emits `var(--shiki-token-*)` instead of hex, and those variables are defined theme-aware in `@vercel/geistdocs/theme.css` (`:root` values that flip under `.dark`).

Secondarily, the chrome *around* the code (panel, tab bar, tab buttons) used the always-dark legacy tokens from `app/styles/legacy-vgpu-tokens.css` — a non-`.dark`-scoped `@theme static` block, i.e. fixed hex forever.

## Fix

Same mechanism the working pages already use, zero new CSS:

| File | Change |
|---|---|
| `apps/docs/lib/shiki.ts` | `github-dark` → `geistShikiTheme` from `@vercel/geistdocs/shiki-theme`. Registered via `createHighlighter({ themes: [theme] })` and referenced by its `name` in `codeToHtml`. `langs` list (incl. `wgsl`) and function signatures unchanged. |
| `apps/docs/components/example-source-viewer-tabs.tsx` | Chrome migrated off legacy tokens onto theme-aware new-scale: `border-gray-4`→`border-gray-200`, `bg-gray-1`→`bg-gray-100`, `bg-gray-2`→`bg-gray-200`, `text-gray-12`/`hover:text-gray-12`→`gray-1000`, `text-gray-9`→`text-gray-900`. |
| `apps/docs/components/example-source-viewer.tsx` | Empty-state `border-gray-4`→`border-gray-200` (its `text-gray-900` was already new-scale). |
| `apps/docs/components/example-card.tsx` (`/examples` gallery card) | No-thumbnail placeholder gradient `to-black`→`to-gray-1000`, matching the `bg-gray-1000` token already on its own container div. Removes the last hardcoded literal in an otherwise-migrated file. |

No new CSS file is needed for the code text: `app/styles/geistdocs.css` already imports `theme.css` site-wide, so the generated markup simply inherits the flipping token vars.

## Verification

`pnpm --filter docs build` ✅ · `tsc --noEmit` (apps/docs) ✅ · `scripts/check-filenames.sh` ✅

**Built HTML now contains zero baked hex.** On `.next/server/app/en/examples/gradient.html`:

```
$ grep -o 'var(--shiki-token-[a-z-]*)' gradient.html | sort -u
var(--shiki-token-comment)   var(--shiki-token-constant)
var(--shiki-token-function)  var(--shiki-token-keyword)
var(--shiki-token-parameter) var(--shiki-token-punctuation)
var(--shiki-token-string)
$ grep -c 'color:#[0-9A-Fa-f]\{6\}' gradient.html
0
```

**Browser check** — `next start` on the production build, theme driven via `localStorage.setItem('theme', …)` + reload, screenshots of `/examples/gradient` (all three tab types: `index.tsx`, `renderer.ts`, `shader.wgsl`) and the `/examples` gallery in both themes.

`getComputedStyle` on the code viewer, scoped to the panel:

| | light | dark |
|---|---|---|
| panel bg | `lab(95.5 0 0)` (near-white) | `lab(9.3 0 0)` |
| tab-bar bg | `lab(93.0 0 0)` | `lab(11.7 0 0)` |
| `<pre>` bg | `rgba(0,0,0,0)` (the `[&_pre]:!bg-transparent` override still wins — confirmed) | `rgba(0,0,0,0)` |
| code text | `lab(7.8 0 0)` (near-black) | `lab(93.7 0 0)` (near-white) |
| keyword token | `lab(43.5 66.4 5.1)` (pink) | `lab(61.7 72.2 7.1)` (pink) |
| function token | — | `lab(61.9 50.2 -56.3)` (purple) |
| active / inactive tab | `lab(7.8)` / `lab(32.7)` | `lab(93.7)` / `lab(65.9)` |

Light mode is now dark, fully colorized syntax on a light panel; dark mode still reads as a normal dark code block (token hues shift a few shades vs. literal `github-dark`, as expected since the palette source is now the `--shiki-token-*` vars — nothing illegible).

Gallery: 38 cards, 38 thumbnails, **0** gradient placeholders rendered — so the `to-gray-1000` change is visually silent in current data, as intended.

## Safety

- **`app/styles/legacy-vgpu-tokens.css` is untouched (zero diff).** `/preview/**` has its own theme-less root layout and depends only on those token *definitions* (`bg-black` / `text-gray-12`), so its render is byte-identical → the `thumbs:check` pixel contract is unaffected.
- **`examples/**` is untouched (zero diff)** — those files are both live-rendered inside `/preview/[slug]` and the literal source text shown in this viewer.
- No `.mdx`, frontmatter, route, slug, copy or `docs/url-inventory.json` change → `docs-parity` unaffected. No `examples-api.md`, `CHANGELOG*` or `package.json` version touched.

`git diff --stat origin/main` is exactly these 4 files:

```
 apps/docs/components/example-card.tsx               |  2 +-
 apps/docs/components/example-source-viewer-tabs.tsx |  8 ++++----
 apps/docs/components/example-source-viewer.tsx      |  2 +-
 apps/docs/lib/shiki.ts                              | 31 +++++++++++++++++++++++--------
```

## FYI, not fixed here

The audit noted the navbar theme-toggle button didn't appear to flip the class in a headless session. `ThemeToggle` lives entirely inside the vendored `@vercel/geistdocs` package (plain `next-themes` `setTheme(resolvedTheme === "dark" ? "light" : "dark")`), so it isn't fixable from `apps/docs` and is most likely a headless hydration-timing artifact. Worth a re-test in a headed browser; out of scope for this PR.
