### PR TITLE
fix(wgsl): silence webpack critical-dependency warnings from the validation device loader

### DIFF
--- a/.changeset/wgsl-validation-device-webpack-ignore.md
+++ b/.changeset/wgsl-validation-device-webpack-ignore.md
@@ -1,0 +1,13 @@
+---
+"@vgpu/wgsl": patch
+---
+
+Fix the lazy `@vgpu/adapter-node` import in the validation device loader so bundlers can see it's an
+ordinary package specifier: it now uses a literal specifier (typed via a local ambient module
+declaration) instead of a variable, so `tsc` no longer wraps it in its
+`__rewriteRelativeImportExtension` helper. That wrapper was invisible to both webpack's module
+parser and Next.js's build-dependency cache scanner, so every consumer that bundles the loader saw
+two spurious warnings per build ("Critical dependency: the request of a dependency is an
+expression" during the webpack ESM build-dependency scan, plus "Build dependencies behind this
+expression are ignored and might cause incorrect cache invalidation"). The dynamic import still
+only runs in Node and behaves identically at runtime.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,6 +142,18 @@ jobs:
           node-version: 22
           cache: pnpm
       - run: pnpm install --frozen-lockfile
+      # This suite loads the repo's own vitest.config.ts, which imports @vgpu/wgsl's Vite loader
+      # by *source path* (./packages/wgsl/src/...), not by package name. Vite's config-file
+      # bundler (a separate, alias-unaware esbuild pass that runs before the config it's loading
+      # can supply any resolve.alias) therefore parses that source file's contents directly — and
+      # since @vgpu/wgsl's validation device now imports the optional @vgpu/adapter-node peer dep
+      # via a literal specifier (so bundlers like webpack/Next can see it; see the wgsl-loader
+      # bundler tests and validation-device.ts for why), that literal is statically resolvable and
+      # esbuild tries to. @vgpu/adapter-node's package.json only exports a built dist/, so this
+      # needs it (and its own dependency chain, @vgpu/core <- @vgpu/wgsl) built first. A real
+      # consumer never hits this: they import the loader by package name, which esbuild always
+      # externalizes without reading its contents, so the dynamic import stays opaque to it.
+      - run: pnpm --filter @vgpu/adapter-node build
       - run: pnpm test packages/wgsl/tests/cache-key.test.ts
 
   wgsl-turbopack-smoke:
@@ -390,6 +402,11 @@ jobs:
           node-version: 22
           cache: pnpm
       - run: pnpm install --frozen-lockfile
+      # The vitest run below loads the repo's own vitest.config.ts, which imports @vgpu/wgsl's
+      # Vite loader by source path and therefore needs @vgpu/adapter-node (and its own dependency
+      # chain, @vgpu/core <- @vgpu/wgsl) built first. See the identical comment on
+      # wgsl-cachekey-determinism above for the full explanation.
+      - run: pnpm --filter @vgpu/adapter-node build
       - name: Validate authored controlled vocabulary
         run: node apps/docs/scripts/validate-example-vocabulary.mjs
       - name: Synchronize frozen embedded schemas

--- a/packages/wgsl/src/runtime/adapter-node-ambient.d.ts
+++ b/packages/wgsl/src/runtime/adapter-node-ambient.d.ts
@@ -1,0 +1,15 @@
+/**
+ * Ambient shape for the optional `@vgpu/adapter-node` peer dependency, declared globally (this file
+ * has no top-level import/export, so `declare module` here creates a brand-new ambient module
+ * instead of augmenting one — no real project reference to `@vgpu/adapter-node` is needed).
+ *
+ * `validation-device.ts` dynamically imports `@vgpu/adapter-node` using a *literal* specifier so
+ * `tsc` emits it verbatim (no `__rewriteRelativeImportExtension` wrapper, which bundlers' static
+ * analysis — and Next's build-dependency cache scanner — cannot see through). Resolving that literal
+ * specifier's real types would need a `wgsl -> adapter-node` project reference, which combined with
+ * `adapter-node -> core -> wgsl` forms a cycle `tsc -b` rejects; this ambient declaration satisfies
+ * the type-checker instead. Keep in sync with `AdapterNodeModule` in validation-device.ts.
+ */
+declare module "@vgpu/adapter-node" {
+  export function createNodeAdapter(): { requestDevice(): Promise<{ readonly gpu: GPUDevice }> };
+}

--- a/packages/wgsl/src/runtime/validation-device.ts
+++ b/packages/wgsl/src/runtime/validation-device.ts
@@ -75,12 +75,20 @@ function destroyIdleDevice(): void {
 async function acquire(): Promise<GPUDevice> {
   let adapterNode: AdapterNodeModule;
   try {
-    // `@vgpu/adapter-node` is an *optional* peer dependency, imported lazily and through an
-    // indirect specifier on purpose: a static import would form a `wgsl -> adapter-node -> core ->
-    // wgsl` cycle that `tsc -b` rejects, and would pull a native dependency into every bundle that
-    // touches `resolveShader`. Never hoist this to module scope.
-    const specifier = "@vgpu/adapter-node";
-    adapterNode = (await import(specifier)) as AdapterNodeModule;
+    // `@vgpu/adapter-node` is an *optional* peer dependency, imported lazily and never hoisted to
+    // module scope: a static `import ... from` declaration would form a `wgsl -> adapter-node ->
+    // core -> wgsl` project-reference cycle that `tsc -b` rejects, and would pull a native
+    // dependency into every bundle that touches `resolveShader`.
+    //
+    // The specifier is kept a *literal* string (types resolved via the ambient module declared in
+    // `./adapter-node-ambient.d.ts`, which sidesteps the same project-reference cycle) rather than
+    // hidden behind a variable: `tsc`'s `rewriteRelativeImportExtensions` only leaves a dynamic
+    // `import()` argument untouched when it can prove, syntactically, that it's a literal and not a
+    // relative specifier. A variable indirection defeats that proof, so `tsc` wraps the call in its
+    // `__rewriteRelativeImportExtension` helper — which neither webpack nor Next's build-dependency
+    // cache scanner can statically analyse, producing a "Critical dependency"/"cache invalidation"
+    // warning in every consumer's build.
+    adapterNode = (await import("@vgpu/adapter-node")) as AdapterNodeModule;
   } catch (cause) {
     throw wgslErrorWithFix(
       "VGPU-WGSL-VALIDATE-ADAPTER-MISSING",


### PR DESCRIPTION
## Fix for F2 (dogfood rc.1 friction log)

`@vgpu/wgsl`'s validation device loader (`packages/wgsl/src/runtime/validation-device.ts`) lazily imports the optional `@vgpu/adapter-node` peer dependency. Before this PR the specifier was stored in a variable to dodge `tsc -b`'s project-reference cycle check (`wgsl -> adapter-node -> core -> wgsl`), which made `tsc`'s `rewriteRelativeImportExtensions` wrap the emitted `import()` call in its `__rewriteRelativeImportExtension` runtime helper:

```js
adapterNode = await import(__rewriteRelativeImportExtension(specifier));
```

Neither webpack's normal module parser nor Next.js's persistent-cache build-dependency scanner (`FileSystemInfo`/`PackFileCacheStrategy`, which uses `es-module-lexer` to statically find imports in files that are part of a webpack loader's own dependency graph) can see through that wrapper, so **every consumer that bundles `@vgpu/wgsl/loader-webpack` printed two warnings on every build** (client + server pass):

```
<w> [webpack.cache.PackFileCacheStrategy/webpack.FileSystemInfo] Parsing of
    .../node_modules/@vgpu/wgsl/dist/runtime/validation-device.js
    for build dependencies failed at 'import(__rewriteRelativeImportExtension(specifier))'.
<w> Build dependencies behind this expression are ignored and might cause incorrect cache invalidation.
```

### Note on the originally-proposed fix
A `webpackIgnore` magic comment does **not** fix this. I verified (by reading Next's vendored `webpack/bundle5.js` and reproducing before/after) that this specific warning comes from Next's build-dependency ESM scanner, a code path that only tries `parseString()` on the raw dynamic-import argument text and has no concept of magic comments at all — that's a separate subsystem from webpack's `ImportParserPlugin`, which is the one that *does* honor `webpackIgnore`. Adding the comment just relocates it into the warning text; the warning count is unchanged.

### Actual fix
- Use a **literal** specifier directly in the `import()` call instead of a variable. `tsc`'s specifier-rewrite transform only leaves a dynamic `import()` argument untouched when it can prove, syntactically, that it's a literal that isn't a relative path — so this emits a plain `import("@vgpu/adapter-node")`, no wrapper, which both webpack and Next's lexer can parse.
- To keep this literal from making `tsc` resolve the real `@vgpu/adapter-node` package (which would need a `wgsl -> adapter-node` project reference and recreate the `adapter-node -> core -> wgsl` cycle), added a small ambient module declaration (`packages/wgsl/src/runtime/adapter-node-ambient.d.ts`, a non-module `.d.ts` so it creates a new ambient module instead of augmenting a resolved one) describing just the slice of the API this file uses.

### Verification
- Reproduced the exact dogfood repro app (Next.js 16.3.0 + `next build --webpack`, loader wired via `next.config.ts`) locally:
  - **Before**: 2 warnings per build.
  - **After**: 0 warnings, build otherwise identical.
- Runtime behavior unchanged — ran the dogfood's `probe-validate.mjs` against the fixed build: `validate:"require"` with a real adapter present still resolves (`{"mode":"require","attempted":true,"ok":true}`), and invalid-shader validation still throws as before.
- `pnpm build` (fresh `tsc -b` across the whole workspace) succeeds with no errors.
- `pnpm -w typecheck` passes.
- `npx vitest run packages/wgsl` — 56 files / 460 tests pass (0 failed), including `validation-device.test.ts`, `validation-device-errors.test.ts`, `validation-concurrency.test.ts`, `adapter-node-contract.test.ts`, `runtime-cjs-require.test.ts`, `webpack-real.test.ts`, and `vite-real.test.ts` (the three latter are exactly what CI's `wgsl-loader-bundler-tests` job runs).
- `pnpm bundle-check` passes; `@vgpu/wgsl/runtime [tooling]` headroom actually *improved* (removing the `__rewriteRelativeImportExtension` helper call site more than offset the extra comment bytes): 606 B headroom vs. the ~128 B it had before this change.
- Added a changeset (`.changeset/wgsl-validation-device-webpack-ignore.md`, `@vgpu/wgsl` patch).

Not merging — for review.

## Update: fixed 4 CI checks (examples-api-generated + wgsl-cachekey-determinism x3 platforms)

The literal specifier (needed for the fix above) made a previously-invisible dynamic import
visible to static analysis everywhere, not just to webpack/Next. Two of this repo's own CI jobs
(`wgsl-cachekey-determinism`, `examples-api-generated`) run `vitest`/`pnpm test` against this
repo's root `vitest.config.ts`, which imports `@vgpu/wgsl`'s Vite loader **by source path**
(`./packages/wgsl/src/loader-vite/index.ts`), not by package name. Loading that config file goes
through Vite's own config-file bundler — a separate, alias-unaware `esbuild` pass that necessarily
runs *before* the config it's loading can supply any `resolve.alias` — which therefore parses
`validation-device.ts`'s contents directly. Its `import("@vgpu/adapter-node")` is now a literal, so
`esbuild`'s `externalize-deps` plugin tries to resolve the real `@vgpu/adapter-node` package, and
fails: that package's `exports` only point at `dist/`, which these two jobs never build (unlike
`test-fast`, which builds it as a side effect of running `tsc -b` for typecheck first).

This is a repo-internal consequence of the literal specifier doing exactly what it's supposed to
do — jobs that execute source code which lazily imports built workspace packages must build those
packages first; the literal specifier makes a previously-invisible runtime dependency visible to
static analysis, which is the point. It is **not** something an external consumer can hit: importing
the loader by package name (`"@vgpu/wgsl/loader-vite"`, as any real consumer does) is always
externalized by `esbuild`/webpack without reading the file's contents, so the dynamic import inside
it stays opaque to them regardless of whether `@vgpu/adapter-node` is installed/built. Verified this
empirically: loading a Vite config that imports the loader by package name from an *installed* copy
(with the literal-specifier dist) succeeds even when done from a project where `@vgpu/adapter-node`
has no reachable `dist` at all — the config bundler never looks inside the loader's file.

Fix: build `@vgpu/adapter-node` (whose `tsc -b` project references transitively build `@vgpu/core`
and `@vgpu/wgsl` too) right after `pnpm install`, in both affected jobs. Measured cost: ~1.3s
locally — negligible.

Verified locally by reproducing the exact CI failure (`rm -rf packages/adapter-node/dist` + rerun
each job's exact command) and confirming the added build step turns both green.
