### PR TITLE
fix(docs): consistent gap spacing for cards on get-started

### DIFF
--- a/apps/docs/content/docs/get-started/index.mdx
+++ b/apps/docs/content/docs/get-started/index.mdx
@@ -6,13 +6,13 @@ description: vgpu runs in the browser and in Node.js with the same API. Pick you
 vgpu runs in two places with the same API: the browser, where WebGPU renders straight to a canvas,
 and Node.js, where Dawn renders headless for scripts, servers, and tests.
 
-<Card
-  title="Agents"
-  description="vgpu is agent-first — the full documentation ships inside the package. Point your agent at `npx vgpu`."
-  href="/docs/get-started/agents"
-/>
-
 <Cards>
+  <Card
+    title="Agents"
+    description="vgpu is agent-first — the full documentation ships inside the package. Point your agent at `npx vgpu`."
+    href="/docs/get-started/agents"
+    className="col-span-2"
+  />
   <Card
     title="Web"
     description="Render to a canvas with WebGPU, and set up the .wgsl loader for Next.js or Vite."
@@ -29,8 +29,10 @@ and Node.js, where Dawn renders headless for scripts, servers, and tests.
 
 Once you can render on your platform, learn the ideas every vgpu program is built from.
 
-<Card
-  title="Concepts"
-  description="Context, effects, passes, frames, and render bundles — in reading order."
-  href="/docs/concepts"
-/>
+<Cards>
+  <Card
+    title="Concepts"
+    description="Context, effects, passes, frames, and render bundles — in reading order."
+    href="/docs/concepts"
+  />
+</Cards>


### PR DESCRIPTION
## Problem

On `/docs/get-started`, the "Agents" card sits alone above the "Web"/"Node.js" row. It had **no bottom margin**, so it butted directly against the row below.

## Root cause

Fumadocs' bare `<Card>` has no margin of its own — vertical/horizontal spacing between cards comes entirely from `gap-3` on the parent `<Cards>` grid. `content/docs/get-started/index.mdx` had the "Agents" card as a standalone `<Card>` **outside** the `<Cards>` grid used by Web/Node.js, so there was zero gap between them.

This is also the only one of the four index pages introduced in #293 (`docs/index.mdx`, `concepts/index.mdx`, `guides/index.mdx`, `get-started/index.mdx`) with a bare `<Card>` outside a `<Cards>` grid — the other three always wrap cards, even single ones, in `<Cards>`. I checked all three and none have this spacing bug.

## Fix

- Moved the "Agents" card into the same `<Cards>` grid as "Web"/"Node.js", spanning both columns (`className="col-span-2"`) so it keeps its full-width look but now shares one grid with a consistent `gap-3`, instead of an ad-hoc standalone margin.
- Wrapped the standalone "Concepts" card (further down the same page) in `<Cards>` too, for consistency with the pattern used everywhere else.

Minimal, markup-only change — no visible text changed.

## Verification

- `pnpm --filter docs build` — green.
- `pnpm --filter docs check:mdast-parity` — passed (gate confirms no visible text changed by the MDX markup edit).
- Verified before/after in the browser (light + dark) with `next start`.

**Before** (light): cards visibly stuck together.
**After** (light/dark): consistent gap between all cards.

Screenshots attached below.