### PR TITLE
chore(changesets): lockstep publishable packages under one fixed group

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -2,7 +2,7 @@
   "$schema": "https://unpkg.com/@changesets/config@3.1.4/schema.json",
   "changelog": "@changesets/cli/changelog",
   "commit": false,
-  "fixed": [],
+  "fixed": [["vgpu", "@vgpu/core", "@vgpu/wgsl", "@vgpu/wgsl-std", "@vgpu/adapter-node", "@vgpu/adapter-mock", "@vgpu/render"]],
   "linked": [],
   "access": "public",
   "baseBranch": "main",

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,6 +45,11 @@ Releases are cut by hand and published by CI. There is no bot and no automatic
 version-packages PR: `.github/workflows/release.yml` runs on a **published GitHub
 Release** whose tag starts with `v`, and that is the only thing that publishes to npm.
 
+All published packages (`vgpu`, `@vgpu/core`, `@vgpu/wgsl`, `@vgpu/wgsl-std`,
+`@vgpu/adapter-node`, `@vgpu/adapter-mock`, `@vgpu/render`) version together via the
+`fixed` group in `.changeset/config.json`; private packages (`@vgpu/cli`, the docs app)
+keep independent lineages outside that group.
+
 ### 1. Version the packages (a PR of its own)
 
 From an up-to-date `main`, on a release branch:


### PR DESCRIPTION
## Decisión del dueño (lockstep para el release 0.3.0)

Se agrupan los **7 paquetes publicables** bajo un `fixed` group de changesets, para que
versionen todos juntos en cada release. Los paquetes privados (`@vgpu/cli`, `docs`)
quedan **fuera** del grupo y mantienen su linaje propio de versionado:

- `@vgpu/cli` es contabilidad interna que nada lee en runtime (ver dossier de release,
  §2.1: `copy-cli.mjs` stampa la versión de `vgpu` en el tarball publicado; el checkout
  in-repo resuelve su versión desde `packages/vgpu-api/package.json`).
- `docs` es una app privada, nunca se publica.

```json
"fixed": [["vgpu", "@vgpu/core", "@vgpu/wgsl", "@vgpu/wgsl-std", "@vgpu/adapter-node", "@vgpu/adapter-mock", "@vgpu/render"]]
```

También se agregaron 2 líneas a `CONTRIBUTING.md` §Releasing documentando la política.

## Verificación — `npx @changesets/cli@2.29.7 status --verbose` (post-edit)

```
🦋  info Packages to be bumped at patch
🦋  - docs 0.1.3
🦋  ---
🦋  info Packages to be bumped at minor
🦋  - @vgpu/cli 0.2.0
🦋    - .changeset/handshake-version-gate-order.md
🦋    - .changeset/no-bundler-and-two-pass-docs.md
🦋    - .changeset/plain-entry-point-reflection.md
🦋    - .changeset/soft-pears-repeat.md
🦋    - .changeset/wgsl-validate-honest.md
🦋  - @vgpu/wgsl 0.3.0
🦋    - .changeset/plain-entry-point-reflection.md
🦋    - .changeset/resolve-shader-esm-only-note.md
🦋    - .changeset/wgsl-mangler-scoped-local-shadowing.md
🦋    - .changeset/wgsl-minify-leading-dot-float.md
🦋    - .changeset/wgsl-minify-local-scope-activation.md
🦋    - .changeset/wgsl-reject-non-ascii-identifiers.md
🦋    - .changeset/wgsl-runtime-works-from-cjs.md
🦋    - .changeset/wgsl-validate-honest.md
🦋    - .changeset/wgsl-validate-the-returned-wgsl.md
🦋  - vgpu 0.3.0
🦋    - .changeset/plain-entry-point-reflection.md
🦋  - @vgpu/adapter-node 0.3.0
🦋    - .changeset/soft-pears-repeat.md
🦋  - @vgpu/core 0.3.0
🦋  - @vgpu/adapter-mock 0.3.0
🦋  - @vgpu/render 0.3.0
🦋  - @vgpu/wgsl-std 0.3.0
🦋  ---
🦋  info Running release would release NO packages as a major
```

Confirmado el lockstep esperado por el dueño:

| Paquete | Antes | Después | Nota |
|---|---|---|---|
| `vgpu` | 0.2.0 | **0.3.0** | explícito |
| `@vgpu/wgsl` | 0.2.0 | **0.3.0** | explícito |
| `@vgpu/wgsl-std` | 0.2.0 | **0.3.0** | **arrastrado por el fixed group** (sin changeset propio) |
| `@vgpu/core` | 0.2.0 | **0.3.0** | arrastrado por el fixed group |
| `@vgpu/adapter-node` | 0.1.7 | **0.3.0** | explícito (patch) + arrastrado |
| `@vgpu/adapter-mock` | 0.2.0 | **0.3.0** | arrastrado por el fixed group |
| `@vgpu/render` | 0.1.7 | **0.3.0** | arrastrado por el fixed group |
| `@vgpu/cli` (privado) | 0.1.8 | 0.2.0 | minor propio, **fuera** del grupo |
| `docs` (privado) | 0.1.2 | 0.1.3 | patch, fuera del grupo |

Los 7 paquetes publicables quedan **idénticos en 0.3.0**. Esta es la semántica estándar de
`fixed` en `@changesets/cli`: si cualquier miembro del grupo recibe un bump por sus propios
changesets, **todo el grupo** se versiona junto al nivel de bump más alto detectado dentro
del grupo — no fue necesario forzar nada.

## Verificación de base

- Base = `origin/main` (`8116cc27`). **No incluye la PR #309** (fue cerrada sin mergear,
  confirmado con `gh pr view 309`: `"state": "CLOSED", "mergedAt": null`).
- `.changeset/plain-entry-point-reflection.md` está en su forma original (`vgpu: minor`,
  `@vgpu/wgsl: minor`, `@vgpu/cli: minor`) — no tocado.

No se corrió `changeset version`. Este PR solo cambia la config de agrupamiento y la doc.
