### PR TITLE
Update docs header examples link

### DIFF
--- a/apps/docs/geistdocs.tsx
+++ b/apps/docs/geistdocs.tsx
@@ -30,8 +30,8 @@ export const nav = [
     href: "/docs",
   },
   {
-    label: "Source",
-    href: `https://github.com/${github.owner}/${github.repo}/`,
+    label: "Examples",
+    href: "/examples",
   },
 ];
 


### PR DESCRIPTION
## Summary

- replace the redundant **Source** header link with **Examples**
- point the new navigation item to the existing `/examples` gallery
- keep the existing GitHub icon as the repository link

## Why

The text link duplicated the GitHub icon. Linking to the examples gallery makes the header navigation more useful without removing repository access.

## Validation

- `git diff --check` passes
- `pnpm install --frozen-lockfile` passes
- `pnpm --dir apps/docs build` was attempted, but the workspace TypeScript prebuild fails with `TS5055` because existing `packages/wgsl/dist/*.d.ts` inputs would be overwritten; the docs app build is not reached
