### PR TITLE
chore(release): 0.3.0-rc.1

### DIFF
--- a/packages/adapter-mock/package.json
+++ b/packages/adapter-mock/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vgpu/adapter-mock",
-  "version": "0.3.0-rc.0",
+  "version": "0.3.0-rc.1",
   "description": "Mock GPU adapter for testing vgpu code without real WebGPU hardware.",
   "keywords": [
     "webgpu",

--- a/packages/adapter-node/package.json
+++ b/packages/adapter-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vgpu/adapter-node",
-  "version": "0.3.0-rc.0",
+  "version": "0.3.0-rc.1",
   "description": "Node.js GPU adapter for vgpu, using Dawn-based WebGPU bindings.",
   "keywords": [
     "webgpu",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vgpu/core",
-  "version": "0.3.0-rc.0",
+  "version": "0.3.0-rc.1",
   "description": "Core WebGPU runtime primitives (device, buffer, texture, shader, queue) for vgpu.",
   "keywords": [
     "webgpu",

--- a/packages/render/package.json
+++ b/packages/render/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vgpu/render",
-  "version": "0.3.0-rc.0",
+  "version": "0.3.0-rc.1",
   "description": "Render pipeline + render pass abstractions for vgpu.",
   "keywords": [
     "webgpu",

--- a/packages/vgpu-api/package.json
+++ b/packages/vgpu-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vgpu",
-  "version": "0.3.0-rc.0",
+  "version": "0.3.0-rc.1",
   "description": "Public VGPU API entrypoint scaffold for browser, Node, mock, scene, and client typing surfaces.",
   "keywords": [
     "webgpu",

--- a/packages/wgsl-std/package.json
+++ b/packages/wgsl-std/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vgpu/wgsl-std",
-  "version": "0.3.0-rc.0",
+  "version": "0.3.0-rc.1",
   "description": "Pure WGSL utility snippets for vgpu shaders.",
   "keywords": [
     "webgpu",

--- a/packages/wgsl/package.json
+++ b/packages/wgsl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vgpu/wgsl",
-  "version": "0.3.0-rc.0",
+  "version": "0.3.0-rc.1",
   "description": "WGSL shader compilation, runtime resolution, and webpack/vite loaders for vgpu.",
   "keywords": [
     "webgpu",

--- a/skills/vgpu/SKILL.md
+++ b/skills/vgpu/SKILL.md
@@ -5,9 +5,9 @@ description: >-
   vgpu/mock, vgpu/scene, and vgpu/client. Use @vgpu/render/inspect, /utils, /edit,
   and /perf only as slim tooling subpaths. Bundles performance guides and the API
   reference; load one doc at a time.
-vgpuVersion: 0.3.0-rc.0
-gitSha: 32d5b095cef875dc201f99f632c38d363935e918
-generatedAt: 2026-08-05T04:57:22.180Z
+vgpuVersion: 0.3.0-rc.1
+gitSha: d8a6c7eae12a6ecbe92f394da4b050dce38af674
+generatedAt: 2026-08-05T05:05:18.440Z
 ---
 
 # vgpu


### PR DESCRIPTION
Second candidate for 0.3.0. `0.3.0-rc.0` ships the webpack noise that #314 fixed, so this is a mechanical suffix bump — **no source changes, no `changeset version` run**.

## Versions

| Package | Publishable | Before (rc.0) | After (this PR) |
| --- | --- | --- | --- |
| `vgpu` | yes | 0.3.0-rc.0 | **0.3.0-rc.1** |
| `@vgpu/core` | yes | 0.3.0-rc.0 | **0.3.0-rc.1** |
| `@vgpu/wgsl` | yes | 0.3.0-rc.0 | **0.3.0-rc.1** |
| `@vgpu/wgsl-std` | yes | 0.3.0-rc.0 | **0.3.0-rc.1** |
| `@vgpu/adapter-node` | yes | 0.3.0-rc.0 | **0.3.0-rc.1** |
| `@vgpu/adapter-mock` | yes | 0.3.0-rc.0 | **0.3.0-rc.1** |
| `@vgpu/render` | yes | 0.3.0-rc.0 | **0.3.0-rc.1** |
| `@vgpu/cli` | no (private) | 0.2.0 | 0.2.0 (untouched) |
| `docs` | no (private app) | 0.1.3 | 0.1.3 (untouched) |

All seven move together — they are one `fixed` group since #310, so unlike `0.2.0-rc.1` (six packages spread across two version lines) no package is left behind.

## What rc.1 contains

Everything merged since the `v0.3.0-rc.0` tag:

- **#314 — the reason for rc.1.** The validation device loader's lazy `@vgpu/adapter-node` import used a variable specifier, so `tsc` wrapped it in `__rewriteRelativeImportExtension`; webpack's module parser and Next.js's build-dependency scanner could not see through it and emitted two spurious warnings per build for every consumer bundling `@vgpu/wgsl`. Anyone dogfooding rc.0 in a webpack/Next app hits that noise.
- **#312** — docs: `@vgpu/wgsl/runtime` is reachable from CJS (stale ESM-only claim removed).
- **#313** — docs: `reflectSource` documented, loader `validate: false` clarified, plus a CI fix recording new redirect destinations and raising the CLI pack budget.

## Why there is no `changeset version` commit

The one pending changeset (`.changeset/wgsl-validation-device-webpack-ignore.md`, `@vgpu/wgsl` patch, from #314) **stays queued on purpose**. This mirrors `0.2.0-rc.1` (`eab87e83`), whose commit message states it explicitly: *"Bumped `version` only, by hand … (no `changeset version` run — the pending changesets stay queued for the 0.2.0 final CHANGELOG)"*. That tag really does carry three unconsumed changesets, and `.changeset/` was only emptied at the 0.2.0 stable release, which is also where the suffix was dropped (`282d8c32`).

Running `changeset version` here is not merely unnecessary, it is **wrong**, and I verified it rather than assuming: from a `0.3.0-rc.0` base with one queued patch it resolves to plain **`0.3.0`** — it drops the rc suffix entirely and folds the entry into the `## 0.3.0` CHANGELOG heading rc.0 already wrote. Result discarded.

So CHANGELOGs are untouched in this PR (same as rc.0 → rc.1 in the 0.2.0 line, where the CHANGELOG diff between the two tags is empty). The #314 entry lands in the 0.3.0 CHANGELOG at promotion, when the queue is consumed once.

## The skill ritual, done up front this time

`skills/vgpu/SKILL.md`'s frontmatter carries a `vgpuVersion` stamp that `check-drift.js` deliberately does **not** normalize, so any version bump makes the committed skill stale and fails `docs-generated`. On rc.0 that cost a red CI round; here it is in the same PR: `vgpuVersion: 0.3.0-rc.0` → `0.3.0-rc.1`, only the three stamp lines move. The docs manifest is untouched (#313 already regenerated it for the new `reflectSource` content).

Regenerated with `pnpm -F @vgpu/cli generate:docs`. ⚠️ Reminder that the hint `check-drift` prints — `pnpm -F vgpu generate:docs` — selects `packages/vgpu-api`, has no such script, and **exits 0 without doing anything**; fixing that hint and documenting the step in `CONTRIBUTING.md` remain post-release follow-ups.

## Gates

| Gate | Result |
| --- | --- |
| `pnpm build` | ✅ pass |
| `pnpm -w typecheck` | ✅ pass (incl. `typecheck:fixtures`) |
| `pnpm exec vitest run` | ✅ pass — 245 files passed / 24 skipped, 1880 tests passed / 139 skipped |
| `pnpm bundle-check` | ✅ pass — all budgets green; `@vgpu/wgsl/runtime` 23970 B / 24576 B and the two loaders each drop ~120 B, courtesy of #314 removing the `__rewriteRelativeImportExtension` wrapper |
| `check-drift.js` | ✅ clean — skills, manifest, 107 geistdocs files |

## Not in this PR

The `v0.3.0-rc.1` tag and the GitHub Release with **Set as a pre-release** ticked are created after this merges, by hand, on the merge commit — that is what triggers `release.yml` to publish the seven packages under the `next` dist-tag. `latest` stays on 0.2.0.
