### PR TITLE
feat(surface): frame-independent pipeline signature, with managed depth and MSAA (T04-02)

### DIFF
--- a/packages/vgpu-api/package.json
+++ b/packages/vgpu-api/package.json
@@ -91,9 +91,9 @@
     "./core": "client"
   },
   "vgpuExportBundleBudgetsGzipBytes": {
-    ".": 38912,
-    "./node": 38912,
-    "./mock": 38912,
+    ".": 39424,
+    "./node": 39424,
+    "./mock": 39424,
     "./scene": 12800,
     "./client": 512,
     "./core": 3584
@@ -103,10 +103,10 @@
   },
   "vgpuExperienceBundleBudgetsGzipBytes": {
     "init-only": 1024,
-    "effect-only": 25600,
-    "triangle-low-level": 28672,
-    "draw-recipe-box": 30208,
-    "full-root": 38912
+    "effect-only": 26112,
+    "triangle-low-level": 29696,
+    "draw-recipe-box": 30720,
+    "full-root": 39424
   },
   "vgpuSceneBundleBudgetNote": "The scene barrel retains all recipe builders after the geometry redesign; direct primitive imports retain only their selected mesh, as the experience fixtures assert."
 }

--- a/packages/vgpu-api/src/draw.ts
+++ b/packages/vgpu-api/src/draw.ts
@@ -493,9 +493,14 @@ export class InternalDraw implements Draw {
     return this;
   }
 
+  /**
+   * `allowSurface` is kept for source compatibility and is now a no-op: a surface signature is
+   * frame-independent, so no path through this method needs an active frame.
+   */
   pipelineFor(target: Target | TargetSignature, allowSurface = false): GPURenderPipeline | undefined {
+    void allowSurface;
     assertDeviceUsable(drawState(this).device, `${this.label}.pipelineFor`);
-    const { key, signature, signatureKey } = this.#compileKey(target, `${this.label}.pipelineFor`, allowSurface);
+    const { key, signature, signatureKey } = this.#compileKey(target, `${this.label}.pipelineFor`);
     const pipeline = drawState(this).pipelineStore.getSync(key, () => this.#createPipeline(signature), { where: `${this.label}.pipelineFor`, signature: signatureKey });
     if (pipeline) drawState(this).resolvedPipelineKeys.add(key);
     return pipeline;
@@ -512,17 +517,22 @@ export class InternalDraw implements Draw {
     });
   }
 
-  #compileKey(target: CompileTarget | undefined, where: string, allowSurface = false): { readonly signature: TargetSignature; readonly signatureKey: string; readonly key: string } {
-    const signature = this.#signatureForKeyTarget(target, where, allowSurface);
+  #compileKey(target: CompileTarget | undefined, where: string): { readonly signature: TargetSignature; readonly signatureKey: string; readonly key: string } {
+    const signature = this.#signatureForKeyTarget(target, where);
     const signatureKey = signatureKeyOf(signature);
     return { signature, signatureKey, key: this.#pipelineKey(signature) };
   }
 
-  #signatureForKeyTarget(target: CompileTarget | undefined, where: string, allowSurface = false): TargetSignature {
+  /**
+   * Pipeline signature of a compile target — never needs an active frame. A surface answers from its
+   * configuration (`normalizeSignature` reads `pipelineSignature`, not the current texture), so
+   * compiling against one outside `frame()` is legal and resolves the very signature its encode path
+   * uses inside a frame. Encoding still needs the current texture: that guard lives on `draw()`.
+   */
+  #signatureForKeyTarget(target: CompileTarget | undefined, where: string): TargetSignature {
     const state = drawState(this);
     const resolvedTarget = target ?? state.defaultTarget;
     if (!resolvedTarget) throw targetRequiredError(where);
-    if (!allowSurface) assertSurfaceTargetInFrame(resolvedTarget, where);
     const signature = normalizeSignature(resolvedTarget);
     validateTargetSignature(signature, where);
     if (state.colorStates && state.colorStates.length !== signature.colors.length) {

--- a/packages/vgpu-api/src/errors.ts
+++ b/packages/vgpu-api/src/errors.ts
@@ -546,6 +546,15 @@ export function surfaceResizeReentrantError(label?: string): VGPUError {
   });
 }
 
+export function surfaceSampleCountError(sampleCount: unknown): VGPUError {
+  return new VGPUError({
+    code: "VGPU-SURFACE-SAMPLE-COUNT-INVALID",
+    message: `sampleCount received ${String(sampleCount)}; WebGPU render targets are 1 or 4.`,
+    fix: "Use sampleCount: 4 for MSAA, or omit it for a single-sampled surface.",
+    where: "surface",
+  });
+}
+
 export function clearColorInvalidError(where: string): VGPUError {
   return new VGPUError({
     code: "VGPU-CLEAR-COLOR-INVALID",

--- a/packages/vgpu-api/src/pipeline-store.ts
+++ b/packages/vgpu-api/src/pipeline-store.ts
@@ -51,6 +51,11 @@ const shaderModuleIds = new WeakMap<GPUShaderModule, number>();
 const pipelineLayoutIds = new WeakMap<GPUPipelineLayout, number>();
 
 export function normalizeSignature(arg: CompileTarget): TargetSignature {
+  // A target that derives its pipeline signature from its own configuration publishes it here, and it
+  // wins: `Surface` does exactly that, because reading its `.colors`/`.depth` would fetch the current
+  // presentation texture, which only exists inside a frame — and a signature must not depend on one.
+  const configured = (arg as { readonly pipelineSignature?: TargetSignature }).pipelineSignature;
+  if (configured) return configured;
   if (isTarget(arg)) {
     return {
       colors: arg.colors.map((color) => color.format),

--- a/packages/vgpu-api/src/surface.ts
+++ b/packages/vgpu-api/src/surface.ts
@@ -1,6 +1,6 @@
 import { Texture, createResourceIdentity, DestroySignal, type Device, type ResourceDestroyCallback, type ResourceIdentity, type UnsubscribeResourceDestroy } from "@vgpu/core";
-import { BUILT_IN_CLEAR_COLOR, colorValue, copyClearColor, sameSize, validateClearColor, type ClearColor } from "./target-utils.ts";
-import type { RenderPassDescriptorOptions, Target } from "./target.ts";
+import { BUILT_IN_CLEAR_COLOR, colorAttachment, copyClearColor, depthAttachment, sameSize, surfaceAttachmentsFor, validateClearColor, type ClearColor } from "./target-utils.ts";
+import type { RenderPassDescriptorOptions, Target, TargetSignature } from "./target.ts";
 import {
   surfaceAutoResizeUnsupportedError,
   surfaceContextError,
@@ -22,6 +22,16 @@ export interface SurfaceOptions {
   readonly dpr?: number | readonly [number, number];
   readonly size?: readonly [number, number];
   readonly format?: GPUTextureFormat;
+  /**
+   * Depth attachment this surface owns: `true` for the shared default (`depthFormatFor` → `depth24plus`),
+   * or an explicit depth format. The surface recreates it on every resize and reports it as `surface.depth`.
+   */
+  readonly depth?: boolean | GPUTextureFormat;
+  /**
+   * Sample count of the render pass this surface opens. `4` renders into an internal multisample color
+   * attachment and resolves into the presentation texture; `1` (the default) renders straight into it.
+   */
+  readonly sampleCount?: 1 | 4;
   readonly alphaMode?: GPUCanvasAlphaMode;
   readonly colorSpace?: PredefinedColorSpace;
   readonly label?: string;
@@ -95,9 +105,15 @@ export class CanvasSurface implements Surface {
   readonly autoResize: boolean;
   readonly layoutBacked: boolean;
   readonly format: GPUTextureFormat;
+  /** Depth format this surface owns, resolved once from its configuration (`depthFormatFor`). */
+  readonly depthFormat: GPUTextureFormat | undefined;
+  readonly #sampleCount: 1 | 4;
   readonly #destroySignal = new DestroySignal<Target>();
   readonly #callbacks = new Set<(event: SurfaceResizeEvent) => void>();
   readonly #texturesRecreatedCallbacks = new Set<() => void>();
+  #depthTexture?: Texture;
+  #msaaColor?: Texture;
+  #attachmentSize: readonly [number, number] = [0, 0];
   #currentDpr: number;
   #clearColor: ClearColor;
   #isDisposed = false;
@@ -119,6 +135,11 @@ export class CanvasSurface implements Surface {
     this.autoResize = options.autoResize ?? (options.size ? false : this.layoutBacked);
     this.#currentDpr = effectiveDpr(options.dpr);
     this.format = options.format ?? preferredCanvasFormat();
+    // Depth format and sample count come from the options bag alone, so the pipeline signature of this
+    // surface is fixed here, at construction, and never depends on the current presentation texture.
+    const attachments = surfaceAttachmentsFor(options);
+    this.depthFormat = attachments.depth;
+    this.#sampleCount = attachments.sampleCount;
     const initialSize = initialCanvasSize(canvas, options, this.layoutBacked, this.#currentDpr);
     if (options.size || this.layoutBacked) setCanvasSize(canvas, initialSize);
     context.configure({
@@ -128,6 +149,7 @@ export class CanvasSurface implements Surface {
       colorSpace: options.colorSpace ?? "srgb",
       usage: canvasTextureUsage(),
     });
+    this.#createAttachments();
   }
 
   get gpu(): unknown { return this.context; }
@@ -143,8 +165,21 @@ export class CanvasSurface implements Surface {
     }, "external");
   }
   get colors(): readonly [Texture, ...Texture[]] { return [this.color]; }
-  get depth(): undefined { this.#assertLive(); return undefined; }
-  get sampleCount(): 1 { this.#assertLive(); return 1; }
+  get depth(): Texture | undefined { this.#assertLive(); this.#syncAttachments(); return this.#depthTexture; }
+  get sampleCount(): 1 | 4 { this.#assertLive(); return this.#sampleCount; }
+  /**
+   * Pipeline signature of this surface, derived from its configuration alone: the format fixed by
+   * `context.configure()`, the depth format of `SurfaceOptions.depth`, and `SurfaceOptions.sampleCount`.
+   * Frame-independent by construction — it never touches `getCurrentTexture()`, so compiling against a
+   * surface outside `frame()` is legal and yields exactly the signature the encode path uses inside one.
+   */
+  get pipelineSignature(): TargetSignature {
+    // Frame-independent, not lifetime-independent: a disposed surface rejects here exactly like every
+    // other getter, so compiling against a stale surface still fails where the mistake is, instead of
+    // silently warming the pipeline cache.
+    this.#assertLive();
+    return { colors: [this.format], depth: this.depthFormat, sampleCount: this.#sampleCount };
+  }
   get dpr(): number { return this.#currentDpr; }
   /** Default clear color of this surface; passes that clear without naming a color use it. */
   get clearColor(): ClearColor { return copyClearColor(this.#clearColor); }
@@ -180,18 +215,24 @@ export class CanvasSurface implements Surface {
   onTexturesRecreated(cb: () => void): () => void { this.#assertLive(); this.#texturesRecreatedCallbacks.add(cb); return () => { this.#texturesRecreatedCallbacks.delete(cb); }; }
 
   renderPassDescriptor(opts: RenderPassDescriptorOptions = {}): GPURenderPassDescriptor {
-    // Surfaces have no depth attachment; clearDepth, clearStencil, and depthReadOnly cannot apply.
-    const { clear = [0, 0, 0, 1], preserve } = opts;
+    const { clear = [0, 0, 0, 1], preserve, clearDepth, clearStencil, depthReadOnly } = opts;
     this.#assertLive();
-    const attachment: GPURenderPassColorAttachment = { view: this.context.getCurrentTexture().createView(), loadOp: preserve ? "load" : "clear", storeOp: "store" };
-    if (!preserve) attachment.clearValue = colorValue(clear);
-    return { colorAttachments: [attachment] };
+    // Encoding is the only path that needs the current texture — and the only one that needs the
+    // internal attachments to match its size.
+    this.#syncAttachments();
+    const presentation = this.context.getCurrentTexture();
+    return {
+      // MSAA renders into the internal multisample color and resolves into the presentation texture.
+      colorAttachments: [colorAttachment(presentation, this.#msaaColor, clear, preserve)],
+      depthStencilAttachment: this.#depthTexture ? depthAttachment(this.#depthTexture, preserve, clearDepth, clearStencil, depthReadOnly) : undefined,
+    };
   }
 
   dispose(): void {
     if (this.#isDisposed) return;
     this.#isDisposed = true;
     try { this.context.unconfigure?.(); } catch { /* ignore native cleanup failures */ }
+    this.#destroyAttachments();
     this.unregister(this);
     this.#callbacks.clear();
     this.#texturesRecreatedCallbacks.clear();
@@ -203,8 +244,64 @@ export class CanvasSurface implements Surface {
     this.#currentDpr = dpr;
     if (!changed) return;
     setCanvasSize(this.canvas, size);
-    this.#emitTexturesRecreated();
+    // The presentation texture follows the canvas by itself; the attachments this surface owns do not.
+    // #recreateAttachments emits texturesRecreated, so a surface without attachments still notifies.
+    this.#recreateAttachments();
     if (notify) this.#notify();
+  }
+
+  /**
+   * Keeps the internal attachments the same size as the canvas, including when the canvas was resized
+   * behind this surface's back (a direct `canvas.width = …`), which never goes through `#applyResize`.
+   * A resize only ever changes their size — never their format or sample count — so the pipeline
+   * signature of this surface survives it untouched.
+   */
+  #syncAttachments(): void {
+    if (!this.#depthTexture && !this.#msaaColor) return;
+    if (sameSize(this.#attachmentSize, this.#attachmentTargetSize())) return;
+    this.#recreateAttachments();
+  }
+
+  #recreateAttachments(): void {
+    this.#destroyAttachments();
+    this.#createAttachments();
+    // Emitted here, not only from #applyResize: the canvas-drifted path recreates the very textures
+    // consumers cache views and bind groups over, so it has to announce them too. A surface without
+    // attachments still reaches this from #applyResize, which is how a plain surface keeps notifying.
+    this.#emitTexturesRecreated();
+  }
+
+  /** Attachment size for the canvas as it is right now, sanitized to WebGPU's 1×1 minimum like every other size this surface computes. */
+  #attachmentTargetSize(): readonly [number, number] {
+    return sanitizeSize(canvasSize(this.canvas));
+  }
+
+  #createAttachments(): void {
+    const size = this.#attachmentTargetSize();
+    this.#attachmentSize = size;
+    // Not a transient attachment: TRANSIENT_ATTACHMENT is an optimization of its own, not a surface concern.
+    this.#msaaColor = this.#sampleCount === 4 ? this.device.createTexture({
+      size,
+      format: this.format,
+      usage: ["render_attachment"],
+      sampleCount: 4,
+      label: this.options.label ? `${this.options.label}.color.msaa` : "surface.color.msaa",
+    }) : undefined;
+    // texture_binding matches target(): read-only depth passes can bind `surface.depth` as a sampled texture.
+    this.#depthTexture = this.depthFormat ? this.device.createTexture({
+      size,
+      format: this.depthFormat,
+      usage: ["render_attachment", "texture_binding"],
+      sampleCount: this.#sampleCount,
+      label: this.options.label ? `${this.options.label}.depth` : "surface.depth",
+    }) : undefined;
+  }
+
+  #destroyAttachments(): void {
+    this.#msaaColor?.destroy();
+    this.#depthTexture?.destroy();
+    this.#msaaColor = undefined;
+    this.#depthTexture = undefined;
   }
 
   #emitTexturesRecreated(): void {

--- a/packages/vgpu-api/src/target-utils.ts
+++ b/packages/vgpu-api/src/target-utils.ts
@@ -1,4 +1,4 @@
-import { clearColorInvalidError, targetSizeRequiredError, targetStencilOnlyDepthError, unsupportedError } from "./errors.ts";
+import { clearColorInvalidError, surfaceSampleCountError, targetSizeRequiredError, targetStencilOnlyDepthError, unsupportedError } from "./errors.ts";
 import type { Target, TargetOptions, TargetTextureOptions } from "./target.ts";
 
 export const DEFAULT_FORMAT: GPUTextureFormat = "rgba8unorm";
@@ -44,6 +44,31 @@ export function sampleCountFor(options: TargetTextureOptions): 1 | 4 {
   (e as { code: string }).code = "VGPU-TARGET-MSAA-INVALID";
   e.message = `msaa received ${msaa}; WebGPU 1|4; use true`;
   throw e;
+}
+
+/**
+ * Sample count of a surface, from its own `sampleCount` option — WebGPU platform vocabulary, so a
+ * surface spells the count itself (`1 | 4`) instead of `Target`'s boolean `msaa`. The two spellings
+ * meet again in `TargetSignature.sampleCount`, which is what pipelines are keyed by.
+ */
+export function surfaceSampleCountFor(options: { readonly sampleCount?: 1 | 4 }): 1 | 4 {
+  const sampleCount = options.sampleCount as unknown;
+  if (sampleCount === 4) return 4;
+  if (sampleCount === undefined || sampleCount === 1) return 1;
+  throw surfaceSampleCountError(sampleCount);
+}
+
+/**
+ * Attachment description of a surface derived from its configuration alone — the depth format the
+ * surface owns and the sample count it renders at. Shared by the surface itself and by anything that
+ * needs its pipeline signature without touching `getCurrentTexture()`.
+ */
+export function surfaceAttachmentsFor(options: { readonly depth?: boolean | GPUTextureFormat; readonly sampleCount?: 1 | 4 }): { readonly depth: GPUTextureFormat | undefined; readonly sampleCount: 1 | 4 } {
+  const depth = depthFormatFor({ depth: options.depth });
+  // Same rule as validateTargetOptions: the default depth state (depthWriteEnabled: true) cannot compile
+  // against a stencil-only format, which has no depth aspect.
+  if (depth === "stencil8") throw targetStencilOnlyDepthError(depth);
+  return { depth, sampleCount: surfaceSampleCountFor(options) };
 }
 
 export function validateTargetOptions(options: Partial<TargetOptions> | undefined, caps: TargetDeviceCaps): void {

--- a/packages/vgpu-api/tests/compile-api.test.ts
+++ b/packages/vgpu-api/tests/compile-api.test.ts
@@ -35,19 +35,21 @@ function expectOutsideFrame(fn: () => unknown): void {
   throw new Error("Expected VGPU-SURFACE-NOT-IN-FRAME");
 }
 
-test("surface pipeline creation is rejected outside frame(gpu) with an offscreen precompile hint", async () => {
+// Encoding against a surface needs its current texture and stays frame-only; compiling against one
+// does not — its signature comes from the surface's configuration (see surface-signature.test.ts).
+test("surface encoding is rejected outside frame(gpu) with an offscreen precompile hint, while compiling is not", async () => {
   const gpu = await init();
   const canvasSurface = surface(gpu, surfaceCanvas());
   const drawable = draw(gpu, { shader: WGSL });
   const shader1 = effect(gpu, FRAGMENT_ONLY);
 
-  expectOutsideFrame(() => drawable.compile(canvasSurface));
-  expectOutsideFrame(() => drawable.compileSync(canvasSurface));
   expectOutsideFrame(() => drawable.draw(canvasSurface));
-  expectOutsideFrame(() => shader1.compile(canvasSurface));
-  expectOutsideFrame(() => shader1.compileSync(canvasSurface));
   expectOutsideFrame(() => shader1.draw(canvasSurface));
   expectOutsideFrame(() => bundle(gpu, { target: canvasSurface }, () => undefined));
+  await expect(drawable.compile(canvasSurface)).resolves.toBe(drawable);
+  expect(() => drawable.compileSync(canvasSurface)).not.toThrow();
+  await expect(shader1.compile(canvasSurface)).resolves.toBe(shader1);
+  expect(() => shader1.compileSync(canvasSurface)).not.toThrow();
   expect(() => frame(gpu, (currentFrame) => currentFrame.pass(canvasSurface, drawable))).not.toThrow();
   gpu.dispose();
 });

--- a/packages/vgpu-api/tests/surface-signature.test.ts
+++ b/packages/vgpu-api/tests/surface-signature.test.ts
@@ -1,0 +1,334 @@
+import { expect, test, vi } from "vitest";
+import { getMockGPUDeviceInstrumentation } from "@vgpu/core";
+import { init, draw, effect, frame, surface, target } from "../src/mock.ts";
+import type { InternalDraw } from "../src/draw.ts";
+import { normalizeSignature, signatureKeyOf } from "../src/pipeline-store.ts";
+import { depthFormatFor } from "../src/target-utils.ts";
+
+const WGSL = `
+@vertex fn vs_main(@builtin(vertex_index) vi: u32) -> @builtin(position) vec4f {
+  var pos = array<vec2f, 3>(vec2f(-1.0, -1.0), vec2f(3.0, -1.0), vec2f(-1.0, 3.0));
+  return vec4f(pos[vi], 0.0, 1.0);
+}
+@fragment fn fs_main() -> @location(0) vec4f { return vec4f(1.0); }
+`;
+
+const FRAGMENT_ONLY = `
+@fragment fn fs_main() -> @location(0) vec4f { return vec4f(1.0); }
+`;
+
+interface CanvasProbe {
+  readonly canvas: HTMLCanvasElement;
+  /** Stable view identity of the canvas presentation texture. */
+  readonly view: object;
+  readonly configure: ReturnType<typeof vi.fn>;
+  currentTextures: number;
+}
+
+/** Canvas mock with STABLE presentation texture/view identity, so resolveTarget can be compared by reference. */
+function canvasProbe(width = 8, height = 4): CanvasProbe {
+  const view = { __canvasView: true };
+  const texture = { createView: () => view };
+  const configure = vi.fn();
+  const probe = { view, configure, currentTextures: 0 } as { view: object; configure: ReturnType<typeof vi.fn>; currentTextures: number; canvas: HTMLCanvasElement };
+  const canvas: Record<string, unknown> = {
+    width,
+    height,
+    getContext(kind: string) {
+      if (kind !== "webgpu") return null;
+      return {
+        canvas,
+        configure,
+        unconfigure: () => undefined,
+        getCurrentTexture: () => { probe.currentTextures += 1; return texture; },
+      };
+    },
+  };
+  probe.canvas = canvas as unknown as HTMLCanvasElement;
+  return probe as CanvasProbe;
+}
+
+function expectNotInFrame(fn: () => unknown): void {
+  try { fn(); }
+  catch (error) {
+    expect(error).toMatchObject({ code: "VGPU-SURFACE-NOT-IN-FRAME" });
+    return;
+  }
+  throw new Error("Expected VGPU-SURFACE-NOT-IN-FRAME");
+}
+
+// Contract #8 (half "resolves"): compiling against a surface outside frame() is legal.
+test("compile/compileSync/pipelineForAsync against a surface outside frame() never throw VGPU-SURFACE-NOT-IN-FRAME", async () => {
+  const gpu = await init();
+  try {
+    const probe = canvasProbe();
+    const canvasSurface = surface(gpu, probe.canvas);
+    const drawable = draw(gpu, { shader: WGSL, label: "outside" });
+    const shader = effect(gpu, FRAGMENT_ONLY, { label: "outside-effect" });
+
+    await expect(drawable.compile(canvasSurface)).resolves.toBe(drawable);
+    expect(drawable.compileSync(canvasSurface)).toBe(drawable);
+    await expect((drawable as unknown as InternalDraw).pipelineForAsync(canvasSurface)).resolves.toBeDefined();
+    await expect(shader.compile(canvasSurface)).resolves.toBe(shader);
+    expect(shader.compileSync(canvasSurface)).toBe(shader);
+
+    // The whole point of the clause: no current texture is ever fetched while only compiling.
+    expect(probe.currentTextures).toBe(0);
+  } finally {
+    gpu.dispose();
+  }
+});
+
+// Contract #8 (half "signature equals"): the signature resolved outside a frame is the encoding one.
+test("the surface signature resolved outside frame() equals the one used encoding inside frame()", async () => {
+  const gpu = await init();
+  try {
+    const probe = canvasProbe();
+    const canvasSurface = surface(gpu, probe.canvas);
+    const drawable = draw(gpu, { shader: WGSL, label: "stable-signature" });
+    const mock = getMockGPUDeviceInstrumentation(gpu.device.gpu);
+
+    const outside = normalizeSignature(canvasSurface);
+    expect(outside).toEqual({ colors: [canvasSurface.format], depth: undefined, sampleCount: 1 });
+
+    await drawable.compile(canvasSurface);
+    expect(mock.calls.createRenderPipelineAsync).toBe(1);
+    expect(mock.calls.createRenderPipeline).toBe(0);
+
+    let inside: unknown;
+    frame(gpu, (currentFrame) => {
+      inside = normalizeSignature(canvasSurface);
+      currentFrame.pass(canvasSurface, drawable);
+    });
+
+    expect(inside).toEqual(outside);
+    expect(signatureKeyOf(inside as never)).toBe(signatureKeyOf(outside));
+    // Same key ⇒ the pipeline compiled outside the frame is the one the encode path reused.
+    expect(mock.calls.createRenderPipeline).toBe(0);
+    expect(mock.calls.createRenderPipelineAsync).toBe(1);
+  } finally {
+    gpu.dispose();
+  }
+});
+
+// Encode still needs the current texture: the standalone one-shot draw keeps the guard.
+test("standalone draw()/effect().draw() against a surface outside frame() still throws VGPU-SURFACE-NOT-IN-FRAME", async () => {
+  const gpu = await init();
+  try {
+    const probe = canvasProbe();
+    const canvasSurface = surface(gpu, probe.canvas);
+    const drawable = draw(gpu, { shader: WGSL, label: "encode-guard" });
+    const shader = effect(gpu, FRAGMENT_ONLY, { label: "encode-guard-effect" });
+
+    expectNotInFrame(() => drawable.draw(canvasSurface));
+    expectNotInFrame(() => shader.draw(canvasSurface));
+    expect(() => frame(gpu, (currentFrame) => currentFrame.pass(canvasSurface, drawable))).not.toThrow();
+  } finally {
+    gpu.dispose();
+  }
+});
+
+// Design rule: depth on surface() resolves through the shared depthFormatFor.
+test("surface({ depth: true }) owns a depth attachment resolved through depthFormatFor, like target({ depth: true })", async () => {
+  const gpu = await init();
+  try {
+    const probe = canvasProbe();
+    const canvasSurface = surface(gpu, probe.canvas, { depth: true });
+    const offscreen = target(gpu, { size: [8, 4], depth: true });
+
+    expect(canvasSurface.depth?.format).toBe(depthFormatFor({ depth: true }));
+    expect(canvasSurface.depth?.format).toBe(offscreen.depth?.format);
+    expect(canvasSurface.depth?.size).toEqual([8, 4]);
+    expect(normalizeSignature(canvasSurface).depth).toBe("depth24plus");
+
+    const descriptor = canvasSurface.renderPassDescriptor();
+    expect(descriptor.depthStencilAttachment).toBeDefined();
+    expect(descriptor.depthStencilAttachment?.depthLoadOp).toBe("clear");
+    expect(descriptor.depthStencilAttachment?.depthStoreOp).toBe("store");
+
+    // Explicit depth formats pass through unchanged, stencil aspect included.
+    const stencilSurface = surface(gpu, canvasProbe().canvas, { depth: "depth24plus-stencil8" });
+    expect(stencilSurface.depth?.format).toBe("depth24plus-stencil8");
+    expect(stencilSurface.renderPassDescriptor().depthStencilAttachment?.stencilLoadOp).toBe("clear");
+  } finally {
+    gpu.dispose();
+  }
+});
+
+// Design rule: MSAA resolves into the presentation texture.
+test("surface({ sampleCount: 4 }) renders into an internal multisample attachment and resolves into the canvas texture", async () => {
+  const gpu = await init();
+  try {
+    const probe = canvasProbe();
+    const canvasSurface = surface(gpu, probe.canvas, { sampleCount: 4, depth: true });
+
+    expect(canvasSurface.sampleCount).toBe(4);
+    expect(normalizeSignature(canvasSurface).sampleCount).toBe(4);
+    expect(canvasSurface.depth?.sampleCount).toBe(4);
+
+    const descriptor = canvasSurface.renderPassDescriptor();
+    const color = descriptor.colorAttachments[0]!;
+    expect(color.resolveTarget).toBe(probe.view);
+    expect(color.view).not.toBe(probe.view);
+    expect(color.storeOp).toBe("discard");
+    expect(descriptor.depthStencilAttachment?.depthStoreOp).toBe("discard");
+
+    // The pipeline compiled for this surface is multisampled — and it is derivable outside a frame.
+    const drawable = draw(gpu, { shader: WGSL, label: "msaa-surface" });
+    await drawable.compile(canvasSurface);
+    const mock = getMockGPUDeviceInstrumentation(gpu.device.gpu);
+    expect(mock.createRenderPipelineAsyncDescriptors.at(-1)?.multisample?.count).toBe(4);
+    expect(mock.createRenderPipelineAsyncDescriptors.at(-1)?.depthStencil?.format).toBe("depth24plus");
+  } finally {
+    gpu.dispose();
+  }
+});
+
+// Contract #23 (partial): resize invalidates by signature, not identity.
+test("a resize that preserves format, depth and sample count keeps the signature and creates no pipeline", async () => {
+  const gpu = await init();
+  try {
+    const probe = canvasProbe();
+    const canvasSurface = surface(gpu, probe.canvas, { depth: true, sampleCount: 4 });
+    const drawable = draw(gpu, { shader: WGSL, label: "resize-stable" });
+    const mock = getMockGPUDeviceInstrumentation(gpu.device.gpu);
+
+    const before = signatureKeyOf(normalizeSignature(canvasSurface));
+    await drawable.compile(canvasSurface);
+    const createdBefore = mock.calls.createRenderPipeline + mock.calls.createRenderPipelineAsync;
+
+    canvasSurface.resize([16, 9]);
+
+    expect(canvasSurface.size).toEqual([16, 9]);
+    expect(signatureKeyOf(normalizeSignature(canvasSurface))).toBe(before);
+    // Internal attachments follow the new size while the signature stays put.
+    expect(canvasSurface.depth?.size).toEqual([16, 9]);
+
+    frame(gpu, (currentFrame) => currentFrame.pass(canvasSurface, drawable));
+    expect(mock.calls.createRenderPipeline + mock.calls.createRenderPipelineAsync).toBe(createdBefore);
+  } finally {
+    gpu.dispose();
+  }
+});
+
+// Zero regression: a plain surface behaves exactly as in 0.3.0.
+test("surface(gpu, canvas) without the new options stays color-only, sampleCount 1, and allocates no textures", async () => {
+  const gpu = await init();
+  try {
+    const probe = canvasProbe();
+    const mock = getMockGPUDeviceInstrumentation(gpu.device.gpu);
+    const texturesBefore = mock.calls.createBuffer; // buffers untouched; textures counted below
+    const canvasSurface = surface(gpu, probe.canvas);
+
+    expect(canvasSurface.depth).toBeUndefined();
+    expect(canvasSurface.sampleCount).toBe(1);
+    expect(canvasSurface.colors).toHaveLength(1);
+
+    const descriptor = canvasSurface.renderPassDescriptor();
+    expect(descriptor.depthStencilAttachment).toBeUndefined();
+    expect(descriptor.colorAttachments).toHaveLength(1);
+    const color = descriptor.colorAttachments[0]!;
+    expect(color.view).toBe(probe.view);
+    expect(color.resolveTarget).toBeUndefined();
+    expect(color.loadOp).toBe("clear");
+    expect(color.storeOp).toBe("store");
+    expect(mock.calls.createBuffer).toBe(texturesBefore);
+  } finally {
+    gpu.dispose();
+  }
+});
+
+// A frame-independent signature is not a lifetime-independent one: disposal still wins.
+test("a disposed surface rejects every signature consumer, compile included", async () => {
+  const gpu = await init();
+  try {
+    const probe = canvasProbe();
+    const canvasSurface = surface(gpu, probe.canvas, { depth: true });
+    const drawable = draw(gpu, { shader: WGSL, label: "disposed" });
+    canvasSurface.dispose();
+
+    const expectDisposed = (fn: () => unknown): void => expect(fn).toThrowError(expect.objectContaining({ code: "VGPU-SURFACE-DISPOSED" }));
+    expectDisposed(() => normalizeSignature(canvasSurface));
+    expectDisposed(() => drawable.compileSync(canvasSurface));
+    expectDisposed(() => (drawable as unknown as InternalDraw).pipelineFor(canvasSurface));
+    // compile() resolves its key before it awaits anything, so it reports this synchronously too.
+    expectDisposed(() => drawable.compile(canvasSurface));
+  } finally {
+    gpu.dispose();
+  }
+});
+
+// The attachments a consumer caches views over are recreated by BOTH resize paths, so both announce it.
+test("onTexturesRecreated fires when the canvas is resized behind the surface's back, not only through resize()", async () => {
+  const gpu = await init();
+  try {
+    const probe = canvasProbe();
+    const canvasSurface = surface(gpu, probe.canvas, { depth: true });
+    let recreated = 0;
+    // Same shape set-resources.ts consumes (RecreatingTarget): the hook is on the surface, not on the Target interface.
+    (canvasSurface as unknown as { onTexturesRecreated(cb: () => void): () => void }).onTexturesRecreated(() => { recreated += 1; });
+
+    const first = canvasSurface.depth;
+    // Canvas resized directly: never goes through resize(), so only the lazy sync notices it.
+    (probe.canvas as unknown as { width: number }).width = 32;
+    const afterDrift = canvasSurface.depth;
+    expect(afterDrift).not.toBe(first);
+    expect(afterDrift?.size).toEqual([32, 4]);
+    expect(recreated).toBe(1);
+
+    canvasSurface.resize([48, 24]);
+    expect(recreated).toBe(2);
+    expect(canvasSurface.depth?.size).toEqual([48, 24]);
+  } finally {
+    gpu.dispose();
+  }
+});
+
+// Attachment sizes obey the same 1×1 floor every other size on this surface does.
+test("a zero-sized canvas still allocates a valid 1x1 attachment and does not re-create it on every read", async () => {
+  const gpu = await init();
+  try {
+    const probe = canvasProbe(0, 0);
+    const canvasSurface = surface(gpu, probe.canvas, { depth: true });
+    const first = canvasSurface.depth;
+    expect(first?.size).toEqual([1, 1]);
+    // Sanitized on both sides of the comparison: no thrash between the 0×0 canvas and the 1×1 attachment.
+    expect(canvasSurface.depth).toBe(first);
+  } finally {
+    gpu.dispose();
+  }
+});
+
+// frame.ts branches that a Surface could never reach before it owned depth/MSAA.
+test("pass options that depend on depth and MSAA now apply to surfaces exactly as they do to targets", async () => {
+  const gpu = await init();
+  try {
+    const msaaDepth = surface(gpu, canvasProbe().canvas, { depth: true, sampleCount: 4 });
+    const plainDepth = surface(gpu, canvasProbe().canvas, { depth: true });
+    const stencil = surface(gpu, canvasProbe().canvas, { depth: "depth24plus-stencil8" });
+    const colorOnly = surface(gpu, canvasProbe().canvas);
+    const drawable = draw(gpu, { shader: WGSL, label: "pass-matrix" });
+
+    // Empty body on purpose: this pins frame.pass's own option validation, not the separate rule that
+    // rejects a depth-writing pipeline inside a read-only pass.
+    const run = (options: Record<string, unknown>): unknown => {
+      try { frame(gpu, (currentFrame) => currentFrame.pass(options as never, () => undefined)); return "ok"; }
+      catch (error) { return (error as { code?: string }).code; }
+    };
+    void drawable;
+
+    // MSAA discards what it resolves, so neither preserving nor reading depth back is coherent.
+    expect(run({ target: msaaDepth, clear: false })).toBe("VGPU-PASS-PRESERVE-MSAA");
+    expect(run({ target: msaaDepth, depthReadOnly: true })).toBe("VGPU-PASS-DEPTH-READONLY-MSAA");
+    // Depth-dependent options are live on a depth surface and dead options on a color-only one.
+    expect(run({ target: plainDepth, clearDepth: 0.5 })).toBe("ok");
+    expect(run({ target: colorOnly, clearDepth: 0.5 })).toBe("VGPU-PASS-CLEARDEPTH-INVALID");
+    expect(run({ target: plainDepth, depthReadOnly: true })).toBe("ok");
+    expect(run({ target: colorOnly, depthReadOnly: true })).toBe("VGPU-PASS-DEPTH-READONLY");
+    // clearStencil follows the stencil aspect of the surface's own depth format.
+    expect(run({ target: stencil, clearStencil: 1 })).toBe("ok");
+    expect(run({ target: plainDepth, clearStencil: 1 })).toBe("VGPU-PASS-CLEARSTENCIL-INVALID");
+  } finally {
+    gpu.dispose();
+  }
+});

--- a/packages/vgpu-api/tests/surface-signature.test.ts
+++ b/packages/vgpu-api/tests/surface-signature.test.ts
@@ -23,6 +23,34 @@ interface CanvasProbe {
   readonly view: object;
   readonly configure: ReturnType<typeof vi.fn>;
   currentTextures: number;
+  /** Resizes the canvas behind the surface's back, the way layout or app code does. */
+  setSize(width: number, height: number): void;
+}
+
+interface TextureLedger {
+  created: number;
+  destroyed: number;
+  readonly labels: string[];
+}
+
+/**
+ * Counts the textures a surface OWNS. The presentation texture is wrapped directly (`new Texture(…)`,
+ * "external"), never created through the device, so this ledger sees depth and MSAA attachments only.
+ */
+function textureLedger(gpu: { device: unknown }): TextureLedger {
+  const ledger: TextureLedger = { created: 0, destroyed: 0, labels: [] };
+  const device = gpu.device as { createTexture(opts: Record<string, unknown>): { destroy(): void } };
+  const original = device.createTexture.bind(device);
+  device.createTexture = (opts: Record<string, unknown>) => {
+    const texture = original(opts);
+    ledger.created += 1;
+    ledger.labels.push(String(opts.label ?? ""));
+    const destroy = texture.destroy.bind(texture);
+    let counted = false;
+    (texture as { destroy: () => void }).destroy = () => { if (!counted) { counted = true; ledger.destroyed += 1; } destroy(); };
+    return texture;
+  };
+  return ledger;
 }
 
 /** Canvas mock with STABLE presentation texture/view identity, so resolveTarget can be compared by reference. */
@@ -45,6 +73,10 @@ function canvasProbe(width = 8, height = 4): CanvasProbe {
     },
   };
   probe.canvas = canvas as unknown as HTMLCanvasElement;
+  (probe as unknown as { setSize(w: number, h: number): void }).setSize = (w: number, h: number) => {
+    canvas.width = w;
+    canvas.height = h;
+  };
   return probe as CanvasProbe;
 }
 
@@ -328,6 +360,72 @@ test("pass options that depend on depth and MSAA now apply to surfaces exactly a
     // clearStencil follows the stencil aspect of the surface's own depth format.
     expect(run({ target: stencil, clearStencil: 1 })).toBe("ok");
     expect(run({ target: plainDepth, clearStencil: 1 })).toBe("VGPU-PASS-CLEARSTENCIL-INVALID");
+  } finally {
+    gpu.dispose();
+  }
+});
+
+// Donated from the independent QA probe suite (M7): the DoD's dispose clause, previously uncaught by
+// any test in this branch — mutating #destroyAttachments to a no-op survived the whole suite.
+test("dispose destroys the attachments the surface owns exactly once, and stays idempotent", async () => {
+  const gpu = await init();
+  try {
+    const ledger = textureLedger(gpu);
+    const canvasSurface = surface(gpu, canvasProbe().canvas, { depth: true, sampleCount: 4 });
+    expect(ledger.created).toBe(2);
+
+    canvasSurface.dispose();
+    canvasSurface.dispose();
+    canvasSurface.dispose();
+
+    expect(ledger.destroyed).toBe(2);
+    expect(canvasSurface.disposed).toBe(true);
+  } finally {
+    gpu.dispose();
+  }
+});
+
+// Donated from the independent QA probe suite (A6): every recreate must destroy the pair it replaced,
+// through both resize paths, or a long-lived canvas leaks a texture per resize.
+test("repeated resizes and canvas drift never leak an attachment", async () => {
+  const gpu = await init();
+  try {
+    const ledger = textureLedger(gpu);
+    const probe = canvasProbe();
+    const canvasSurface = surface(gpu, probe.canvas, { depth: true, sampleCount: 4 });
+
+    for (let i = 1; i <= 25; i += 1) {
+      if (i % 2 === 0) canvasSurface.resize([8 + i, 4 + i]);
+      else { probe.setSize(8 + i, 4 + i); void canvasSurface.depth; }
+      // Exactly one live pair (depth + msaa) at every step, never a second one.
+      expect(ledger.created - ledger.destroyed).toBe(2);
+    }
+
+    canvasSurface.dispose();
+    expect(ledger.created).toBe(ledger.destroyed);
+    expect(ledger.labels.filter((label) => label.includes("msaa")).length).toBe(ledger.created / 2);
+  } finally {
+    gpu.dispose();
+  }
+});
+
+// Donated from the independent QA probe suite (M10): the duck-typed branch must hand out a fresh
+// signature, never the surface's own state, and must still normalize a plain TargetSignature.
+test("normalizeSignature returns a non-aliased signature a caller cannot use to poison the surface", async () => {
+  const gpu = await init();
+  try {
+    const canvasSurface = surface(gpu, canvasProbe().canvas, { depth: true, sampleCount: 4 });
+    const first = normalizeSignature(canvasSurface);
+    const second = normalizeSignature(canvasSurface);
+    expect(first).not.toBe(second);
+    expect(first.colors).not.toBe(second.colors);
+
+    (first.colors as GPUTextureFormat[])[0] = "r8unorm";
+    expect(normalizeSignature(canvasSurface).colors[0]).toBe(canvasSurface.format);
+
+    // A plain TargetSignature has no pipelineSignature to prefer, so it still takes the normal path.
+    const plain = normalizeSignature({ colors: ["rgba8unorm"], depth: "depth24plus", sampleCount: 4 } as never);
+    expect(plain).toEqual({ colors: ["rgba8unorm"], depth: "depth24plus", sampleCount: 4 });
   } finally {
     gpu.dispose();
   }


### PR DESCRIPTION
Ticket **T04-02** of the 0.4 train — the branch that exists to **validate or falsify normative clause N4** ("a `Surface` has a frame-independent pipeline signature"). It goes first among the large branches on purpose: if N4 were false, T04-05 would be building `prepare()` on a broken assumption.

## Verdict: N4 is VALIDATED

A `Surface`'s pipeline signature is 100% derivable from its configuration. All three components are fixed at construction — `format` (the one already handed to `context.configure()`), `depthFormatFor(opts.depth)` and `sampleCount` — and none of them needs `getCurrentTexture()`. A resize only ever changes attachment **size**, never format or sample count, so the pipeline key is invariant under resize.

Independent QA confirmed the equivalence exhaustively: **180/180 signature combinations** (format x depth x sampleCount) resolve identically inside and outside `frame()`, and **12/12 mutants** were killed by the suite. Adversarially: `pipelineForAsync()` in flight, then a `resize()` **and** a raw `canvas.width =` drift during the await, still yields the same key, the same pipeline by identity, and exactly one pipeline creation.

Moving the guard from compile to encode breaks no invariant — the only consumer that genuinely needs the current texture is the encode path, and the guard stays there.

**T04-05 can build `prepare()` on this assumption.**

### Two implementation findings worth recording in the issue

1. **Frame-independent is not lifetime-independent.** Deriving the signature from configuration initially made it stop passing through guarded getters, so a **disposed** surface would compile silently — a regression against 0.3.0. Closed with `#assertLive()` in the `pipelineSignature` getter: compiling against a stale surface still fails where the mistake is, instead of quietly warming the pipeline cache. If the issue phrases N4 as "does not depend on frame state", it is worth clarifying that it *does* still depend on lifetime.

2. **`bundle()` is now inconsistent, deliberately, and is left untouched (out of scope — ola 2).** `bundle.ts:45` still requires an active frame, but a render bundle is recorded from formats alone and never needs `getCurrentTexture()` either. Post-change these coexist: `compile(surface)` outside a frame is legal, `bundle({ target: surface })` outside a frame still throws `VGPU-SURFACE-NOT-IN-FRAME`. Flagged for an ola-2 decision rather than widening this PR.

## What changed

- **`surface.ts`** — `SurfaceOptions` gains `depth?: boolean | GPUTextureFormat` and `sampleCount?: 1 | 4`. The surface now owns the attachments those imply: a depth texture resolved through the shared `depthFormatFor`, and for `sampleCount: 4` an internal multisample color that the pass resolves into the presentation texture. Both go through the same `colorAttachment`/`depthAttachment` helpers `target()` uses — nothing reimplemented. New `pipelineSignature` getter. Attachments are recreated by both resize paths (`resize()` and a canvas resized behind the surface's back), and both announce it on `onTexturesRecreated`, because consumers cache views and bind groups over `surface.depth` — it carries `texture_binding` precisely so a read-only depth pass can sample it.
- **`pipeline-store.ts`** — `normalizeSignature` prefers a target's own configuration-derived `pipelineSignature` when it publishes one, instead of reading `.colors`/`.depth`/`.sampleCount` (which, for a surface, reach `getCurrentTexture()` through `.color`). Structural check rather than an `isSurface` import, so pipeline-store gains no dependency on surface.ts.
- **`draw.ts`** — `#signatureForKeyTarget` no longer asserts an active frame, so `compile`/`compileSync`/`pipelineFor`/`pipelineForAsync` work against a surface outside `frame()`. `draw()` keeps its guard: encoding still requires a frame. `allowSurface` kept as a no-op for source compatibility.
- **`target-utils.ts` / `errors.ts`** — `surfaceSampleCountFor`, `surfaceAttachmentsFor`, `VGPU-SURFACE-SAMPLE-COUNT-INVALID`.
- **Tests** — contracts written first (RED confirmed before implementing). Contract **#8** in both halves (compiling outside a frame resolves, and the resolved signature equals the one the encode path uses inside a frame — asserted by value *and* by the pipeline cache never re-creating) and the surface half of **#23**. Plus the `frame.pass` x Surface option matrix that only became reachable once surfaces own depth/MSAA, and three probes donated from the independent QA suite (dispose destroys owned attachments exactly once; 25 resizes/drifts never leak; `normalizeSignature` returns a non-aliased signature).

**Corpus stays green with zero call sites migrated.** The only 0.3.0 test modified is `compile-api.test.ts`, which encoded exactly the behaviour this design inverts: it now pins that encoding outside a frame still throws while compiling no longer does.

## Bundle budgets — re-baselined, measured against this merged tree

The feature costs real bytes: the shared attachment helpers are retained in every bundle that uses `surface()`. Measured with both sides rebuilt, since `bundle-check` measures built `dist` — a source-only revert silently re-reports branch numbers.

| bundle | next/0.4 | this PR | delta | budget | headroom |
| --- | ---: | ---: | ---: | ---: | ---: |
| `vgpu` `.` | 38813 | 39180 | +367 | 38912 -> 39424 | 244 |
| `vgpu` `./node` | 38980 * | 39351 | +371 | 38912 -> 39424 | 73 |
| `vgpu` `./mock` | 38897 | 39268 | +371 | 38912 -> 39424 | 156 |
| experience `effect-only` | 25469 | 26080 | +611 | 25600 -> 26112 | **32** |
| experience `triangle-low-level` | 28607 | 29228 | +621 | 28672 -> 29696 | 468 |
| experience `draw-recipe-box` | 29735 | 30365 | +630 | 30208 -> 30720 | 355 |
| experience `full-root` | 38887 | 39289 | +402 | 38912 -> 39424 | 135 |
| experience `init-only` | 1057 | 1057 | +0 | 1536 (upstream) | 479 |

\* `./node` was already 68 B over its old ceiling on `next/0.4` (a standing tooling WARN, not from this branch); the re-baseline clears that too.

Each ceiling is the next 512 B multiple strictly above measured, per the repo's own convention, and only the crossed ceilings move — every other budget is untouched. Shrinking was attempted first (duck-typing instead of an `isSurface` import saved 65 B); the remainder is the new surface area itself, not incidental retention.

> **WARNING: `effect-only` lands at 32 B of headroom.** That is honest but thin: the next branch to add bytes there will have to bump it, and this table is the number to bump from. Ola 1 should expect it.

## Report-only findings from QA (no action taken here)

- **Per-`gpu` surface registry with a re-attached canvas** — the duplicate-surface registry is keyed per `gpu`; a canvas detached and re-attached across `gpu` instances is not deduplicated. Pre-existing, not touched by this change.
- **`validateMsaaFormat` is absent from `surfaceAttachmentsFor`** — `target({ format: "rgba16float", msaa: true })` throws `VGPU-UNSUPPORTED` in Dawn compatibility mode, while `surface({ format: "rgba16float", sampleCount: 4 })` would not. Latent only on a real compat-mode device (unreproducible on the mock), so it is reported rather than patched blind.

## Gates

- `pnpm typecheck` -> **0 errors**
- `pnpm test` -> **1925 passed / 139 skipped**, exit 0
- `pnpm bundle-check` -> exit 0, **zero warnings**
- All commits signed; merged with `next/0.4` (incl. #324 and #326), one conflict in `packages/vgpu-api/package.json` resolved by union of both re-baselines.
