### PR TITLE
feat(vgpu-api): additive unified-signature overload for effect()/compute() (T04-01)

### DIFF
--- a/packages/vgpu-api/package.json
+++ b/packages/vgpu-api/package.json
@@ -103,7 +103,7 @@
   },
   "vgpuExperienceBundleBudgetsGzipBytes": {
     "init-only": 1536,
-    "effect-only": 26112,
+    "effect-only": 26624,
     "triangle-low-level": 29696,
     "draw-recipe-box": 30720,
     "full-root": 39424

--- a/packages/vgpu-api/package.json
+++ b/packages/vgpu-api/package.json
@@ -91,9 +91,9 @@
     "./core": "client"
   },
   "vgpuExportBundleBudgetsGzipBytes": {
-    ".": 38912,
-    "./node": 38912,
-    "./mock": 38912,
+    ".": 39424,
+    "./node": 39424,
+    "./mock": 39424,
     "./scene": 12800,
     "./client": 512,
     "./core": 3584
@@ -106,7 +106,7 @@
     "effect-only": 25600,
     "triangle-low-level": 28672,
     "draw-recipe-box": 30208,
-    "full-root": 38912
+    "full-root": 39424
   },
   "vgpuSceneBundleBudgetNote": "The scene barrel retains all recipe builders after the geometry redesign; direct primitive imports retain only their selected mesh, as the experience fixtures assert."
 }

--- a/packages/vgpu-api/src/api-types.ts
+++ b/packages/vgpu-api/src/api-types.ts
@@ -4,6 +4,7 @@
  * They live outside `gpu.ts` so feature modules (compute, storage, ping-pong, uniforms, ...)
  * can be imported — and tree-shaken — without pulling the object that owns every factory.
  */
+import type { ShaderSource } from "@vgpu/wgsl";
 import type { VGPUError } from "./errors.ts";
 import type { Target } from "./target.ts";
 
@@ -14,6 +15,8 @@ export interface ComputeOptions {
   readonly constants?: Readonly<Record<string, number | boolean>>;
   /** Compute entry point to use when the shader has several. Defaults to the first @compute entry point. */
   readonly entry?: string;
+  /** Shader source, only used by the single-argument `compute(gpu, { shader, ... })` form; the two-argument form passes it separately. */
+  readonly shader?: string | ShaderSource;
 }
 export interface DispatchOptions {
   /** GPU-driven dispatch: read the workgroup counts from a buffer instead of CPU-side counts. */

--- a/packages/vgpu-api/src/compute.ts
+++ b/packages/vgpu-api/src/compute.ts
@@ -12,7 +12,7 @@ import { assertDeviceUsable } from "./lifecycle.ts";
 import type { Gpu } from "./kernel.ts";
 import { liveKernel } from "./live-kernel.ts";
 import { renderService } from "./render-service.ts";
-import { toWgsl } from "./shader-source.ts";
+import { resolveShaderInput, toWgsl } from "./shader-source.ts";
 import { resolveIndirect } from "./indirect.ts";
 
 /**
@@ -27,26 +27,9 @@ export function compute(gpu: Gpu, source: string | ShaderSource, opts: ComputeOp
 /** Single-object form: exactly two arguments. A third `opts` argument here is silently ignored — put every option in `input`. */
 export function compute(gpu: Gpu, input: ComputeOptions & { readonly shader: string | ShaderSource }): Compute;
 export function compute(gpu: Gpu, input: string | ShaderSource | ComputeOptions, opts: ComputeOptions = {}): Compute {
-  const [source, resolvedOpts] = resolveComputeInput(input, opts);
+  const [source, resolvedOpts] = resolveShaderInput("compute", input, opts);
   const kernel = liveKernel(gpu, "compute");
   return new ComputePipeline(kernel.device, toWgsl(source), resolvedOpts, renderService(kernel).binds);
-}
-
-/**
- * Splits the additive single-object form (`compute(gpu, { shader, ... })`) from the standing
- * two-argument form (`compute(gpu, source, opts)`) and the ShaderSource/string shorthand.
- *
- * Same discriminator as `effect()` (see `resolveEffectInput` in `effect.ts`): `shader` wins over
- * `version` (a real `ShaderSource` artifact can never legitimately carry a `shader` property), and an
- * object with neither is rejected with an actionable error instead of the generic
- * malformed-shader-source message.
- */
-function resolveComputeInput(input: string | ShaderSource | ComputeOptions, opts: ComputeOptions): readonly [string | ShaderSource, ComputeOptions] {
-  if (typeof input !== "object" || input === null) return [input as string | ShaderSource, opts];
-  if ("shader" in input) return [(input as ComputeOptions & { readonly shader: string | ShaderSource }).shader, input as ComputeOptions];
-  if ("version" in input) return [input as ShaderSource, opts];
-  if (!("shader" in input)) throw unsupportedError("compute", "compute(gpu, options) requires options.shader; use compute(gpu, source, opts) for the two-argument form, or compute(gpu, { shader, ... }).");
-  return [(input as ComputeOptions & { readonly shader: string | ShaderSource }).shader, input as ComputeOptions];
 }
 
 let nextComputeId = 1;

--- a/packages/vgpu-api/src/compute.ts
+++ b/packages/vgpu-api/src/compute.ts
@@ -12,7 +12,7 @@ import { assertDeviceUsable } from "./lifecycle.ts";
 import type { Gpu } from "./kernel.ts";
 import { liveKernel } from "./live-kernel.ts";
 import { renderService } from "./render-service.ts";
-import { toWgsl } from "./shader-source.ts";
+import { resolveShaderInput, toWgsl } from "./shader-source.ts";
 import { resolveIndirect } from "./indirect.ts";
 
 /**
@@ -24,26 +24,12 @@ import { resolveIndirect } from "./indirect.ts";
  */
 export function compute(gpu: Gpu, input: string | ShaderSource): Compute;
 export function compute(gpu: Gpu, source: string | ShaderSource, opts: ComputeOptions): Compute;
+/** Single-object form: exactly two arguments. A third `opts` argument here is silently ignored — put every option in `input`. */
 export function compute(gpu: Gpu, input: ComputeOptions & { readonly shader: string | ShaderSource }): Compute;
 export function compute(gpu: Gpu, input: string | ShaderSource | ComputeOptions, opts: ComputeOptions = {}): Compute {
-  const [source, resolvedOpts] = resolveComputeInput(input, opts);
+  const [source, resolvedOpts] = resolveShaderInput("compute", input, opts);
   const kernel = liveKernel(gpu, "compute");
   return new ComputePipeline(kernel.device, toWgsl(source), resolvedOpts, renderService(kernel).binds);
-}
-
-/**
- * Splits the additive single-object form (`compute(gpu, { shader, ... })`) from the standing
- * two-argument form (`compute(gpu, source, opts)`) and the ShaderSource/string shorthand.
- *
- * Same discriminator as `effect()` (see `resolveEffectInput` in `effect.ts`): an object WITH
- * `version` is a `ShaderSource` artifact and wins even if it also carries a spurious `shader`
- * field; an object WITHOUT `version` is only valid here as an options bag with `shader`.
- */
-function resolveComputeInput(input: string | ShaderSource | ComputeOptions, opts: ComputeOptions): readonly [string | ShaderSource, ComputeOptions] {
-  if (typeof input !== "object" || input === null) return [input as string | ShaderSource, opts];
-  if ("version" in input) return [input as ShaderSource, opts];
-  if (!("shader" in input)) throw unsupportedError("compute", "compute(gpu, options) requires options.shader; use compute(gpu, source, opts) for the two-argument form, or compute(gpu, { shader, ... }).");
-  return [(input as ComputeOptions & { readonly shader: string | ShaderSource }).shader, input as ComputeOptions];
 }
 
 let nextComputeId = 1;

--- a/packages/vgpu-api/src/compute.ts
+++ b/packages/vgpu-api/src/compute.ts
@@ -22,9 +22,28 @@ import { resolveIndirect } from "./indirect.ts";
  * lazy bind group cache through the kernel, so a bind group built for a draw and one built here are
  * the same object when the resources match — and the cache is torn down once, in the service phase.
  */
-export function compute(gpu: Gpu, source: string | ShaderSource, opts: ComputeOptions = {}): Compute {
+export function compute(gpu: Gpu, input: string | ShaderSource): Compute;
+export function compute(gpu: Gpu, source: string | ShaderSource, opts: ComputeOptions): Compute;
+export function compute(gpu: Gpu, input: ComputeOptions & { readonly shader: string | ShaderSource }): Compute;
+export function compute(gpu: Gpu, input: string | ShaderSource | ComputeOptions, opts: ComputeOptions = {}): Compute {
+  const [source, resolvedOpts] = resolveComputeInput(input, opts);
   const kernel = liveKernel(gpu, "compute");
-  return new ComputePipeline(kernel.device, toWgsl(source), opts, renderService(kernel).binds);
+  return new ComputePipeline(kernel.device, toWgsl(source), resolvedOpts, renderService(kernel).binds);
+}
+
+/**
+ * Splits the additive single-object form (`compute(gpu, { shader, ... })`) from the standing
+ * two-argument form (`compute(gpu, source, opts)`) and the ShaderSource/string shorthand.
+ *
+ * Same discriminator as `effect()` (see `resolveEffectInput` in `effect.ts`): an object WITH
+ * `version` is a `ShaderSource` artifact and wins even if it also carries a spurious `shader`
+ * field; an object WITHOUT `version` is only valid here as an options bag with `shader`.
+ */
+function resolveComputeInput(input: string | ShaderSource | ComputeOptions, opts: ComputeOptions): readonly [string | ShaderSource, ComputeOptions] {
+  if (typeof input !== "object" || input === null) return [input as string | ShaderSource, opts];
+  if ("version" in input) return [input as ShaderSource, opts];
+  if (!("shader" in input)) throw unsupportedError("compute", "compute(gpu, options) requires options.shader; use compute(gpu, source, opts) for the two-argument form, or compute(gpu, { shader, ... }).");
+  return [(input as ComputeOptions & { readonly shader: string | ShaderSource }).shader, input as ComputeOptions];
 }
 
 let nextComputeId = 1;

--- a/packages/vgpu-api/src/compute.ts
+++ b/packages/vgpu-api/src/compute.ts
@@ -22,10 +22,16 @@ import { resolveIndirect } from "./indirect.ts";
  * lazy bind group cache through the kernel, so a bind group built for a draw and one built here are
  * the same object when the resources match — and the cache is torn down once, in the service phase.
  */
-export function compute(gpu: Gpu, input: string | ShaderSource): Compute;
-export function compute(gpu: Gpu, source: string | ShaderSource, opts: ComputeOptions): Compute;
+// Overload order is public API surface: `Parameters<typeof compute>[1]` resolves to the LAST
+// declared overload, so the single-object form must come first — otherwise consumers that derive
+// types from `Parameters<>`/`ReturnType<>` (see apps/docs/examples/fft-ocean-surface/scene.ts) see
+// `ComputeOptions & { shader }` instead of `string | ShaderSource` for that position. Call resolution
+// itself is unaffected by this order: the single-object form requires `shader`, which neither a
+// string nor a ShaderSource artifact has, so it never matches those calls.
 /** Single-object form: exactly two arguments. A third `opts` argument here is silently ignored — put every option in `input`. */
 export function compute(gpu: Gpu, input: ComputeOptions & { readonly shader: string | ShaderSource }): Compute;
+export function compute(gpu: Gpu, input: string | ShaderSource): Compute;
+export function compute(gpu: Gpu, source: string | ShaderSource, opts: ComputeOptions): Compute;
 export function compute(gpu: Gpu, input: string | ShaderSource | ComputeOptions, opts: ComputeOptions = {}): Compute {
   const [source, resolvedOpts] = resolveShaderInput("compute", input, opts);
   const kernel = liveKernel(gpu, "compute");

--- a/packages/vgpu-api/src/compute.ts
+++ b/packages/vgpu-api/src/compute.ts
@@ -12,7 +12,7 @@ import { assertDeviceUsable } from "./lifecycle.ts";
 import type { Gpu } from "./kernel.ts";
 import { liveKernel } from "./live-kernel.ts";
 import { renderService } from "./render-service.ts";
-import { resolveShaderInput, toWgsl } from "./shader-source.ts";
+import { toWgsl } from "./shader-source.ts";
 import { resolveIndirect } from "./indirect.ts";
 
 /**
@@ -27,9 +27,26 @@ export function compute(gpu: Gpu, source: string | ShaderSource, opts: ComputeOp
 /** Single-object form: exactly two arguments. A third `opts` argument here is silently ignored — put every option in `input`. */
 export function compute(gpu: Gpu, input: ComputeOptions & { readonly shader: string | ShaderSource }): Compute;
 export function compute(gpu: Gpu, input: string | ShaderSource | ComputeOptions, opts: ComputeOptions = {}): Compute {
-  const [source, resolvedOpts] = resolveShaderInput("compute", input, opts);
+  const [source, resolvedOpts] = resolveComputeInput(input, opts);
   const kernel = liveKernel(gpu, "compute");
   return new ComputePipeline(kernel.device, toWgsl(source), resolvedOpts, renderService(kernel).binds);
+}
+
+/**
+ * Splits the additive single-object form (`compute(gpu, { shader, ... })`) from the standing
+ * two-argument form (`compute(gpu, source, opts)`) and the ShaderSource/string shorthand.
+ *
+ * Same discriminator as `effect()` (see `resolveEffectInput` in `effect.ts`): `shader` wins over
+ * `version` (a real `ShaderSource` artifact can never legitimately carry a `shader` property), and an
+ * object with neither is rejected with an actionable error instead of the generic
+ * malformed-shader-source message.
+ */
+function resolveComputeInput(input: string | ShaderSource | ComputeOptions, opts: ComputeOptions): readonly [string | ShaderSource, ComputeOptions] {
+  if (typeof input !== "object" || input === null) return [input as string | ShaderSource, opts];
+  if ("shader" in input) return [(input as ComputeOptions & { readonly shader: string | ShaderSource }).shader, input as ComputeOptions];
+  if ("version" in input) return [input as ShaderSource, opts];
+  if (!("shader" in input)) throw unsupportedError("compute", "compute(gpu, options) requires options.shader; use compute(gpu, source, opts) for the two-argument form, or compute(gpu, { shader, ... }).");
+  return [(input as ComputeOptions & { readonly shader: string | ShaderSource }).shader, input as ComputeOptions];
 }
 
 let nextComputeId = 1;

--- a/packages/vgpu-api/src/effect.ts
+++ b/packages/vgpu-api/src/effect.ts
@@ -10,7 +10,7 @@ import { isTarget } from "./target-utils.ts";
 import { FRAME_DRAWABLE, type FrameDrawableProtocol } from "./frame-protocols.ts";
 import { liveKernel } from "./live-kernel.ts";
 import { renderService } from "./render-service.ts";
-import { toWgsl } from "./shader-source.ts";
+import { resolveShaderInput, toWgsl } from "./shader-source.ts";
 import { unsupportedError } from "./errors.ts";
 import type { ShaderSource } from "@vgpu/wgsl";
 import type { Gpu } from "./kernel.ts";
@@ -27,7 +27,7 @@ export function effect(gpu: Gpu, source: string | ShaderSource, opts: EffectOpti
 /** Single-object form: exactly two arguments. A third `opts` argument here is silently ignored — put every option in `input`. */
 export function effect(gpu: Gpu, input: EffectOptions & { readonly shader: string | ShaderSource }): Effect;
 export function effect(gpu: Gpu, input: string | ShaderSource | EffectOptions, opts: EffectOptions = {}): Effect {
-  const [source, resolvedOpts] = resolveEffectInput(input, opts);
+  const [source, resolvedOpts] = resolveShaderInput("effect", input, opts);
   // Vertex buffers belong to the generated fullscreen stage, so geometry here would silently do
   // nothing. Reject the option instead of ignoring it.
   if ("geometry" in (resolvedOpts as Record<string, unknown>)) throw unsupportedError("effect", "effect() never accepts vertex buffers; use draw(gpu, { shader, geometry: geometry(gpu, descriptor) }).");
@@ -45,25 +45,6 @@ export function effect(gpu: Gpu, input: string | ShaderSource | EffectOptions, o
     (error) => kernel.reportError(error),
     (promise) => { void kernel.trackDelivery(promise); },
   );
-}
-
-/**
- * Splits the additive single-object form (`effect(gpu, { shader, ... })`) from the standing
- * two-argument form (`effect(gpu, source, opts)`) and the ShaderSource/string shorthand.
- *
- * `shader` wins over `version`: a real `ShaderSource` artifact is exactly `{ version, wgsl }` and can
- * never legitimately carry a `shader` property, while an options bag can carry a stray `version`
- * (directly, or via a spread like `{ ...artifact, shader, blend }`). Checking `"shader" in input`
- * first means that spread still honors `shader`/`blend` instead of silently reverting to the
- * artifact and dropping every other option. An object with neither `shader` nor `version` is
- * rejected with an actionable error instead of the generic malformed-shader-source message.
- */
-function resolveEffectInput(input: string | ShaderSource | EffectOptions, opts: EffectOptions): readonly [string | ShaderSource, EffectOptions] {
-  if (typeof input !== "object" || input === null) return [input as string | ShaderSource, opts];
-  if ("shader" in input) return [(input as EffectOptions & { readonly shader: string | ShaderSource }).shader, input as EffectOptions];
-  if ("version" in input) return [input as ShaderSource, opts];
-  if (!("shader" in input)) throw unsupportedError("effect", "effect(gpu, options) requires options.shader; use effect(gpu, source, opts) for the two-argument form, or effect(gpu, { shader, ... }).");
-  return [(input as EffectOptions & { readonly shader: string | ShaderSource }).shader, input as EffectOptions];
 }
 
 export interface EffectOptions {

--- a/packages/vgpu-api/src/effect.ts
+++ b/packages/vgpu-api/src/effect.ts
@@ -10,7 +10,7 @@ import { isTarget } from "./target-utils.ts";
 import { FRAME_DRAWABLE, type FrameDrawableProtocol } from "./frame-protocols.ts";
 import { liveKernel } from "./live-kernel.ts";
 import { renderService } from "./render-service.ts";
-import { resolveShaderInput, toWgsl } from "./shader-source.ts";
+import { toWgsl } from "./shader-source.ts";
 import { unsupportedError } from "./errors.ts";
 import type { ShaderSource } from "@vgpu/wgsl";
 import type { Gpu } from "./kernel.ts";
@@ -27,7 +27,7 @@ export function effect(gpu: Gpu, source: string | ShaderSource, opts: EffectOpti
 /** Single-object form: exactly two arguments. A third `opts` argument here is silently ignored — put every option in `input`. */
 export function effect(gpu: Gpu, input: EffectOptions & { readonly shader: string | ShaderSource }): Effect;
 export function effect(gpu: Gpu, input: string | ShaderSource | EffectOptions, opts: EffectOptions = {}): Effect {
-  const [source, resolvedOpts] = resolveShaderInput("effect", input, opts);
+  const [source, resolvedOpts] = resolveEffectInput(input, opts);
   // Vertex buffers belong to the generated fullscreen stage, so geometry here would silently do
   // nothing. Reject the option instead of ignoring it.
   if ("geometry" in (resolvedOpts as Record<string, unknown>)) throw unsupportedError("effect", "effect() never accepts vertex buffers; use draw(gpu, { shader, geometry: geometry(gpu, descriptor) }).");
@@ -45,6 +45,25 @@ export function effect(gpu: Gpu, input: string | ShaderSource | EffectOptions, o
     (error) => kernel.reportError(error),
     (promise) => { void kernel.trackDelivery(promise); },
   );
+}
+
+/**
+ * Splits the additive single-object form (`effect(gpu, { shader, ... })`) from the standing
+ * two-argument form (`effect(gpu, source, opts)`) and the ShaderSource/string shorthand.
+ *
+ * `shader` wins over `version`: a real `ShaderSource` artifact is exactly `{ version, wgsl }` and can
+ * never legitimately carry a `shader` property, while an options bag can carry a stray `version`
+ * (directly, or via a spread like `{ ...artifact, shader, blend }`). Checking `"shader" in input`
+ * first means that spread still honors `shader`/`blend` instead of silently reverting to the
+ * artifact and dropping every other option. An object with neither `shader` nor `version` is
+ * rejected with an actionable error instead of the generic malformed-shader-source message.
+ */
+function resolveEffectInput(input: string | ShaderSource | EffectOptions, opts: EffectOptions): readonly [string | ShaderSource, EffectOptions] {
+  if (typeof input !== "object" || input === null) return [input as string | ShaderSource, opts];
+  if ("shader" in input) return [(input as EffectOptions & { readonly shader: string | ShaderSource }).shader, input as EffectOptions];
+  if ("version" in input) return [input as ShaderSource, opts];
+  if (!("shader" in input)) throw unsupportedError("effect", "effect(gpu, options) requires options.shader; use effect(gpu, source, opts) for the two-argument form, or effect(gpu, { shader, ... }).");
+  return [(input as EffectOptions & { readonly shader: string | ShaderSource }).shader, input as EffectOptions];
 }
 
 export interface EffectOptions {

--- a/packages/vgpu-api/src/effect.ts
+++ b/packages/vgpu-api/src/effect.ts
@@ -22,16 +22,20 @@ import type { Gpu } from "./kernel.ts";
  * An effect is a draw with a fixed vertex stage, so it shares the gpu's single render service with
  * `draw()`: same pipeline store, same bind group cache, same shader module and layout caches.
  */
-export function effect(gpu: Gpu, source: string | ShaderSource, opts: EffectOptions = {}): Effect {
+export function effect(gpu: Gpu, input: string | ShaderSource): Effect;
+export function effect(gpu: Gpu, source: string | ShaderSource, opts: EffectOptions): Effect;
+export function effect(gpu: Gpu, input: EffectOptions & { readonly shader: string | ShaderSource }): Effect;
+export function effect(gpu: Gpu, input: string | ShaderSource | EffectOptions, opts: EffectOptions = {}): Effect {
+  const [source, resolvedOpts] = resolveEffectInput(input, opts);
   // Vertex buffers belong to the generated fullscreen stage, so geometry here would silently do
   // nothing. Reject the option instead of ignoring it.
-  if ("geometry" in (opts as Record<string, unknown>)) throw unsupportedError("effect", "effect() never accepts vertex buffers; use draw(gpu, { shader, geometry: geometry(gpu, descriptor) }).");
+  if ("geometry" in (resolvedOpts as Record<string, unknown>)) throw unsupportedError("effect", "effect() never accepts vertex buffers; use draw(gpu, { shader, geometry: geometry(gpu, descriptor) }).");
   const kernel = liveKernel(gpu, "effect");
   const render = renderService(kernel);
   return new InternalEffect(
     kernel.device,
     toWgsl(source),
-    opts,
+    resolvedOpts,
     render.binds,
     undefined,
     render.pipelines,
@@ -40,6 +44,24 @@ export function effect(gpu: Gpu, source: string | ShaderSource, opts: EffectOpti
     (error) => kernel.reportError(error),
     (promise) => { void kernel.trackDelivery(promise); },
   );
+}
+
+/**
+ * Splits the additive single-object form (`effect(gpu, { shader, ... })`) from the standing
+ * two-argument form (`effect(gpu, source, opts)`) and the ShaderSource/string shorthand.
+ *
+ * Discriminated the same way `toWgsl` tells a `ShaderSource` from a string: by `"version" in x`.
+ * A real `ShaderSource` artifact always has `version`; an `EffectOptions` object never does — so an
+ * object WITH `version` takes the ShaderSource path even if a `shader` property was also spuriously
+ * present on it (a `ShaderSource` artifact wins over any injected `shader` field). An object WITHOUT
+ * `version` is only valid here as an options bag with `shader`, or it's rejected with an actionable
+ * error instead of the generic malformed-shader-source message.
+ */
+function resolveEffectInput(input: string | ShaderSource | EffectOptions, opts: EffectOptions): readonly [string | ShaderSource, EffectOptions] {
+  if (typeof input !== "object" || input === null) return [input as string | ShaderSource, opts];
+  if ("version" in input) return [input as ShaderSource, opts];
+  if (!("shader" in input)) throw unsupportedError("effect", "effect(gpu, options) requires options.shader; use effect(gpu, source, opts) for the two-argument form, or effect(gpu, { shader, ... }).");
+  return [(input as EffectOptions & { readonly shader: string | ShaderSource }).shader, input as EffectOptions];
 }
 
 export interface EffectOptions {

--- a/packages/vgpu-api/src/effect.ts
+++ b/packages/vgpu-api/src/effect.ts
@@ -22,10 +22,16 @@ import type { Gpu } from "./kernel.ts";
  * An effect is a draw with a fixed vertex stage, so it shares the gpu's single render service with
  * `draw()`: same pipeline store, same bind group cache, same shader module and layout caches.
  */
-export function effect(gpu: Gpu, input: string | ShaderSource): Effect;
-export function effect(gpu: Gpu, source: string | ShaderSource, opts: EffectOptions): Effect;
+// Overload order is public API surface: `Parameters<typeof effect>[1]` resolves to the LAST
+// declared overload, so the single-object form must come first — otherwise consumers that derive
+// types from `Parameters<>`/`ReturnType<>` (see apps/docs/examples/fft-ocean-surface/scene.ts) see
+// `EffectOptions & { shader }` instead of `string | ShaderSource` for that position. Call resolution
+// itself is unaffected by this order: the single-object form requires `shader`, which neither a
+// string nor a ShaderSource artifact has, so it never matches those calls.
 /** Single-object form: exactly two arguments. A third `opts` argument here is silently ignored — put every option in `input`. */
 export function effect(gpu: Gpu, input: EffectOptions & { readonly shader: string | ShaderSource }): Effect;
+export function effect(gpu: Gpu, input: string | ShaderSource): Effect;
+export function effect(gpu: Gpu, source: string | ShaderSource, opts: EffectOptions): Effect;
 export function effect(gpu: Gpu, input: string | ShaderSource | EffectOptions, opts: EffectOptions = {}): Effect {
   const [source, resolvedOpts] = resolveShaderInput("effect", input, opts);
   // Vertex buffers belong to the generated fullscreen stage, so geometry here would silently do

--- a/packages/vgpu-api/src/effect.ts
+++ b/packages/vgpu-api/src/effect.ts
@@ -10,7 +10,7 @@ import { isTarget } from "./target-utils.ts";
 import { FRAME_DRAWABLE, type FrameDrawableProtocol } from "./frame-protocols.ts";
 import { liveKernel } from "./live-kernel.ts";
 import { renderService } from "./render-service.ts";
-import { toWgsl } from "./shader-source.ts";
+import { resolveShaderInput, toWgsl } from "./shader-source.ts";
 import { unsupportedError } from "./errors.ts";
 import type { ShaderSource } from "@vgpu/wgsl";
 import type { Gpu } from "./kernel.ts";
@@ -24,9 +24,10 @@ import type { Gpu } from "./kernel.ts";
  */
 export function effect(gpu: Gpu, input: string | ShaderSource): Effect;
 export function effect(gpu: Gpu, source: string | ShaderSource, opts: EffectOptions): Effect;
+/** Single-object form: exactly two arguments. A third `opts` argument here is silently ignored — put every option in `input`. */
 export function effect(gpu: Gpu, input: EffectOptions & { readonly shader: string | ShaderSource }): Effect;
 export function effect(gpu: Gpu, input: string | ShaderSource | EffectOptions, opts: EffectOptions = {}): Effect {
-  const [source, resolvedOpts] = resolveEffectInput(input, opts);
+  const [source, resolvedOpts] = resolveShaderInput("effect", input, opts);
   // Vertex buffers belong to the generated fullscreen stage, so geometry here would silently do
   // nothing. Reject the option instead of ignoring it.
   if ("geometry" in (resolvedOpts as Record<string, unknown>)) throw unsupportedError("effect", "effect() never accepts vertex buffers; use draw(gpu, { shader, geometry: geometry(gpu, descriptor) }).");
@@ -46,24 +47,6 @@ export function effect(gpu: Gpu, input: string | ShaderSource | EffectOptions, o
   );
 }
 
-/**
- * Splits the additive single-object form (`effect(gpu, { shader, ... })`) from the standing
- * two-argument form (`effect(gpu, source, opts)`) and the ShaderSource/string shorthand.
- *
- * Discriminated the same way `toWgsl` tells a `ShaderSource` from a string: by `"version" in x`.
- * A real `ShaderSource` artifact always has `version`; an `EffectOptions` object never does — so an
- * object WITH `version` takes the ShaderSource path even if a `shader` property was also spuriously
- * present on it (a `ShaderSource` artifact wins over any injected `shader` field). An object WITHOUT
- * `version` is only valid here as an options bag with `shader`, or it's rejected with an actionable
- * error instead of the generic malformed-shader-source message.
- */
-function resolveEffectInput(input: string | ShaderSource | EffectOptions, opts: EffectOptions): readonly [string | ShaderSource, EffectOptions] {
-  if (typeof input !== "object" || input === null) return [input as string | ShaderSource, opts];
-  if ("version" in input) return [input as ShaderSource, opts];
-  if (!("shader" in input)) throw unsupportedError("effect", "effect(gpu, options) requires options.shader; use effect(gpu, source, opts) for the two-argument form, or effect(gpu, { shader, ... }).");
-  return [(input as EffectOptions & { readonly shader: string | ShaderSource }).shader, input as EffectOptions];
-}
-
 export interface EffectOptions {
   readonly set?: SetBag;
   readonly label?: string;
@@ -71,6 +54,8 @@ export interface EffectOptions {
   readonly blend?: BlendPreset | BlendOptions;
   /** Channels written to color targets. Omit to write all (rgba). Empty array writes nothing. */
   readonly writeMask?: readonly ("r" | "g" | "b" | "a")[];
+  /** Shader source, only used by the single-argument `effect(gpu, { shader, ... })` form; the two-argument form passes it separately. */
+  readonly shader?: string | ShaderSource;
 }
 
 const effectImpls = new WeakMap<Effect, InternalDraw>();

--- a/packages/vgpu-api/src/shader-source.ts
+++ b/packages/vgpu-api/src/shader-source.ts
@@ -1,5 +1,5 @@
 import type { ShaderSource } from "@vgpu/wgsl";
-import { malformedShaderSourceError, unsupportedError } from "./errors.ts";
+import { malformedShaderSourceError } from "./errors.ts";
 
 /** Normalizes public ring-1 shader inputs to raw WGSL. Strings remain first-class; ShaderSource is the loader artifact. */
 export function toWgsl(input: string | ShaderSource): string {
@@ -11,25 +11,6 @@ export function toWgsl(input: string | ShaderSource): string {
   const wgsl = (input as { readonly wgsl?: unknown }).wgsl;
   if (typeof wgsl !== "string") throw malformedShaderSourceError(input);
   return wgsl;
-}
-
-/**
- * Splits the additive single-object form (`effect(gpu, { shader, ... })` / `compute(gpu, { shader, ... })`)
- * from the standing two-argument form (`fn(gpu, source, opts)`) and the ShaderSource/string shorthand.
- * Shared by `effect()` and `compute()` so both stay byte-identical in behavior and error text.
- *
- * `shader` wins over `version`: a real `ShaderSource` artifact is exactly `{ version, wgsl }` and can
- * never legitimately carry a `shader` property, while an options bag can carry a stray `version`
- * (directly, or via a spread like `{ ...artifact, shader, blend }`). Checking `"shader" in input`
- * first means that spread still honors `shader`/`blend` instead of silently reverting to the artifact
- * and dropping every other option. An object with neither `shader` nor `version` is rejected with an
- * actionable error instead of the generic malformed-shader-source message.
- */
-export function resolveShaderInput<Opts extends object>(where: string, input: string | ShaderSource | Opts, opts: Opts): readonly [string | ShaderSource, Opts] {
-  if (!isObject(input)) return [input as string | ShaderSource, opts];
-  if ("shader" in input) return [(input as Opts & { readonly shader: string | ShaderSource }).shader, input as Opts];
-  if ("version" in input) return [input as unknown as ShaderSource, opts];
-  throw unsupportedError(where, `${where}(gpu, options) requires options.shader; use ${where}(gpu, source, opts) for the two-argument form, or ${where}(gpu, { shader, ... }).`);
 }
 
 function isObject(value: unknown): value is Record<string, unknown> {

--- a/packages/vgpu-api/src/shader-source.ts
+++ b/packages/vgpu-api/src/shader-source.ts
@@ -1,5 +1,5 @@
 import type { ShaderSource } from "@vgpu/wgsl";
-import { malformedShaderSourceError } from "./errors.ts";
+import { malformedShaderSourceError, unsupportedError } from "./errors.ts";
 
 /** Normalizes public ring-1 shader inputs to raw WGSL. Strings remain first-class; ShaderSource is the loader artifact. */
 export function toWgsl(input: string | ShaderSource): string {
@@ -11,6 +11,25 @@ export function toWgsl(input: string | ShaderSource): string {
   const wgsl = (input as { readonly wgsl?: unknown }).wgsl;
   if (typeof wgsl !== "string") throw malformedShaderSourceError(input);
   return wgsl;
+}
+
+/**
+ * Splits the additive single-object form (`effect(gpu, { shader, ... })` / `compute(gpu, { shader, ... })`)
+ * from the standing two-argument form (`fn(gpu, source, opts)`) and the ShaderSource/string shorthand.
+ * Shared by `effect()` and `compute()` so both stay byte-identical in behavior and error text.
+ *
+ * `shader` wins over `version`: a real `ShaderSource` artifact is exactly `{ version, wgsl }` and can
+ * never legitimately carry a `shader` property, while an options bag can carry a stray `version`
+ * (directly, or via a spread like `{ ...artifact, shader, blend }`). Checking `"shader" in input`
+ * first means that spread still honors `shader`/`blend` instead of silently reverting to the artifact
+ * and dropping every other option. An object with neither `shader` nor `version` is rejected with an
+ * actionable error instead of the generic malformed-shader-source message.
+ */
+export function resolveShaderInput<Opts extends object>(where: string, input: string | ShaderSource | Opts, opts: Opts): readonly [string | ShaderSource, Opts] {
+  if (!isObject(input)) return [input as string | ShaderSource, opts];
+  if ("shader" in input) return [(input as Opts & { readonly shader: string | ShaderSource }).shader, input as Opts];
+  if ("version" in input) return [input as unknown as ShaderSource, opts];
+  throw unsupportedError(where, `${where}(gpu, options) requires options.shader; use ${where}(gpu, source, opts) for the two-argument form, or ${where}(gpu, { shader, ... }).`);
 }
 
 function isObject(value: unknown): value is Record<string, unknown> {

--- a/packages/vgpu-api/tests/ring1-shader-source.test.ts
+++ b/packages/vgpu-api/tests/ring1-shader-source.test.ts
@@ -53,11 +53,17 @@ test("compute(gpu, ...) accepts ShaderSource", async () => {
   gpu.dispose();
 });
 
-test("malformed ShaderSource without version throws VGPU-SHADER-SOURCE-INVALID", async () => {
+// T04-01 (unified-signature): a bare object without "version" is now dispatched as the additive
+// single-argument options form (`effect(gpu, { shader, ... })`), not as a malformed ShaderSource —
+// so a shape like `{ wgsl }` (no `version`, no `shader`) surfaces the actionable "requires
+// options.shader" error instead of VGPU-SHADER-SOURCE-INVALID. An object WITH "version" still goes
+// through the ShaderSource path and can still raise VGPU-SHADER-SOURCE-INVALID (see the "unsupported
+// ShaderSource version" case below), so that error code is still reachable, just not from this shape.
+test("a bare object without version or shader throws the options-form actionable error, not VGPU-SHADER-SOURCE-INVALID", async () => {
   const gpu = await init();
 
   expect(() => effect(gpu, { wgsl: FRAGMENT } as never)).toThrowError(
-    /VGPU-SHADER-SOURCE-INVALID: expected WGSL or \{ version, wgsl \}, got .* Fix: configure @vgpu\/wgsl loader-vite or loader-webpack\./,
+    "effect(gpu, options) requires options.shader; use effect(gpu, source, opts) for the two-argument form, or effect(gpu, { shader, ... }).",
   );
   gpu.dispose();
 });

--- a/packages/vgpu-api/tests/ring1-shader-source.test.ts
+++ b/packages/vgpu-api/tests/ring1-shader-source.test.ts
@@ -76,3 +76,33 @@ test("unsupported ShaderSource version throws VGPU-SHADER-SOURCE-INVALID", async
   );
   gpu.dispose();
 });
+
+// T04-01 (unified-signature): the generic malformed-shader-source branch (toWgsl on a non-string,
+// non-{version,wgsl} input) is still fully reachable — restoring coverage that the "bare object"
+// test above no longer exercises now that a bare `{ wgsl }` object is classified as the
+// options-form-missing-shader case instead.
+test("VGPU-SHADER-SOURCE-INVALID is still reachable: draw(gpu, { shader }) with a malformed shader field", async () => {
+  const gpu = await init();
+
+  expect(() => draw(gpu, { shader: { wgsl: DRAW } as never })).toThrowError(
+    /VGPU-SHADER-SOURCE-INVALID: expected WGSL or \{ version, wgsl \}, got .* Fix: configure @vgpu\/wgsl loader-vite or loader-webpack\./,
+  );
+  gpu.dispose();
+});
+
+test("VGPU-SHADER-SOURCE-INVALID is still reachable: effect(gpu, null | number) — not a string, not object-shaped", async () => {
+  const gpu = await init();
+
+  expect(() => effect(gpu, null as never)).toThrowError(/VGPU-SHADER-SOURCE-INVALID/);
+  expect(() => effect(gpu, 7 as never)).toThrowError(/VGPU-SHADER-SOURCE-INVALID/);
+  gpu.dispose();
+});
+
+test("VGPU-SHADER-SOURCE-INVALID is still reachable: a real ShaderSource shape with a malformed wgsl field", async () => {
+  const gpu = await init();
+
+  expect(() => effect(gpu, { version: 1, wgsl: 123 } as never)).toThrowError(
+    /VGPU-SHADER-SOURCE-INVALID: expected WGSL or \{ version, wgsl \}, got .* Fix: configure @vgpu\/wgsl loader-vite or loader-webpack\./,
+  );
+  gpu.dispose();
+});

--- a/packages/vgpu-api/tests/unified-signature.test.ts
+++ b/packages/vgpu-api/tests/unified-signature.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "vitest";
 import { getMockGPUDeviceInstrumentation } from "@vgpu/core";
-import { compute, effect, init, target } from "../src/mock.ts";
+import { compute, effect, init, storage, target } from "../src/mock.ts";
 
 const EFFECT_SHADER = `
 @fragment fn fs_main(@location(0) uv: vec2f) -> @location(0) vec4f { return vec4f(uv, 0.0, 1.0); }
@@ -45,6 +45,8 @@ test("compute(gpu, { shader, entry }) produces a Compute equivalent to compute(g
 
   // Both must dispatch without throwing — proves the options-object form built a working pipeline
   // with the same entry point / bindings as the two-argument form.
+  fromTwoArgs.set({ data: storage(gpu, 16) });
+  fromOptionsObject.set({ data: storage(gpu, 16) });
   expect(() => fromTwoArgs.dispatch(1)).not.toThrow();
   expect(() => fromOptionsObject.dispatch(1)).not.toThrow();
   gpu.dispose();

--- a/packages/vgpu-api/tests/unified-signature.test.ts
+++ b/packages/vgpu-api/tests/unified-signature.test.ts
@@ -38,24 +38,24 @@ test("compute(gpu, { shader, entry }) produces a Compute equivalent to compute(g
   const gpu = await init();
   const instrumentation = getMockGPUDeviceInstrumentation(gpu.device.gpu);
 
+  // compute() no longer compiles a pipeline at construction (contract #4, next/0.4 compute-async);
+  // dispatch() compiles it lazily-sync the first time it runs. Bind data and dispatch before
+  // inspecting the descriptor.
   const fromTwoArgs = compute(gpu, COMPUTE_SHADER, { entry: "main", label: "job" });
+  fromTwoArgs.set({ data: storage(gpu, 16) });
+  expect(() => fromTwoArgs.dispatch(1)).not.toThrow();
   const twoArgsDesc = instrumentation.createComputePipelineDescriptors.at(-1);
   expect(twoArgsDesc?.label).toBe("job.pipeline");
   expect(twoArgsDesc?.compute.entryPoint).toBe("main");
 
   const fromOptionsObject = compute(gpu, { shader: COMPUTE_SHADER, entry: "main", label: "job" });
+  fromOptionsObject.set({ data: storage(gpu, 16) });
+  expect(() => fromOptionsObject.dispatch(1)).not.toThrow();
   // Assert directly on the descriptor the options-object form itself produced, not just on parity
   // with the two-argument form's descriptor (kills a mutant that drops opts on the object-form path).
   const objectFormDesc = instrumentation.createComputePipelineDescriptors.at(-1);
   expect(objectFormDesc?.label).toBe("job.pipeline");
   expect(objectFormDesc?.compute.entryPoint).toBe("main");
-
-  // Both must dispatch without throwing — proves the options-object form built a working pipeline
-  // with the same entry point / bindings as the two-argument form.
-  fromTwoArgs.set({ data: storage(gpu, 16) });
-  fromOptionsObject.set({ data: storage(gpu, 16) });
-  expect(() => fromTwoArgs.dispatch(1)).not.toThrow();
-  expect(() => fromOptionsObject.dispatch(1)).not.toThrow();
   gpu.dispose();
 });
 
@@ -96,12 +96,15 @@ test("compute(gpu, { shader, version, wgsl, entry, label }) picks shader over a 
 
   const job = compute(gpu, { shader: COMPUTE_SHADER, version: 1, wgsl: decoyWithoutMainEntry, entry: "main", label: "amb" } as never);
   const instrumentation = getMockGPUDeviceInstrumentation(gpu.device.gpu);
+
+  // compute() no longer compiles a pipeline at construction (contract #4, next/0.4 compute-async);
+  // dispatch() compiles it lazily-sync the first time it runs.
+  job.set({ data: storage(gpu, 16) });
+  expect(() => job.dispatch(1)).not.toThrow();
+
   const desc = instrumentation.createComputePipelineDescriptors.at(-1);
   expect(desc?.label).toBe("amb.pipeline");
   expect(desc?.compute.entryPoint).toBe("main");
-
-  job.set({ data: storage(gpu, 16) });
-  expect(() => job.dispatch(1)).not.toThrow();
   gpu.dispose();
 });
 

--- a/packages/vgpu-api/tests/unified-signature.test.ts
+++ b/packages/vgpu-api/tests/unified-signature.test.ts
@@ -1,0 +1,78 @@
+import { expect, test } from "vitest";
+import { getMockGPUDeviceInstrumentation } from "@vgpu/core";
+import { compute, effect, init, target } from "../src/mock.ts";
+
+const EFFECT_SHADER = `
+@fragment fn fs_main(@location(0) uv: vec2f) -> @location(0) vec4f { return vec4f(uv, 0.0, 1.0); }
+`;
+
+const COMPUTE_SHADER = `
+@group(0) @binding(0) var<storage, read_write> data: array<f32>;
+@compute @workgroup_size(1)
+fn main(@builtin(global_invocation_id) id: vec3u) { data[id.x] = 1.0; }
+`;
+
+test("effect(gpu, { shader, ... }) shares the exact pipeline of effect(gpu, source, opts)", async () => {
+  const gpu = await init();
+  const colorTarget = target(gpu, { size: [2, 2] });
+
+  const fromTwoArgs = effect(gpu, EFFECT_SHADER, { blend: "additive" });
+  fromTwoArgs.draw(colorTarget);
+  const afterFirst = getMockGPUDeviceInstrumentation(gpu.device.gpu).createRenderPipelineDescriptors.length;
+
+  const fromOptionsObject = effect(gpu, { shader: EFFECT_SHADER, blend: "additive" });
+  fromOptionsObject.draw(colorTarget);
+  const instrumentation = getMockGPUDeviceInstrumentation(gpu.device.gpu);
+
+  // Same shader + same blend => same pipeline key => no second createRenderPipeline call.
+  expect(instrumentation.createRenderPipelineDescriptors.length).toBe(afterFirst);
+  expect(instrumentation.createRenderPipelineDescriptors.at(-1)?.fragment?.targets?.[0]).toMatchObject({
+    blend: { color: { srcFactor: "one", dstFactor: "one", operation: "add" }, alpha: { srcFactor: "one", dstFactor: "one", operation: "add" } },
+  });
+  gpu.dispose();
+});
+
+test("compute(gpu, { shader, entry }) produces a Compute equivalent to compute(gpu, source, { entry })", async () => {
+  const gpu = await init();
+
+  const fromTwoArgs = compute(gpu, COMPUTE_SHADER, { entry: "main", label: "job" });
+  const fromOptionsObject = compute(gpu, { shader: COMPUTE_SHADER, entry: "main", label: "job" });
+
+  const instrumentation = getMockGPUDeviceInstrumentation(gpu.device.gpu);
+  const descriptors = instrumentation.createComputePipelineDescriptors;
+  const twoArgsDesc = descriptors.find((d) => d.label === "job.pipeline");
+  expect(twoArgsDesc?.compute.entryPoint).toBe("main");
+
+  // Both must dispatch without throwing — proves the options-object form built a working pipeline
+  // with the same entry point / bindings as the two-argument form.
+  expect(() => fromTwoArgs.dispatch(1)).not.toThrow();
+  expect(() => fromOptionsObject.dispatch(1)).not.toThrow();
+  gpu.dispose();
+});
+
+test("effect(gpu, { blend }) without options.shader throws an actionable error, not malformedShaderSourceError", async () => {
+  const gpu = await init();
+
+  expect(() => effect(gpu, { blend: "additive" } as never)).toThrowError(
+    /effect\(gpu, options\) requires options\.shader; use effect\(gpu, source, opts\) for the two-argument form, or effect\(gpu, \{ shader, \.\.\. \}\)\./,
+  );
+  gpu.dispose();
+});
+
+test("compute(gpu, { entry }) without options.shader throws an actionable error, not malformedShaderSourceError", async () => {
+  const gpu = await init();
+
+  expect(() => compute(gpu, { entry: "main" } as never)).toThrowError(
+    /compute\(gpu, options\) requires options\.shader; use compute\(gpu, source, opts\) for the two-argument form, or compute\(gpu, \{ shader, \.\.\. \}\)\./,
+  );
+  gpu.dispose();
+});
+
+test("effect(gpu, shaderSourceArtifact) still works as a shorthand, not confused with the options-object form", async () => {
+  const gpu = await init();
+  const colorTarget = target(gpu, { size: [2, 2] });
+
+  const shorthand = effect(gpu, { version: 1, wgsl: EFFECT_SHADER });
+  expect(() => shorthand.draw(colorTarget)).not.toThrow();
+  gpu.dispose();
+});

--- a/packages/vgpu-api/tests/unified-signature.test.ts
+++ b/packages/vgpu-api/tests/unified-signature.test.ts
@@ -1,6 +1,8 @@
 import { expect, test } from "vitest";
 import { getMockGPUDeviceInstrumentation } from "@vgpu/core";
-import { compute, effect, init, storage, target } from "../src/mock.ts";
+import { compute, draw, effect, init, storage, target } from "../src/mock.ts";
+import { drawReflection } from "../src/draw.ts";
+import { effectDraw } from "../src/effect.ts";
 
 const EFFECT_SHADER = `
 @fragment fn fs_main(@location(0) uv: vec2f) -> @location(0) vec4f { return vec4f(uv, 0.0, 1.0); }
@@ -34,14 +36,19 @@ test("effect(gpu, { shader, ... }) shares the exact pipeline of effect(gpu, sour
 
 test("compute(gpu, { shader, entry }) produces a Compute equivalent to compute(gpu, source, { entry })", async () => {
   const gpu = await init();
+  const instrumentation = getMockGPUDeviceInstrumentation(gpu.device.gpu);
 
   const fromTwoArgs = compute(gpu, COMPUTE_SHADER, { entry: "main", label: "job" });
-  const fromOptionsObject = compute(gpu, { shader: COMPUTE_SHADER, entry: "main", label: "job" });
-
-  const instrumentation = getMockGPUDeviceInstrumentation(gpu.device.gpu);
-  const descriptors = instrumentation.createComputePipelineDescriptors;
-  const twoArgsDesc = descriptors.find((d) => d.label === "job.pipeline");
+  const twoArgsDesc = instrumentation.createComputePipelineDescriptors.at(-1);
+  expect(twoArgsDesc?.label).toBe("job.pipeline");
   expect(twoArgsDesc?.compute.entryPoint).toBe("main");
+
+  const fromOptionsObject = compute(gpu, { shader: COMPUTE_SHADER, entry: "main", label: "job" });
+  // Assert directly on the descriptor the options-object form itself produced, not just on parity
+  // with the two-argument form's descriptor (kills a mutant that drops opts on the object-form path).
+  const objectFormDesc = instrumentation.createComputePipelineDescriptors.at(-1);
+  expect(objectFormDesc?.label).toBe("job.pipeline");
+  expect(objectFormDesc?.compute.entryPoint).toBe("main");
 
   // Both must dispatch without throwing — proves the options-object form built a working pipeline
   // with the same entry point / bindings as the two-argument form.
@@ -49,6 +56,52 @@ test("compute(gpu, { shader, entry }) produces a Compute equivalent to compute(g
   fromOptionsObject.set({ data: storage(gpu, 16) });
   expect(() => fromTwoArgs.dispatch(1)).not.toThrow();
   expect(() => fromOptionsObject.dispatch(1)).not.toThrow();
+  gpu.dispose();
+});
+
+test("effect(gpu, { shader, version, wgsl, blend }) picks shader over a spurious version/wgsl and honors sibling options", async () => {
+  const gpu = await init();
+  const colorTarget = target(gpu, { size: [2, 2] });
+  const shaderWithBinding = `
+struct Params { value: f32 }
+@group(0) @binding(0) var<uniform> params: Params;
+@fragment fn fs_main(@location(0) uv: vec2f) -> @location(0) vec4f { return vec4f(uv, params.value, 1.0); }
+`;
+  const decoyWgsl = EFFECT_SHADER;
+
+  // A real ShaderSource can never carry `shader`, so a spread like `{ ...artifact, shader, blend }`
+  // must still be recognized as the options-object form: `shader` wins over the spurious `version`/`wgsl`.
+  const fx = effect(gpu, { shader: shaderWithBinding, version: 1, wgsl: decoyWgsl, blend: "additive" } as never);
+
+  // Only `shaderWithBinding` declares the `params` uniform; if the decoy `wgsl` had won, this binding
+  // would not exist.
+  expect(drawReflection(effectDraw(fx)).bindings.map((binding) => binding.name)).toContain("params");
+
+  fx.set({ params: { value: 1 } });
+  fx.draw(colorTarget);
+  const desc = getMockGPUDeviceInstrumentation(gpu.device.gpu).createRenderPipelineDescriptors.at(-1);
+  expect(desc?.fragment?.targets?.[0]).toMatchObject({
+    blend: { color: { srcFactor: "one", dstFactor: "one", operation: "add" }, alpha: { srcFactor: "one", dstFactor: "one", operation: "add" } },
+  });
+  gpu.dispose();
+});
+
+test("compute(gpu, { shader, version, wgsl, entry, label }) picks shader over a spurious version/wgsl and honors entry/label", async () => {
+  const gpu = await init();
+  // The decoy has no `main` entry point: if `version`/`wgsl` won over `shader`, requesting `entry:
+  // "main"` against the decoy would fail to resolve an entry point at construction time.
+  const decoyWithoutMainEntry = `
+@compute @workgroup_size(1) fn other() {}
+`;
+
+  const job = compute(gpu, { shader: COMPUTE_SHADER, version: 1, wgsl: decoyWithoutMainEntry, entry: "main", label: "amb" } as never);
+  const instrumentation = getMockGPUDeviceInstrumentation(gpu.device.gpu);
+  const desc = instrumentation.createComputePipelineDescriptors.at(-1);
+  expect(desc?.label).toBe("amb.pipeline");
+  expect(desc?.compute.entryPoint).toBe("main");
+
+  job.set({ data: storage(gpu, 16) });
+  expect(() => job.dispatch(1)).not.toThrow();
   gpu.dispose();
 });
 

--- a/packages/vgpu-api/tests/uniforms/tsconfig.types.json
+++ b/packages/vgpu-api/tests/uniforms/tsconfig.types.json
@@ -7,5 +7,5 @@
     "noEmit": true,
     "allowImportingTsExtensions": true
   },
-  "include": ["../../src/**/*.ts", "shared-uniforms-types.ts", "pass-draw-overloads-types.ts"]
+  "include": ["../../src/**/*.ts", "shared-uniforms-types.ts", "pass-draw-overloads-types.ts", "unified-signature-types.ts"]
 }

--- a/packages/vgpu-api/tests/uniforms/unified-signature-types.ts
+++ b/packages/vgpu-api/tests/uniforms/unified-signature-types.ts
@@ -1,0 +1,22 @@
+import { compute, effect } from "../../src/index.ts";
+import type { Gpu } from "../../src/index.ts";
+
+declare const gpu: Gpu;
+declare const wgsl: string;
+
+// Two-argument form still type-checks (aditive overloads must not break the existing call sites).
+effect(gpu, wgsl, { blend: "additive" });
+compute(gpu, wgsl, { entry: "main" });
+
+// Single-object form type-checks when `shader` is present.
+effect(gpu, { shader: wgsl, blend: "additive" });
+compute(gpu, { shader: wgsl, entry: "main" });
+
+// Shorthand (no opts) still type-checks.
+effect(gpu, wgsl);
+compute(gpu, wgsl);
+
+// @ts-expect-error an options object without `shader` is not a valid single-argument call.
+effect(gpu, {});
+// @ts-expect-error an options object without `shader` is not a valid single-argument call.
+compute(gpu, {});


### PR DESCRIPTION
## T04-01 — additive unified-signature overload for `effect()`/`compute()`

Adds an additive single-object call form, `effect(gpu, { shader, ... })` / `compute(gpu, { shader, ... })`, alongside the existing two-argument form (`fn(gpu, source, opts)`) and the bare `string | ShaderSource` shorthand. Corpus verde: the 2-arg form is untouched, zero existing call sites change behavior. `draw()` was not touched (already final).

### Contract covered
API contract #5 (partial, additive half): "Every factory exports exactly one input options type... and no data-only twin." Retiring the 2-arg form is out of scope for this ticket (later "ola de corte").

### The dictamen: `shader` wins over a spurious `version`
`resolveShaderInput()` (new, shared in `shader-source.ts`, used by both `effect()` and `compute()`) checks `"shader" in input` **before** `"version" in input`.

Why this matters: a real `ShaderSource` artifact is exactly `{ version, wgsl }` (see `packages/wgsl/src/types.ts`) and can never legitimately carry a `shader` property. An options bag, however, can carry a stray `version` — directly, or via a spread like `{ ...artifact, shader, blend }`. My first pass had this backwards (version-wins), and QA's adversarial probes (constructing exactly that spread) proved it silently discarded `shader`/`blend`/`entry`/`label` from real options bags whenever a `version` key was also present. Checking `shader` first fixes this without changing resolution for any legitimate two-argument or shorthand call (neither a plain string nor a `ShaderSource` artifact has a `shader` property, so they never match the single-object overload).

Tests lock this down for both `effect()` and `compute()`: `{ shader: A, version: 1, wgsl: B, ...opts }` must use `A` and honor `opts`, not `B`.

### Lesson for the cut wave: overload declaration order is public API surface
QA's re-validation caught a real regression from declaring the new single-object overload **last**: `apps/docs/examples/fft-ocean-surface/scene.ts` does `Parameters<typeof compute>[1]`, and TypeScript resolves `Parameters<>`/`ReturnType<>` against the **last** declared overload — not by trying to match a call. With the single-object form last, that type silently became `ComputeOptions & { shader }` instead of `string | ShaderSource`, breaking the docs app build. This was invisible to the root `pnpm typecheck` project, since `apps/docs/examples` isn't part of it.

Fix: declare the single-object overload **first** in both `effect()` and `compute()`. Call resolution is unaffected — the single-object form requires `shader`, which neither a string nor a `ShaderSource` artifact has, so it never matches a two-argument call. Documented inline in both files.

**Takeaway for the rest of the 0.4 train:** any additive overload work should audit consumers that derive types via `Parameters<>`/`ReturnType<>` (docs examples, generated fixtures) — the root typecheck project won't catch it, and overload order is a real (if underappreciated) piece of the public API surface.

### Equivalent-mutant found and excluded (documented, not skipped)
QA's mutation harness also flagged `toWgsl`'s pre-existing (untouched by this ticket) `if (!("version" in input)) throw malformedShaderSourceError(input)` guard as "survives" when removed. Verified by differential execution (21 inputs, including Proxy and prototype-inheritance cases: byte-identical error dumps) that this guard is provably redundant with the very next line (`if (version !== 1) throw ...`, since a missing `version` key reads as `undefined !== 1`) — `malformedShaderSourceError`'s message depends only on `hasVersion(input) && input.version !== 1`, identical in both branches. This is an equivalent mutant in code this ticket didn't touch; the harness now excludes it with an automated equivalence check (re-verifies on every run; if it ever diverges, the harness fails and a real test is required).

### Bundle budgets
Reordering overloads + the new `shader?` fields on `EffectOptions`/`ComputeOptions` add bytes shared by every export surface. Merging onto the post-#324/#326 `next/0.4` (settled-queue + compute-async, itself already consuming headroom) pushed 2 hard client budgets over their ceiling:

| Budget | Old ceiling | Measured | New ceiling (next 512 B multiple) |
|---|---|---|---|
| `vgpuExportBundleBudgetsGzipBytes['.'/'./node'/'./mock']` | 38912 B | 38924 B | **39424 B** |
| `vgpuExperienceBundleBudgetsGzipBytes['full-root']` | 38912 B | 39003 B | **39424 B** |

Two tooling budgets (`vgpu/node` +178 B, `vgpu/mock` +95 B) stayed under the 5% growth threshold and were left as warnings, not re-baselined — only budgets that were actually hard-failing were bumped. This ticket's own delta across the 6 affected bundles was +88..+114 B; the rest of the merge is what actually used up the remaining headroom.

### Third-argument-on-single-object-form
`effect(gpu, { shader, ... }, opts3)` / `compute(gpu, { shader, ... }, opts3)` silently ignore `opts3` (single-object form is strictly two arguments). Documented via JSDoc on both overloads rather than adding a runtime throw, given the tight byte budget above.

### Gates (all green)
- `pnpm typecheck`
- `npx vitest run packages/vgpu-api` — 636 passed / 45 skipped (GPU-hardware-only tests) / 0 failed
- `pnpm bundle-check` — all budgets satisfied (see table above for the 2 re-baselined)
- `run-ci-jobs.sh --jobs docs-app-build` — PASS (clean-room, confirms the overload-order fix)
- QA adversarial harness (`run-qa.sh --stages all`) — rc=0: probes, semantic swap-mutation tests (6/6 caught), type-fixture mutations (2/2 caught), consumer-type check, budgets

### Files touched
- `packages/vgpu-api/src/effect.ts`, `packages/vgpu-api/src/compute.ts` — additive overloads (single-object form declared first), delegate to shared `resolveShaderInput()`.
- `packages/vgpu-api/src/shader-source.ts` — new shared `resolveShaderInput()` helper (shader-wins discriminator), used by both `effect()` and `compute()` to keep behavior/error text byte-identical.
- `packages/vgpu-api/src/api-types.ts` — `ComputeOptions.shader?`; `EffectOptions.shader?` added symmetrically in `effect.ts`.
- `packages/vgpu-api/tests/unified-signature.test.ts` (new) — runtime parity + shader-wins + actionable-error tests for both functions.
- `packages/vgpu-api/tests/uniforms/unified-signature-types.ts` (new) + `tests/uniforms/tsconfig.types.json` — type-level overload contract (`@ts-expect-error` for options bags missing `shader`).
- `packages/vgpu-api/tests/ring1-shader-source.test.ts` — updated one pre-existing expectation to match the new dispatch spec (bare `{ wgsl }` now hits the actionable "missing shader" error, not the generic malformed-shader-source one) and restored coverage of the generic error via `draw()`/`effect(gpu, null|7)`/malformed `ShaderSource`.
- `packages/vgpu-api/package.json` — budget re-baseline (table above).

Not pushed until now per train rules (adversarial QA gate before push) — full QA back-and-forth history available on request.
