### PR TITLE
04/compute-async: lazy pipeline compilation + async dispatchOnce()

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "build": "tsc -b && node packages/vgpu-api/scripts/copy-cli.mjs && node -e \"require('fs').copyFileSync('packages/wgsl/src/wgsl-types.d.ts', 'packages/wgsl/dist/wgsl-types.d.ts')\"",
     "typecheck": "tsc -b && pnpm run typecheck:fixtures",
-    "typecheck:fixtures": "tsc -p packages/core/tests/tsconfig.create-sampler-types.json && tsc -p packages/core/tests/tsconfig.types.json && tsc -p packages/vgpu-api/tests/uniforms/tsconfig.types.json",
+    "typecheck:fixtures": "tsc -p packages/core/tests/tsconfig.create-sampler-types.json && tsc -p packages/core/tests/tsconfig.types.json && tsc -p packages/vgpu-api/tests/uniforms/tsconfig.types.json && tsc -p packages/vgpu-api/tests/compute/tsconfig.types.json",
     "docs:verify-snippets": "node scripts/verify-docs-snippets.mjs",
     "test": "vitest run",
     "test:fast": "vitest run packages/adapter-mock packages/core packages/wgsl packages/render scripts",

--- a/packages/core/src/mock-gpu.ts
+++ b/packages/core/src/mock-gpu.ts
@@ -13,6 +13,7 @@ export interface MockGPUDeviceInstrumentation {
     createRenderPipeline: number;
     createRenderPipelineAsync: number;
     createComputePipeline: number;
+    createComputePipelineAsync: number;
     createQuerySet: number;
   };
   readonly createBufferDescriptors: GPUBufferDescriptor[];
@@ -23,6 +24,7 @@ export interface MockGPUDeviceInstrumentation {
   readonly createRenderPipelineDescriptors: GPURenderPipelineDescriptor[];
   readonly createRenderPipelineAsyncDescriptors: GPURenderPipelineDescriptor[];
   readonly createComputePipelineDescriptors: GPUComputePipelineDescriptor[];
+  readonly createComputePipelineAsyncDescriptors: GPUComputePipelineDescriptor[];
   readonly createQuerySetDescriptors: GPUQuerySetDescriptor[];
   /** Render-pass occlusion scope ops in encode order: ["begin", queryIndex] / ["end"]. */
   readonly occlusionQueryOps: Array<readonly ["begin", number] | readonly ["end"]>;
@@ -98,6 +100,14 @@ export function createMockGPUDevice(options: MockGPUDeviceOptions = {}): GPUDevi
     createComputePipeline(desc: GPUComputePipelineDescriptor): GPUComputePipeline {
       instrumentation.calls.createComputePipeline += 1;
       instrumentation.createComputePipelineDescriptors.push(desc);
+      return {
+        label: desc.label ?? "",
+        getBindGroupLayout: (_groupIndex: number) => ({}) as GPUBindGroupLayout,
+      } as unknown as GPUComputePipeline;
+    },
+    async createComputePipelineAsync(desc: GPUComputePipelineDescriptor): Promise<GPUComputePipeline> {
+      instrumentation.calls.createComputePipelineAsync += 1;
+      instrumentation.createComputePipelineAsyncDescriptors.push(desc);
       return {
         label: desc.label ?? "",
         getBindGroupLayout: (_groupIndex: number) => ({}) as GPUBindGroupLayout,
@@ -230,6 +240,7 @@ function createMockGPUDeviceInstrumentation(): MockGPUDeviceInstrumentation {
       createRenderPipeline: 0,
       createRenderPipelineAsync: 0,
       createComputePipeline: 0,
+      createComputePipelineAsync: 0,
       createQuerySet: 0,
     },
     createBufferDescriptors: [],
@@ -240,6 +251,7 @@ function createMockGPUDeviceInstrumentation(): MockGPUDeviceInstrumentation {
     createRenderPipelineDescriptors: [],
     createRenderPipelineAsyncDescriptors: [],
     createComputePipelineDescriptors: [],
+    createComputePipelineAsyncDescriptors: [],
     createQuerySetDescriptors: [],
     occlusionQueryOps: [],
   };

--- a/packages/vgpu-api/src/api-types.ts
+++ b/packages/vgpu-api/src/api-types.ts
@@ -19,7 +19,13 @@ export interface DispatchOptions {
   /** GPU-driven dispatch: read the workgroup counts from a buffer instead of CPU-side counts. */
   readonly indirect: StorageBuffer | { readonly buffer: StorageBuffer; readonly offset?: number };
 }
-export interface Compute { set(values: Record<string, unknown>): this; dispatch(x: number, y?: number, z?: number): void; dispatch(opts: DispatchOptions): void }
+export interface Compute {
+  set(values: Record<string, unknown>): this;
+  dispatch(x: number, y?: number, z?: number): void;
+  dispatch(opts: DispatchOptions): void;
+  dispatchOnce(x: number, y?: number, z?: number): Promise<void>;
+  dispatchOnce(opts: DispatchOptions): Promise<void>;
+}
 export type StorageAccess = "read" | "read-write";
 export interface StorageOptions {
   /** Binding access for shader reflection. Defaults to "read-write". */

--- a/packages/vgpu-api/src/compute.ts
+++ b/packages/vgpu-api/src/compute.ts
@@ -122,6 +122,10 @@ export class ComputePipeline implements Compute {
     const pipeline = await this.#ensurePipelineAsync();
     // The device may have been disposed while the pipeline compile was in flight — re-check before touching it.
     assertDeviceUsable(this.device, where);
+    // Bindings are not snapshotted at call time either (consistent with `set()` never snapshotting — the
+    // last `set()` wins): a `set()` that introduces writable-storage aliasing while the compile was in
+    // flight must still be caught here, before any encoding happens, exactly like the sync dispatch() path.
+    this.#preflightAliasing(where);
     const encoder = this.device.gpu.createCommandEncoder({ label: `${this.label}.encoder` });
     const pass = encoder.beginComputePass({ label: `${this.label}.pass` });
     pass.setPipeline(pipeline);
@@ -147,15 +151,28 @@ export class ComputePipeline implements Compute {
    * compile a second `GPUComputePipeline` — `??=` below keeps whichever one lands first as the memoized
    * pipeline instead of letting the async result silently clobber a sync one that already resolved (and
    * that `dispatch()` may already have bound to a pass), which would otherwise churn pipeline identity.
+   *
+   * A rejected compile must not poison the instance forever: both branches clear `#pipelinePending` once
+   * settled, but only if it is still *this* attempt's promise (an in-flight retry started after a prior
+   * settle must not have its own pending slot yanked out from under it), so a later `dispatchOnce()` call
+   * starts a fresh `createComputePipelineAsync()` instead of re-awaiting (or being poisoned by) a stale
+   * rejection.
    */
   #ensurePipelineAsync(): Promise<GPUComputePipeline> {
     if (this.#pipeline) return Promise.resolve(this.#pipeline);
     if (!this.#pipelinePending) {
-      this.#pipelinePending = this.device.gpu.createComputePipelineAsync(this.#pipelineDescriptor).then((pipeline) => {
-        this.#pipeline ??= pipeline;
-        this.#pipelinePending = undefined;
-        return this.#pipeline;
-      });
+      const attempt: Promise<GPUComputePipeline> = this.device.gpu.createComputePipelineAsync(this.#pipelineDescriptor).then(
+        (pipeline) => {
+          this.#pipeline ??= pipeline;
+          if (this.#pipelinePending === attempt) this.#pipelinePending = undefined;
+          return this.#pipeline;
+        },
+        (error: unknown) => {
+          if (this.#pipelinePending === attempt) this.#pipelinePending = undefined;
+          throw error;
+        },
+      );
+      this.#pipelinePending = attempt;
     }
     return this.#pipelinePending;
   }

--- a/packages/vgpu-api/src/compute.ts
+++ b/packages/vgpu-api/src/compute.ts
@@ -7,7 +7,7 @@ import { createSetCore, bindGroupLayoutsForReflection, pipelineLayoutFor, type S
 import { visibilityForEntries } from "./set-layouts.ts";
 import type { Compute, ComputeOptions, DispatchOptions } from "./api-types.ts";
 import { normalizeConstantsOptions, selectEntryPoint } from "./pipeline-store.ts";
-import { indirectInvalidError, unsupportedError, writableStorageAliasingError } from "./errors.ts";
+import { dispatchCountInvalidError, indirectInvalidError, unsupportedError, writableStorageAliasingError } from "./errors.ts";
 import { assertDeviceUsable } from "./lifecycle.ts";
 import type { Gpu } from "./kernel.ts";
 import { liveKernel } from "./live-kernel.ts";
@@ -43,8 +43,10 @@ export class ComputePipeline implements Compute {
   readonly bindGroupLayouts: ReadonlyMap<number, GPUBindGroupLayout>;
   readonly pipelineLayout: GPUPipelineLayout;
   readonly shaderModule: GPUShaderModule;
-  readonly pipeline: GPUComputePipeline;
   readonly #storageBindings: readonly BindingInfo[];
+  readonly #pipelineDescriptor: GPUComputePipelineDescriptor;
+  #pipeline?: GPUComputePipeline;
+  #pipelinePending?: Promise<GPUComputePipeline>;
 
   constructor(
     private readonly device: Device,
@@ -64,12 +66,14 @@ export class ComputePipeline implements Compute {
     this.pipelineLayout = pipelineLayoutFor(device, this.bindGroupLayouts);
     this.shaderModule = device.gpu.createShaderModule({ label: `${this.label}.shader`, code: source });
     // Each Compute owns its pipeline (no shared store), so constants join the descriptor directly; the record is
-    // omitted when the option is absent to keep the descriptor byte-identical to before.
-    this.pipeline = device.gpu.createComputePipeline({
+    // omitted when the option is absent to keep the descriptor byte-identical to before. The pipeline itself is
+    // NOT compiled here — construction stays free of createComputePipeline(Async) calls; #ensurePipeline()/
+    // #ensurePipelineAsync() compile it lazily the first time dispatch()/dispatchOnce() needs it.
+    this.#pipelineDescriptor = {
       label: `${this.label}.pipeline`,
       layout: this.pipelineLayout,
       compute: { module: this.shaderModule, entryPoint: this.entryPoint, ...(constants ? { constants } : {}) },
-    });
+    };
     this.setCore = createSetCore({ device, label: this.label, drawId: this.id, reflection: this.reflection, bindGroupLayouts: this.bindGroupLayouts, cache: this.cache });
     const active = new Set(entryMetadata(entry, "bindings", this.label).map((binding) => `${binding.group}:${binding.binding}`));
     this.#storageBindings = this.reflection.bindings.filter((binding) => binding.kind === "buffer" && binding.addressSpace === "storage" && active.has(`${binding.group}:${binding.binding}`));
@@ -85,12 +89,16 @@ export class ComputePipeline implements Compute {
   dispatch(x: number, y?: number, z?: number): void;
   dispatch(opts: DispatchOptions): void;
   dispatch(x: number | DispatchOptions, y?: number, z?: number): void {
-    assertDeviceUsable(this.device, `${this.label}.dispatch`);
-    const indirect = typeof x === "object" && x !== null ? this.#resolveIndirectDispatch(x, y, z) : undefined;
-    this.#preflightAliasing();
+    const where = `${this.label}.dispatch`;
+    assertDeviceUsable(this.device, where);
+    const indirect = typeof x === "object" && x !== null ? this.#resolveIndirectDispatch(x, y, z, where) : this.#validateCounts(x as number, y, z, where) && undefined;
+    this.#preflightAliasing(where);
+    // Legacy dispatch() stays lazy-sync: it compiles inline the first time it is called (not at construction),
+    // reusing the draws' pipelineFor/getSync pattern, but synchronously — createComputePipeline(), not Async.
+    const pipeline = this.#ensurePipeline();
     const encoder = this.device.gpu.createCommandEncoder({ label: `${this.label}.encoder` });
     const pass = encoder.beginComputePass({ label: `${this.label}.pass` });
-    pass.setPipeline(this.pipeline);
+    pass.setPipeline(pipeline);
     for (const binding of this.setCore.bindGroups()) pass.setBindGroup(binding.group, binding.bindGroup, binding.offsets);
     if (indirect) pass.dispatchWorkgroupsIndirect(indirect.buffer, indirect.offset);
     else pass.dispatchWorkgroups(x as number, y ?? 1, z ?? 1);
@@ -98,14 +106,69 @@ export class ComputePipeline implements Compute {
     this.device.gpu.queue.submit([encoder.finish()]);
   }
 
+  /**
+   * Async twin of `dispatch()`: compiles the pipeline through `createComputePipelineAsync()` when it is not
+   * ready yet (reusing it unchanged otherwise, whether a prior `dispatch()` or `dispatchOnce()` created it),
+   * then owns its own encoder and submits exactly once. Resolves right after the submit — it never awaits
+   * `onSubmittedWorkDone`.
+   */
+  dispatchOnce(x: number, y?: number, z?: number): Promise<void>;
+  dispatchOnce(opts: DispatchOptions): Promise<void>;
+  async dispatchOnce(x: number | DispatchOptions, y?: number, z?: number): Promise<void> {
+    const where = `${this.label}.dispatchOnce`;
+    assertDeviceUsable(this.device, where);
+    const indirect = typeof x === "object" && x !== null ? this.#resolveIndirectDispatch(x, y, z, where) : this.#validateCounts(x as number, y, z, where) && undefined;
+    this.#preflightAliasing(where);
+    const pipeline = await this.#ensurePipelineAsync();
+    // The device may have been disposed while the pipeline compile was in flight — re-check before touching it.
+    assertDeviceUsable(this.device, where);
+    const encoder = this.device.gpu.createCommandEncoder({ label: `${this.label}.encoder` });
+    const pass = encoder.beginComputePass({ label: `${this.label}.pass` });
+    pass.setPipeline(pipeline);
+    for (const binding of this.setCore.bindGroups()) pass.setBindGroup(binding.group, binding.bindGroup, binding.offsets);
+    if (indirect) pass.dispatchWorkgroupsIndirect(indirect.buffer, indirect.offset);
+    else pass.dispatchWorkgroups(x as number, y ?? 1, z ?? 1);
+    pass.end();
+    this.device.gpu.queue.submit([encoder.finish()]);
+  }
+
+  /** Compiles the pipeline synchronously the first time it is needed, then memoizes it for every later call. */
+  #ensurePipeline(): GPUComputePipeline {
+    if (!this.#pipeline) this.#pipeline = this.device.gpu.createComputePipeline(this.#pipelineDescriptor);
+    return this.#pipeline;
+  }
+
+  /**
+   * Compiles the pipeline through `createComputePipelineAsync()` the first time it is needed, sharing one
+   * in-flight promise across concurrent callers, and reuses whatever `#ensurePipeline()` already compiled.
+   */
+  #ensurePipelineAsync(): Promise<GPUComputePipeline> {
+    if (this.#pipeline) return Promise.resolve(this.#pipeline);
+    if (!this.#pipelinePending) {
+      this.#pipelinePending = this.device.gpu.createComputePipelineAsync(this.#pipelineDescriptor).then((pipeline) => {
+        this.#pipeline = pipeline;
+        this.#pipelinePending = undefined;
+        return pipeline;
+      });
+    }
+    return this.#pipelinePending;
+  }
+
   /** The GPU reads the workgroup counts from the buffer, so explicit counts alongside indirect are dead options and throw. */
-  #resolveIndirectDispatch(opts: DispatchOptions, y?: number, z?: number): { readonly buffer: GPUBuffer; readonly offset: number } {
-    const where = `${this.label}.dispatch`;
+  #resolveIndirectDispatch(opts: DispatchOptions, y?: number, z?: number, where = `${this.label}.dispatch`): { readonly buffer: GPUBuffer; readonly offset: number } {
     if (y !== undefined || z !== undefined) throw indirectInvalidError(this.label, `indirect cannot be combined with explicit workgroup counts in the same call; the GPU reads the counts from the buffer, so the CPU-side values would be ignored.`, where);
     return resolveIndirect(this.label, where, opts.indirect, "dispatchWorkgroupsIndirect");
   }
 
-  #preflightAliasing(): void {
+  /** Contract #17: dispatch()/dispatchOnce() workgroup counts must be integers >= 0 — no NaN/negative/fractional counts reach WebGPU. */
+  #validateCounts(x: number, y: number | undefined, z: number | undefined, where: string): true {
+    validateDispatchCount(this.label, "x", x, where);
+    if (y !== undefined) validateDispatchCount(this.label, "y", y, where);
+    if (z !== undefined) validateDispatchCount(this.label, "z", z, where);
+    return true;
+  }
+
+  #preflightAliasing(where = `${this.label}.dispatch`): void {
     if (!this.#storageBindings.length) return;
     const buckets = new Map<string, { identity: BindGroupIdentityPart; writable: boolean }[]>();
     for (const binding of this.#storageBindings) {
@@ -118,7 +181,7 @@ export class ComputePipeline implements Compute {
     for (const bucket of buckets.values()) {
       if (bucket.length < 2) continue;
       if (!bucket.some((entry) => entry.writable)) continue;
-      throw writableStorageAliasingError(`${this.label}.dispatch`);
+      throw writableStorageAliasingError(where);
     }
   }
 }
@@ -129,4 +192,10 @@ function computeEntryPoint(reflection: Reflection, label: string, name?: string)
   const entry = selectEntryPoint(label, reflection.entryPoints, "compute", name, "compute");
   if (!entry) throw unsupportedError(`${label}.compute`, "The compute shader requires a @compute entry point.");
   return entry;
+}
+
+/** Contract #17, shared by dispatch()/dispatchOnce(): workgroup counts must be integers >= 0. */
+function validateDispatchCount(label: string, field: string, value: number, where: string): void {
+  if (Number.isInteger(value) && value >= 0) return;
+  throw dispatchCountInvalidError(label, field, value, where);
 }

--- a/packages/vgpu-api/src/compute.ts
+++ b/packages/vgpu-api/src/compute.ts
@@ -141,14 +141,20 @@ export class ComputePipeline implements Compute {
   /**
    * Compiles the pipeline through `createComputePipelineAsync()` the first time it is needed, sharing one
    * in-flight promise across concurrent callers, and reuses whatever `#ensurePipeline()` already compiled.
+   *
+   * `#ensurePipeline()` (the sync path used by legacy `dispatch()`) does not know about an in-flight async
+   * compile, so a `dispatch()` call racing an un-awaited `dispatchOnce()` on the same instance can still
+   * compile a second `GPUComputePipeline` — `??=` below keeps whichever one lands first as the memoized
+   * pipeline instead of letting the async result silently clobber a sync one that already resolved (and
+   * that `dispatch()` may already have bound to a pass), which would otherwise churn pipeline identity.
    */
   #ensurePipelineAsync(): Promise<GPUComputePipeline> {
     if (this.#pipeline) return Promise.resolve(this.#pipeline);
     if (!this.#pipelinePending) {
       this.#pipelinePending = this.device.gpu.createComputePipelineAsync(this.#pipelineDescriptor).then((pipeline) => {
-        this.#pipeline = pipeline;
+        this.#pipeline ??= pipeline;
         this.#pipelinePending = undefined;
-        return pipeline;
+        return this.#pipeline;
       });
     }
     return this.#pipelinePending;

--- a/packages/vgpu-api/src/errors.ts
+++ b/packages/vgpu-api/src/errors.ts
@@ -653,6 +653,15 @@ export function writableStorageAliasingError(where: string): VGPUError {
   });
 }
 
+/** Mirrors draw's VGPU-R1-DRAW-COUNT for the compute dispatch surface (dispatch()/dispatchOnce()). */
+export function dispatchCountInvalidError(label: string, field: string, value: unknown, where: string): VGPUError {
+  return new VGPUError({
+    code: "VGPU-R1-DISPATCH-COUNT",
+    message: `${field} of '${label}' must be an integer >= 0; received ${String(value)}.`,
+    where,
+  });
+}
+
 export function sharedUniformLayoutMismatchError(opts: {
   readonly bindingName: string;
   readonly adoptedLayout: string;

--- a/packages/vgpu-api/tests/compute/compute-pipeline-types.ts
+++ b/packages/vgpu-api/tests/compute/compute-pipeline-types.ts
@@ -1,0 +1,13 @@
+import type { Compute, Gpu } from "../../src/index.ts";
+import { compute } from "../../src/index.ts";
+
+declare const gpu: Gpu;
+
+const c: Compute = compute(gpu, "@compute @workgroup_size(1) fn main() {}");
+c.set({});
+c.dispatch(1);
+void c.dispatchOnce(1);
+
+// @ts-expect-error Compute exposes no `pipeline` field — the low-level escape hatch is `prepared.gpu`,
+// added by prepare() in a later ticket, not a public field on the Compute returned by compute(gpu, source).
+c.pipeline;

--- a/packages/vgpu-api/tests/compute/dispatch-once.test.ts
+++ b/packages/vgpu-api/tests/compute/dispatch-once.test.ts
@@ -101,6 +101,24 @@ describe("dispatchOnce() async pipeline readiness (contract #20)", () => {
     expect(mock.calls.createComputePipeline).toBe(1);
     expect(mock.calls.createComputePipelineAsync).toBe(0);
   });
+
+  test("dispatch() racing an un-awaited dispatchOnce() on the same instance settles on one memoized pipeline", async () => {
+    // #ensurePipeline() (sync) does not know about an in-flight #ensurePipelineAsync() compile, so this
+    // interleaving can still trigger both createComputePipeline and createComputePipelineAsync once each —
+    // but whichever result lands first must win (##= in the async .then()) and stay memoized: no further
+    // calls, sync or async, may compile again afterwards.
+    gpu = await init();
+    const mock = getMockGPUDeviceInstrumentation(gpu.device.gpu);
+    const sim = compute(gpu, SHADER, { label: "race-mixed" });
+    const pending = sim.dispatchOnce(1); // kicks off createComputePipelineAsync, not yet resolved
+    sim.dispatch(1); // synchronous dispatch races ahead and compiles via createComputePipeline
+    await pending;
+    const totalCompilesAfterRace = mock.calls.createComputePipeline + mock.calls.createComputePipelineAsync;
+    expect(totalCompilesAfterRace).toBeGreaterThanOrEqual(1);
+    sim.dispatch(1);
+    await sim.dispatchOnce(1);
+    expect(mock.calls.createComputePipeline + mock.calls.createComputePipelineAsync).toBe(totalCompilesAfterRace);
+  });
 });
 
 // --- Contract #17 — dispatch()/dispatchOnce() validate integer workgroup counts >= 0 -------------

--- a/packages/vgpu-api/tests/compute/dispatch-once.test.ts
+++ b/packages/vgpu-api/tests/compute/dispatch-once.test.ts
@@ -1,0 +1,167 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { getMockGPUDeviceInstrumentation } from "@vgpu/core";
+import { init } from "../../src/mock.ts";
+import { compute } from "../../src/compute.ts";
+
+const SHADER = `
+@compute @workgroup_size(1) fn main() {}
+`;
+
+let gpu: Awaited<ReturnType<typeof init>> | undefined;
+
+afterEach(() => {
+  gpu?.dispose();
+  gpu = undefined;
+});
+
+// --- Contract #4 — compute() performs no pipeline creation at construction ---------------------
+
+describe("compute() construction does not compile a pipeline (contract #4)", () => {
+  test("neither createComputePipeline nor createComputePipelineAsync run in the constructor", async () => {
+    gpu = await init();
+    const mock = getMockGPUDeviceInstrumentation(gpu.device.gpu);
+    compute(gpu, SHADER, { label: "ctor-only" });
+    expect(mock.calls.createComputePipeline).toBe(0);
+    expect(mock.calls.createComputePipelineAsync).toBe(0);
+  });
+
+  test("the concrete instance exposes no public `pipeline` field at runtime", async () => {
+    gpu = await init();
+    const sim = compute(gpu, SHADER, { label: "no-field" }) as unknown as Record<string, unknown>;
+    expect(Object.prototype.hasOwnProperty.call(sim, "pipeline")).toBe(false);
+    expect(sim.pipeline).toBeUndefined();
+  });
+});
+
+// --- dispatch() stays lazy-sync: it compiles on first use, not construction, and memoizes -------
+
+describe("dispatch() lazy-sync pipeline compilation", () => {
+  test("dispatch() compiles exactly once on the first call and reuses it afterwards", async () => {
+    gpu = await init();
+    const mock = getMockGPUDeviceInstrumentation(gpu.device.gpu);
+    const sim = compute(gpu, SHADER, { label: "lazy" });
+    expect(mock.calls.createComputePipeline).toBe(0);
+    sim.dispatch(1);
+    expect(mock.calls.createComputePipeline).toBe(1);
+    sim.dispatch(1);
+    sim.dispatch(2, 3, 4);
+    expect(mock.calls.createComputePipeline).toBe(1);
+    expect(mock.calls.createComputePipelineAsync).toBe(0);
+  });
+});
+
+// --- dispatchOnce(): async readiness, own encoder, submit exactly once, never onSubmittedWorkDone -
+
+describe("dispatchOnce() async pipeline readiness (contract #20)", () => {
+  test("uses createComputePipelineAsync when the pipeline is not ready yet", async () => {
+    gpu = await init();
+    const mock = getMockGPUDeviceInstrumentation(gpu.device.gpu);
+    const sim = compute(gpu, SHADER, { label: "once" });
+    await sim.dispatchOnce(1);
+    expect(mock.calls.createComputePipelineAsync).toBe(1);
+    expect(mock.calls.createComputePipeline).toBe(0);
+  });
+
+  test("resolves right after submit and never awaits queue.onSubmittedWorkDone", async () => {
+    gpu = await init();
+    const sim = compute(gpu, SHADER, { label: "readiness" });
+    const order: string[] = [];
+    const onSubmittedWorkDone = vi.spyOn(gpu.device.gpu.queue, "onSubmittedWorkDone");
+    const originalSubmit = gpu.device.gpu.queue.submit.bind(gpu.device.gpu.queue);
+    vi.spyOn(gpu.device.gpu.queue, "submit").mockImplementation((buffers: GPUCommandBuffer[]) => {
+      order.push("submit");
+      return originalSubmit(buffers);
+    });
+    await sim.dispatchOnce(8);
+    order.push("resolved");
+    expect(order).toEqual(["submit", "resolved"]);
+    expect(onSubmittedWorkDone).not.toHaveBeenCalled();
+    vi.restoreAllMocks();
+  });
+
+  test("dispatchOnce() and dispatch() interleaved on the same instance share one compiled pipeline", async () => {
+    gpu = await init();
+    const mock = getMockGPUDeviceInstrumentation(gpu.device.gpu);
+    const sim = compute(gpu, SHADER, { label: "shared-async-first" });
+    await sim.dispatchOnce(1);
+    expect(mock.calls.createComputePipelineAsync).toBe(1);
+    sim.dispatch(1); // legacy sync dispatch must reuse the pipeline dispatchOnce already compiled
+    expect(mock.calls.createComputePipeline).toBe(0);
+    await sim.dispatchOnce(1); // a second dispatchOnce must not recompile either
+    expect(mock.calls.createComputePipelineAsync).toBe(1);
+  });
+
+  test("dispatch() first, then dispatchOnce(): the async path reuses the sync-compiled pipeline", async () => {
+    gpu = await init();
+    const mock = getMockGPUDeviceInstrumentation(gpu.device.gpu);
+    const sim = compute(gpu, SHADER, { label: "shared-sync-first" });
+    sim.dispatch(1);
+    expect(mock.calls.createComputePipeline).toBe(1);
+    await sim.dispatchOnce(1);
+    expect(mock.calls.createComputePipeline).toBe(1);
+    expect(mock.calls.createComputePipelineAsync).toBe(0);
+  });
+});
+
+// --- Contract #17 — dispatch()/dispatchOnce() validate integer workgroup counts >= 0 -------------
+
+describe("dispatch()/dispatchOnce() reject invalid workgroup counts with a stable error code (contract #17)", () => {
+  test("dispatch() throws VGPU-R1-DISPATCH-COUNT for negative, fractional, or NaN counts", async () => {
+    gpu = await init();
+    const sim = compute(gpu, SHADER, { label: "invalid-sync" });
+    for (const bad of [-1, 1.5, Number.NaN]) {
+      expect(() => sim.dispatch(bad)).toThrowError(expect.objectContaining({ code: "VGPU-R1-DISPATCH-COUNT" }));
+    }
+    expect(() => sim.dispatch(1, -2)).toThrowError(expect.objectContaining({ code: "VGPU-R1-DISPATCH-COUNT" }));
+    expect(() => sim.dispatch(1, 2, 1.2)).toThrowError(expect.objectContaining({ code: "VGPU-R1-DISPATCH-COUNT" }));
+  });
+
+  test("dispatchOnce() rejects with VGPU-R1-DISPATCH-COUNT for the same invalid counts", async () => {
+    gpu = await init();
+    const sim = compute(gpu, SHADER, { label: "invalid-async" });
+    await expect(sim.dispatchOnce(-1)).rejects.toMatchObject({ code: "VGPU-R1-DISPATCH-COUNT" });
+    await expect(sim.dispatchOnce(1.5)).rejects.toMatchObject({ code: "VGPU-R1-DISPATCH-COUNT" });
+    await expect(sim.dispatchOnce(1, 2, -3)).rejects.toMatchObject({ code: "VGPU-R1-DISPATCH-COUNT" });
+  });
+
+  test("valid counts (including 0) never throw", async () => {
+    gpu = await init();
+    const sim = compute(gpu, SHADER, { label: "valid" });
+    expect(() => sim.dispatch(0)).not.toThrow();
+    await expect(sim.dispatchOnce(0, 0, 0)).resolves.toBeUndefined();
+  });
+});
+
+// --- Lifecycle: a disposed gpu must fail with VGPU-DEVICE-DISPOSED, not a raw WebGPU error ----------
+
+describe("dispose() interacting with the lazy/async pipeline paths", () => {
+  test("dispatchOnce() rejects with VGPU-DEVICE-DISPOSED if the gpu was disposed before the call", async () => {
+    gpu = await init();
+    const sim = compute(gpu, SHADER, { label: "disposed-before" });
+    gpu.dispose();
+    await expect(sim.dispatchOnce(1)).rejects.toMatchObject({ code: "VGPU-DEVICE-DISPOSED" });
+    gpu = undefined;
+  });
+
+  test("dispatch() throws VGPU-DEVICE-DISPOSED if the gpu was disposed before the call", async () => {
+    gpu = await init();
+    const sim = compute(gpu, SHADER, { label: "disposed-before-sync" });
+    gpu.dispose();
+    expect(() => sim.dispatch(1)).toThrowError(expect.objectContaining({ code: "VGPU-DEVICE-DISPOSED" }));
+    gpu = undefined;
+  });
+
+  test("dispatchOnce() rejects with VGPU-DEVICE-DISPOSED (not a raw WebGPU error) when disposed while the async compile is in flight", async () => {
+    gpu = await init();
+    const sim = compute(gpu, SHADER, { label: "disposed-mid-flight" });
+    let resolvePipeline!: (pipeline: GPUComputePipeline) => void;
+    const pending = new Promise<GPUComputePipeline>((resolve) => { resolvePipeline = resolve; });
+    vi.spyOn(gpu.device.gpu, "createComputePipelineAsync").mockReturnValue(pending);
+    const dispatched = sim.dispatchOnce(1);
+    gpu.dispose();
+    resolvePipeline({} as GPUComputePipeline);
+    await expect(dispatched).rejects.toMatchObject({ code: "VGPU-DEVICE-DISPOSED" });
+    vi.restoreAllMocks();
+    gpu = undefined;
+  });
+});

--- a/packages/vgpu-api/tests/compute/dispatch-once.test.ts
+++ b/packages/vgpu-api/tests/compute/dispatch-once.test.ts
@@ -10,9 +10,31 @@ const SHADER = `
 let gpu: Awaited<ReturnType<typeof init>> | undefined;
 
 afterEach(() => {
+  vi.restoreAllMocks();
   gpu?.dispose();
   gpu = undefined;
 });
+
+/** Records every pipeline object bound through a compute pass, in encode order — used to prove identity, not just call counts. */
+function recordBoundPipelines(device: GPUDevice): GPUComputePipeline[] {
+  const bound: GPUComputePipeline[] = [];
+  const originalCreateEncoder = device.createCommandEncoder.bind(device);
+  vi.spyOn(device, "createCommandEncoder").mockImplementation((desc?: GPUCommandEncoderDescriptor) => {
+    const encoder = originalCreateEncoder(desc);
+    const originalBegin = encoder.beginComputePass.bind(encoder);
+    (encoder as { beginComputePass: unknown }).beginComputePass = (passDesc?: GPUComputePassDescriptor) => {
+      const pass = originalBegin(passDesc);
+      const originalSet = pass.setPipeline.bind(pass);
+      (pass as { setPipeline: unknown }).setPipeline = (pipeline: GPUComputePipeline) => {
+        bound.push(pipeline);
+        originalSet(pipeline);
+      };
+      return pass;
+    };
+    return encoder;
+  });
+  return bound;
+}
 
 // --- Contract #4 — compute() performs no pipeline creation at construction ---------------------
 
@@ -102,22 +124,59 @@ describe("dispatchOnce() async pipeline readiness (contract #20)", () => {
     expect(mock.calls.createComputePipelineAsync).toBe(0);
   });
 
-  test("dispatch() racing an un-awaited dispatchOnce() on the same instance settles on one memoized pipeline", async () => {
+  test("dispatch() racing an un-awaited dispatchOnce() on the same instance binds one pipeline object throughout (no identity churn)", async () => {
     // #ensurePipeline() (sync) does not know about an in-flight #ensurePipelineAsync() compile, so this
     // interleaving can still trigger both createComputePipeline and createComputePipelineAsync once each —
-    // but whichever result lands first must win (##= in the async .then()) and stay memoized: no further
-    // calls, sync or async, may compile again afterwards.
+    // that double-compile is a known, accepted tradeoff of mixing an un-awaited dispatchOnce() with a
+    // same-tick dispatch() on one instance. What must NOT happen is identity churn: counting compiler
+    // *calls* does not catch a `this.#pipeline = pipeline` (plain assignment) regression, because the
+    // clobber changes which object is memoized without changing how many times the compilers ran. So this
+    // asserts on the pipeline OBJECT actually bound to every pass — all 4 dispatches below must bind the
+    // exact same object, proving the `??=` in #ensurePipelineAsync's `.then()` keeps whichever pipeline
+    // (sync or async) resolved first, instead of letting the async result silently replace an
+    // already-bound sync one.
     gpu = await init();
-    const mock = getMockGPUDeviceInstrumentation(gpu.device.gpu);
+    const bound = recordBoundPipelines(gpu.device.gpu);
     const sim = compute(gpu, SHADER, { label: "race-mixed" });
     const pending = sim.dispatchOnce(1); // kicks off createComputePipelineAsync, not yet resolved
-    sim.dispatch(1); // synchronous dispatch races ahead and compiles via createComputePipeline
-    await pending;
-    const totalCompilesAfterRace = mock.calls.createComputePipeline + mock.calls.createComputePipelineAsync;
-    expect(totalCompilesAfterRace).toBeGreaterThanOrEqual(1);
+    sim.dispatch(1); // sync compile wins the race and is bound immediately
+    await pending; // async result lands afterwards
     sim.dispatch(1);
     await sim.dispatchOnce(1);
-    expect(mock.calls.createComputePipeline + mock.calls.createComputePipelineAsync).toBe(totalCompilesAfterRace);
+    expect(bound).toHaveLength(4);
+    expect(new Set(bound).size).toBe(1);
+  });
+});
+
+// --- A rejected compile must not poison the instance forever (#pipelinePending cleanup on failure) -
+
+describe("a failed createComputePipelineAsync does not poison the instance", () => {
+  test("dispatchOnce() can succeed on retry after an earlier rejection", async () => {
+    gpu = await init();
+    const device = gpu.device.gpu;
+    const real = device.createComputePipelineAsync.bind(device);
+    let failNext = true;
+    vi.spyOn(device, "createComputePipelineAsync").mockImplementation(async (desc: GPUComputePipelineDescriptor) => {
+      if (failNext) {
+        failNext = false;
+        throw new Error("transient compile failure");
+      }
+      return real(desc);
+    });
+    const sim = compute(gpu, SHADER, { label: "poison-retry" });
+    await expect(sim.dispatchOnce(1)).rejects.toThrow(/transient compile failure/);
+    // A stale rejected promise must not stay memoized in #pipelinePending: this retry has to kick off a
+    // fresh createComputePipelineAsync() and actually resolve, not re-reject with the old error forever.
+    await expect(sim.dispatchOnce(1)).resolves.toBeUndefined();
+  });
+
+  test("dispatch() (sync path) still works after dispatchOnce()'s async compile rejected", async () => {
+    gpu = await init();
+    const device = gpu.device.gpu;
+    vi.spyOn(device, "createComputePipelineAsync").mockRejectedValue(new Error("boom"));
+    const sim = compute(gpu, SHADER, { label: "poison-sync" });
+    await expect(sim.dispatchOnce(1)).rejects.toThrow(/boom/);
+    expect(() => sim.dispatch(1)).not.toThrow();
   });
 });
 

--- a/packages/vgpu-api/tests/compute/dispatch-once.test.ts
+++ b/packages/vgpu-api/tests/compute/dispatch-once.test.ts
@@ -1,10 +1,16 @@
 import { afterEach, describe, expect, test, vi } from "vitest";
 import { getMockGPUDeviceInstrumentation } from "@vgpu/core";
-import { init } from "../../src/mock.ts";
+import { init, storage } from "../../src/mock.ts";
 import { compute } from "../../src/compute.ts";
 
 const SHADER = `
 @compute @workgroup_size(1) fn main() {}
+`;
+
+const ALIAS_SHADER = `
+@group(0) @binding(0) var<storage, read_write> a: array<f32>;
+@group(0) @binding(1) var<storage, read_write> b: array<f32>;
+@compute @workgroup_size(1) fn main() { a[0] = 1.0; b[0] = 2.0; }
 `;
 
 let gpu: Awaited<ReturnType<typeof init>> | undefined;
@@ -177,6 +183,21 @@ describe("a failed createComputePipelineAsync does not poison the instance", () 
     const sim = compute(gpu, SHADER, { label: "poison-sync" });
     await expect(sim.dispatchOnce(1)).rejects.toThrow(/boom/);
     expect(() => sim.dispatch(1)).not.toThrow();
+  });
+});
+
+// --- H3: validation must not escape across the await boundary (aliasing introduced mid-flight) ----
+
+describe("dispatchOnce() re-validates writable-storage aliasing after the await", () => {
+  test("aliasing introduced by a set() while the compile is in flight is rejected before encoding", async () => {
+    gpu = await init();
+    const sim = compute(gpu, ALIAS_SHADER, { label: "alias-late" });
+    const bufA = storage(gpu, 16, "read-write");
+    const bufB = storage(gpu, 16, "read-write");
+    sim.set({ a: bufA, b: bufB }); // not aliasing at call time
+    const pending = sim.dispatchOnce(1);
+    sim.set({ a: bufA, b: bufA }); // aliasing introduced while the compile is in flight
+    await expect(pending).rejects.toMatchObject({ code: expect.stringContaining("ALIAS") });
   });
 });
 

--- a/packages/vgpu-api/tests/compute/tsconfig.types.json
+++ b/packages/vgpu-api/tests/compute/tsconfig.types.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "composite": false,
+    "declaration": false,
+    "declarationMap": false,
+    "noEmit": true,
+    "allowImportingTsExtensions": true
+  },
+  "include": ["../../src/**/*.ts", "compute-pipeline-types.ts"]
+}

--- a/packages/vgpu-api/tests/entry-selection.test.ts
+++ b/packages/vgpu-api/tests/entry-selection.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "vitest";
 import { getMockGPUDeviceInstrumentation } from "@vgpu/core";
-import { init, compute, draw, geometry, target } from "../src/mock.ts";
+import { init, compute, draw, geometry, storage, target } from "../src/mock.ts";
 
 const TWO_FRAGMENT_WGSL = `
 @group(0) @binding(0) var<uniform> tintA: vec4f;
@@ -128,8 +128,15 @@ test("absent entry keeps descriptors byte-identical to first-of-stage selection"
 test("compute entry selects the named @compute entry point and its binding visibility", async () => {
   const gpu = await init();
 
-  compute(gpu, TWO_COMPUTE_WGSL, { label: "pick-cs-b", entry: "cs_b" });
-  compute(gpu, TWO_COMPUTE_WGSL, { label: "cs-default" });
+  const pickB = compute(gpu, TWO_COMPUTE_WGSL, { label: "pick-cs-b", entry: "cs_b" });
+  const csDefault = compute(gpu, TWO_COMPUTE_WGSL, { label: "cs-default" });
+  // compute() no longer compiles its pipeline at construction (contract #4) — dispatch(0) is a valid,
+  // no-op-workgroup call that satisfies each entry's active binding and triggers the lazy compile this
+  // assertion inspects, without running any shader logic.
+  pickB.set({ b: storage(gpu, 4) });
+  pickB.dispatch(0);
+  csDefault.set({ a: storage(gpu, 4) });
+  csDefault.dispatch(0);
 
   const descs = getMockGPUDeviceInstrumentation(gpu.device.gpu).createComputePipelineDescriptors;
   expect(descs.at(-2)?.compute.entryPoint).toBe("cs_b");

--- a/packages/vgpu-api/tests/override-constants.test.ts
+++ b/packages/vgpu-api/tests/override-constants.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "vitest";
 import { getMockGPUDeviceInstrumentation } from "@vgpu/core";
-import { init, compute, draw, target } from "../src/mock.ts";
+import { init, compute, draw, storage, target } from "../src/mock.ts";
 
 const OVERRIDE_WGSL = `
 override SCALE: f32 = 1.0;
@@ -134,8 +134,15 @@ test("an override without a default must be provided", async () => {
 test("compute constants reach the compute stage; @id keys and omission behave like draws", async () => {
   const gpu = await init();
 
-  compute(gpu, COMPUTE_WGSL, { label: "sim", constants: { STEP: 0.5, "3": 4 } });
-  compute(gpu, COMPUTE_WGSL, { label: "sim-absent" });
+  const sim = compute(gpu, COMPUTE_WGSL, { label: "sim", constants: { STEP: 0.5, "3": 4 } });
+  const simAbsent = compute(gpu, COMPUTE_WGSL, { label: "sim-absent" });
+  // compute() no longer compiles its pipeline at construction (contract #4) — dispatch(0) is a valid,
+  // no-op-workgroup call that satisfies the one active binding and triggers the lazy compile this
+  // assertion inspects, without running any shader logic.
+  sim.set({ data: storage(gpu, 4) });
+  sim.dispatch(0);
+  simAbsent.set({ data: storage(gpu, 4) });
+  simAbsent.dispatch(0);
 
   const descs = getMockGPUDeviceInstrumentation(gpu.device.gpu).createComputePipelineDescriptors;
   expect(descs.at(-2)?.compute.constants).toEqual({ STEP: 0.5, "3": 4 });


### PR DESCRIPTION
## T04-04 — `04/compute-async`

Delivers the half of design contract **#4** that doesn't depend on `prepare()` (that's T04-05): `compute()` stops compiling its `GPUComputePipeline` at construction, the public `Compute` type drops its `.pipeline` field entirely, and a new async `dispatchOnce()` is added.

### What changed

- **`packages/vgpu-api/src/compute.ts`**: the `ComputePipeline` constructor now only builds a `GPUComputePipelineDescriptor` (`#pipelineDescriptor`) — no `createComputePipeline`/`createComputePipelineAsync` call happens during construction.
  - `dispatch()` (legacy) stays **lazy-sync**: `#ensurePipeline()` compiles inline via `createComputePipeline()` the first time it's needed (not at construction), mirroring the `pipelineFor`/`getSync` pattern draws already use, and memoizes the result.
  - `dispatchOnce()` (new) is **async**: `#ensurePipelineAsync()` compiles via `createComputePipelineAsync()`, dedupes concurrent callers on one in-flight promise, and shares the memoized pipeline with `dispatch()` regardless of which method compiled it first. It owns its own encoder, submits exactly once, and resolves right after the submit — it **never** awaits `queue.onSubmittedWorkDone` (contract **#20**).
  - The public `pipeline` field is gone from the concrete class — `Compute` never exposed it in its type either (verified by a `@ts-expect-error` type fixture, see below). The low-level escape hatch for this will be `prepared.gpu`, added by `prepare()` in T04-05 (design rule N1).
  - Both `dispatch()`/`dispatchOnce()` validate integer workgroup counts `>= 0` for the direct `(x,y,z)` overload via a new `VGPU-R1-DISPATCH-COUNT` error (mirrors `draw.ts`'s `VGPU-R1-DRAW-COUNT`) — contract **#17**.
- **`packages/vgpu-api/src/api-types.ts`**: `Compute` interface gains `dispatchOnce(x,y?,z?): Promise<void>` / `dispatchOnce(opts): Promise<void>` overloads.
- **`packages/vgpu-api/src/errors.ts`**: new `dispatchCountInvalidError` → `VGPU-R1-DISPATCH-COUNT`.
- **`packages/core/src/mock-gpu.ts`**: added `createComputePipelineAsync` to the mock GPU device (same instrumentation pattern as the existing `createRenderPipelineAsync`) so the async path is testable without a real adapter.
- **Tests**: `packages/vgpu-api/tests/compute/dispatch-once.test.ts` (17 cases) + a typecheck fixture `packages/vgpu-api/tests/compute/compute-pipeline-types.ts` (`+tsconfig.types.json`, wired into `typecheck:fixtures`) asserting `Compute` exposes no `pipeline` field.

### Validated deviation: two pre-existing corpus tests adjusted

`packages/vgpu-api/tests/entry-selection.test.ts` and `packages/vgpu-api/tests/override-constants.test.ts` inspected `createComputePipelineDescriptors` immediately after `compute()` construction — an assumption that no longer holds now that compilation is lazy. Both were adjusted to `set()` the required binding and `dispatch(0)` before inspecting the descriptors. QA mutation-tested this change (M4/M5 in the harness below): reverting the underlying behavior each test guards (ignored `entry` option, dropped `constants`) still fails the adjusted tests, confirming they retain their original guarding power.

### QA adversarial pass — 3 real findings, all fixed

An adversarial mutation-tested QA pass (harness: `/tmp/debug/scripts/vgpu-compute-async-mutation/`, `./run.sh --suite full`) found and confirmed fixes for:

1. **Sync/async pipeline-identity race**: an un-awaited `dispatchOnce()` racing a same-tick `dispatch()` on one instance let the async `.then()` unconditionally overwrite the memoized pipeline, churning identity even after a sync compile had already been bound to a pass. Fixed with `this.#pipeline ??= pipeline` (first-to-resolve wins). Regression test asserts every pipeline object bound across such a race is identical (`Set(bound).size === 1`), not just that compiler call counts stay bounded — an earlier, weaker version of this test (that only counted calls) was caught by QA mutation testing as not actually exercising the fix.
2. **Failed async compile poisoning the instance**: a rejected `createComputePipelineAsync()` left its rejected promise memoized in `#pipelinePending` forever, so every later `dispatchOnce()` on that instance re-rejected with the stale error instead of retrying. This mattered because T04-05's `prepare()` will call this exact path. Fixed: both the success and failure branches of the internal `.then()` now clear `#pipelinePending`, guarded by reference-equality to the specific attempt (so a newer, unrelated attempt can't be cancelled early). Two regression tests: fail-then-retry-succeeds, and "sync `dispatch()` still works after `dispatchOnce()`'s async compile failed."
3. **Validation escaping across the await boundary**: `dispatchOnce()` re-checked `assertDeviceUsable` after awaiting the pipeline, but not the writable-storage aliasing preflight — a `set()` call that introduces aliasing while the compile is in flight reached the compute pass unchecked. Fixed by re-running `#preflightAliasing(where)` right after the post-await device recheck. **Design note**: `dispatchOnce()` does not snapshot bindings at call time — this is consistent with `set()` never snapshotting ("last `set()` wins"), so re-validating post-await (rather than freezing bindings for the compile's duration) is the correct behavior, not a workaround.

Final harness result: **`./run.sh --suite full` → 13 ok, 0 unexpected** (typecheck, repo suites, mutation matrix M1–M8, full monorepo suite all green; M8 is a confirmed-equivalent mutant, intentionally left without its own test per QA).

### Known pre-existing gap (out of scope, filed separately)

The QA harness's probe suite also exercises "a storage binding disposed mid-flight" during `dispatchOnce()` and finds it resolves without error instead of surfacing a `VGPU-*` code. The harness's own control test confirms this is **not a regression**: the exact same scenario on the legacy, synchronous `dispatch()` path (unrelated to this ticket, unchanged since 0.3.0) also doesn't detect a disposed binding. This is a systemic gap in buffer-liveness checking at bind-group encode time across both `draw()` and `compute()`, out of scope for `04/compute-async`. Filed as **#325** for separate triage (likely belongs with the lifecycle/adjudication work).

### Errata

- The ticket text names `VGPU-GPU-DISPOSED` for disposed-gpu handling on `dispatch()`/`dispatchOnce()`. The correct code (and what's implemented/tested here) is **`VGPU-DEVICE-DISPOSED`** — `VGPU-GPU-DISPOSED` is a different, unrelated code used only by top-level `gpu`-handle factories (`kernel()`, `clock()`).

### Gates (all green, post-merge with `next/0.4` @ `b66c9e11` incl. #324 `04/settled-queue`)

- `pnpm typecheck` — OK
- `pnpm test` (full monorepo) — 247 files / 1911 tests passed, 0 failed, 139 skipped (GPU-only, expected)
- `pnpm bundle-check` — green; one **tooling**-audience budget (`vgpu/node`) sits +68B over its soft baseline, well within the 5% growth threshold — left as a warning per design (tooling budgets only fail past the growth threshold; not re-baselined, since 68B doesn't warrant moving the goalposts yet).

### Forbidden files respected

No changes to `pipeline-store.ts` (T04-05), `set-core.ts`/`set-layouts.ts`, `surface.ts`, or `kernel.ts` (the merge from `next/0.4` brought in unrelated upstream changes to `kernel.ts` from `04/settled-queue`, not touched by this branch's own commits).
