### PR TITLE
fix(docs): make code-viewer copy button theme-aware in light mode

### DIFF
--- a/apps/docs/components/copy-button.tsx
+++ b/apps/docs/components/copy-button.tsx
@@ -22,7 +22,7 @@ export function CopyButton({ code }: CopyButtonProps) {
   return (
     <button
       aria-label={copied ? "Copied!" : "Copy code"}
-      className="rounded-md p-1.5 text-gray-9 transition-colors hover:bg-gray-4 hover:text-gray-12"
+      className="rounded-md p-1.5 text-gray-900 transition-colors hover:bg-gray-200 hover:text-gray-1000"
       onClick={handleCopy}
       type="button"
     >

--- a/apps/docs/components/copy-button.tsx
+++ b/apps/docs/components/copy-button.tsx
@@ -22,11 +22,11 @@ export function CopyButton({ code }: CopyButtonProps) {
   return (
     <button
       aria-label={copied ? "Copied!" : "Copy code"}
-      className="rounded-md p-1.5 text-gray-900 transition-colors hover:bg-gray-200 hover:text-gray-1000"
+      className="rounded-md p-1.5 text-gray-900 transition-colors hover:bg-background-100 hover:text-gray-1000"
       onClick={handleCopy}
       type="button"
     >
-      {copied ? <Check className="size-4 text-green-9" /> : <Copy className="size-4" />}
+      {copied ? <Check className="size-4 text-green-900" /> : <Copy className="size-4" />}
     </button>
   );
 }


### PR DESCRIPTION
## Problem

Follow-up to #305 (examples code viewer light mode). The code-viewer tab bar's copy button — `apps/docs/components/copy-button.tsx` — was still on the always-dark legacy `@theme static` tokens from `app/styles/legacy-vgpu-tokens.css`. Those are not `.dark`-scoped, so in light mode the button's hover state painted a dark (~#222) chip with a near-white (~#eee) glyph directly on top of the now-light code panel.

## Fix

Styling only, one file, no markup/behavior/text/URL changes. All four tokens move onto the theme-aware new scale from `@vercel/geistdocs/theme.css`:

| before | after | why |
| --- | --- | --- |
| `text-gray-9` | `text-gray-900` | legacy fixed hex → theme-aware idle glyph |
| `hover:text-gray-12` | `hover:text-gray-1000` | legacy fixed hex → theme-aware hover glyph |
| `hover:bg-gray-4` | `hover:bg-background-100` | legacy fixed hex → theme-aware hover chip. Note `gray-200` (the obvious 1:1 port) is **not** usable here: #305 sets the tab bar itself to `bg-gray-200`, so a `gray-200` chip renders at 1.000:1 against its own container — invisible in both themes. `background-100` is white on #ebebeb in light / black on #1f1f1f in dark, visible either way. |
| `text-green-9` | `text-green-900` | the copied-state `Check` icon. `green-9` is a fixed #46a758 measuring 2.54:1 on the light tab bar, below the WCAG 1.4.11 non-text minimum of 3:1. `green-900` is theme-aware (#107d32 light / #00ca50 dark → 4.38:1 / 7.54:1). |

## Verification

- `pnpm --filter docs build` — pass · `pnpm --filter docs exec tsc --noEmit` — pass · `bash scripts/check-filenames.sh` — pass
- `git diff --stat origin/main...HEAD` — exactly 1 file changed (2 insertions, 2 deletions)
- Excluded-path check clean: nothing under `app/preview/**`, `apps/docs/examples/**`, `app/[lang]/(home)/**`, `components/hero/**`, and no `legacy-vgpu-tokens.css`, `examples-api.md`, `CHANGELOG*`, `package.json` or `*.mdx` touched.
- Emitted CSS confirmed theme-aware, not baked hex: `hover\:bg-background-100:hover{background-color:var(--ds-background-100)}` and `.text-green-900{color:var(--ds-green-900)}`.
- Browser check on `/examples/gradient` for the original gray swap: light → chip near-white + glyph near-black; dark → chip near-black + glyph near-white (unchanged from before). Note headless Chromium reports `(hover: hover) = false` and Tailwind v4 wraps `hover:` utilities in `@media (hover:hover)`, so hover states there must be read by force-applying the compiled declarations rather than by simulating a mouse hover.

## Notes

- Independent of #305 — mergeable in either order.
- No legacy `gray-*` / `green-*` tokens remain in this component.
