### PR TITLE
chore(changeset): vgpu patch bump for 0.2.1 (not 0.3.0)

### DIFF
--- a/.changeset/plain-entry-point-reflection.md
+++ b/.changeset/plain-entry-point-reflection.md
@@ -1,7 +1,7 @@
 ---
 "@vgpu/wgsl": minor
 "@vgpu/cli": minor
-"vgpu": minor
+"vgpu": patch
 ---
 
 `EntryPointInfo` (`bindings`, `samplingPairs`, `inputs`) is now plain data: every field is an ordinary enumerable, own property. `JSON.stringify`, `{ ...entry }`, `Object.keys/entries/assign`, `structuredClone`, and worker `postMessage` all see the full shape — previously `bindings`, `samplingPairs` and `inputs` were non-enumerable, so they were readable through dot access but silently dropped across every serialization/structured-clone boundary (issue #252), including the `vgpu check` CLI JSON payload. The stopgap non-enumerable `toJSON()`/`EntryPointInfoJSON` this package briefly carried is removed in favor of making the underlying data itself lossless.
@@ -9,3 +9,5 @@
 Consumers that build bind group layouts (`vgpu`'s `set-layouts.ts`) still throw `VGPU-REFLECT-ENTRY-METADATA-MISSING` when an entry point arrives without `bindings`/`samplingPairs`/`inputs` metadata, rather than silently falling back to a wrong layout.
 
 BREAKING CHANGE (pre-1.0): code relying on `Object.keys(entryPoint)`, `{ ...entryPoint }`, or a JSON diff of an entry point *not* containing `bindings`/`samplingPairs`/`inputs` will now see those keys. This is a clean break with no deprecated alias, consistent with this package's other 0.x breaking changes.
+
+(Flagship re-export surface: patch — decision by release owner, the reflection shape change is additive-in-practice for vgpu consumers.)


### PR DESCRIPTION
## Summary

Edición puntual pre-release para la 0.2.1 (decisión del release owner): bajamos SOLO la entrada de `"vgpu"` en `.changeset/plain-entry-point-reflection.md` de `minor` a `patch`. Las entradas `"@vgpu/wgsl": minor` y `"@vgpu/cli": minor` del mismo changeset quedan intactas (wgsl va a 0.3.0 por sus propios cambios acumulados, no por este changeset en particular — decisión ya tomada).

Se agregó una línea al final del summary del changeset documentando el criterio, para que quede en el CHANGELOG:

> (Flagship re-export surface: patch — decision by release owner, the reflection shape change is additive-in-practice for vgpu consumers.)

## Diff

```diff
--- a/.changeset/plain-entry-point-reflection.md
+++ b/.changeset/plain-entry-point-reflection.md
@@ -1,7 +1,7 @@
 ---
 "@vgpu/wgsl": minor
 "@vgpu/cli": minor
-"vgpu": minor
+"vgpu": patch
 ---
 
 `EntryPointInfo` (`bindings`, `samplingPairs`, `inputs`) is now plain data: every field is an ordinary enumerable, own property. `JSON.stringify`, `{ ...entry }`, `Object.keys/entries/assign`, `structuredClone`, and worker `postMessage` all see the full shape — previously `bindings`, `samplingPairs` and `inputs` were non-enumerable, so they were readable through dot access but silently dropped across every serialization/structured-clone boundary (issue #252), including the `vgpu check` CLI JSON payload. The stopgap non-enumerable `toJSON()`/`EntryPointInfoJSON` this package briefly carried is removed in favor of making the underlying data itself lossless.
@@ -9,3 +9,5 @@ Consumers that build bind group layouts (`vgpu`'s `set-layouts.ts`) still throw
 Consumers that build bind group layouts (`vgpu`'s `set-layouts.ts`) still throw `VGPU-REFLECT-ENTRY-METADATA-MISSING` when an entry point arrives without `bindings`/`samplingPairs`/`inputs` metadata, rather than silently falling back to a wrong layout.
 
 BREAKING CHANGE (pre-1.0): code relying on `Object.keys(entryPoint)`, `{ ...entryPoint }`, or a JSON diff of an entry point *not* containing `bindings`/`samplingPairs`/`inputs` will now see those keys. This is a clean break with no deprecated alias, consistent with this package's other 0.x breaking changes.
+
+(Flagship re-export surface: patch — decision by release owner, the reflection shape change is additive-in-practice for vgpu consumers.)
```

## Verificación — `npx @changesets/cli@2.29.7 status --verbose`

```
🦋  info Packages to be bumped at patch
🦋  - vgpu 0.2.1
🦋    - .changeset/plain-entry-point-reflection.md
🦋  - @vgpu/adapter-node 0.1.8
🦋    - .changeset/soft-pears-repeat.md
🦋  - docs 0.1.3
🦋  - @vgpu/core 0.2.1
🦋  - @vgpu/adapter-mock 0.2.1
🦋  - @vgpu/render 0.1.8
🦋  ---
🦋  info Packages to be bumped at minor
🦋  - @vgpu/cli 0.2.0
🦋    - .changeset/handshake-version-gate-order.md
🦋    - .changeset/no-bundler-and-two-pass-docs.md
🦋    - .changeset/plain-entry-point-reflection.md
🦋    - .changeset/soft-pears-repeat.md
🦋    - .changeset/wgsl-validate-honest.md
🦋  - @vgpu/wgsl 0.3.0
🦋    - .changeset/plain-entry-point-reflection.md
🦋    - .changeset/resolve-shader-esm-only-note.md
🦋    - .changeset/wgsl-mangler-scoped-local-shadowing.md
🦋    - .changeset/wgsl-minify-leading-dot-float.md
🦋    - .changeset/wgsl-minify-local-scope-activation.md
🦋    - .changeset/wgsl-reject-non-ascii-identifiers.md
🦋    - .changeset/wgsl-runtime-works-from-cjs.md
🦋    - .changeset/wgsl-validate-honest.md
🦋    - .changeset/wgsl-validate-the-returned-wgsl.md
🦋  ---
🦋  info Running release would release NO packages as a major
```

### Tabla de bumps verificada

| Paquete | Bump | Versión resultante | Confirma expectativa |
|---|---|---|---|
| `vgpu` | patch | 0.2.0 → 0.2.1 | ✅ |
| `@vgpu/wgsl` | minor | → 0.3.0 | ✅ (por sus propios changesets) |
| `@vgpu/cli` | minor | 0.1.8 → 0.2.0 | ✅ |
| `@vgpu/core` | patch (cascada) | → 0.2.1 | ✅ |
| `@vgpu/adapter-mock` | patch (cascada) | → 0.2.1 | ✅ |
| `@vgpu/render` | patch (cascada) | → 0.1.8 | ✅ |
| `@vgpu/adapter-node` | patch | → 0.1.8 | ✅ |
| `@vgpu/wgsl-std` | — | sin cambios | ✅ (no aparece en el output) |
| `docs` | patch | → 0.1.3 | (paquete interno, no forma parte del pedido, sin impacto en el criterio) |
| Major | — | ninguno | ✅ |

No se corrió `changeset version`. No se consume ningún changeset.
