### PR TITLE
chore: add missing changeset for docs find ranking (#231)

### DIFF
--- a/.changeset/docs-find-ranking.md
+++ b/.changeset/docs-find-ranking.md
@@ -1,0 +1,7 @@
+---
+"@vgpu/cli": patch
+---
+
+`vgpu docs find` route hits are now ranked instead of returned alphabetically. `docs find gpu` used to dump 134 unranked lines (since "gpu" substring-matches nearly the whole index) and bury the exact match `Gpu` / `/vgpu/gpu.docs.md` around line 100; `find a` returned 260 lines with no way to tell a complete result set from a truncated one.
+
+Route hits are now sorted into six match-quality tiers (exact symbol, exact page identity, word-boundary in name text, word-boundary in path, substring in name text, substring in path only), tie-broken by the shared package curation ladder, then page hits before symbol hits, then a stable line compare. Both the route and content tiers now share one `HIT_LIMIT` of 20 (replacing the separate `CONTENT_HIT_LIMIT`), and stdout appends a truncation notice whenever a tier is capped, so it's clear when results were cut off.


### PR DESCRIPTION
PR #231 ("feat(docs): rank and cap the find route-hits tier") changed the shipped behavior of `vgpu docs find` (six-tier route-hit ranking, a shared `HIT_LIMIT` of 20 replacing `CONTENT_HIT_LIMIT`, and a truncation notice on stdout) without a changeset, so the release CHANGELOG would not mention it.

This adds the missing patch changeset for `@vgpu/cli` describing the user-visible change. No code changes.

Detected during release dossier gap review. Do not merge yet — flagging for release manager review.