### PR TITLE
feat(vgpu-api): prepare() + the pendingPipelines policy chain (T04-05)

### DIFF
--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -16,6 +16,12 @@ export interface VGPUErrorDetail {
   readonly samplerName?: string;
   readonly samplerGroup?: number;
   readonly samplerBinding?: number;
+  /**
+   * Every failed combination of a `prepare()` call — renderable label, resolved target signature
+   * (absent for a compute request, which has no target) and the underlying cause. A batch of
+   * combinations fails as a batch, so the whole list travels with the error.
+   */
+  readonly failures?: readonly { readonly label: string; readonly signature?: string; readonly cause?: unknown }[];
 }
 
 export interface VGPUErrorData {

--- a/packages/vgpu-api/package.json
+++ b/packages/vgpu-api/package.json
@@ -91,9 +91,9 @@
     "./core": "client"
   },
   "vgpuExportBundleBudgetsGzipBytes": {
-    ".": 39424,
-    "./node": 39424,
-    "./mock": 39424,
+    ".": 40960,
+    "./node": 40960,
+    "./mock": 40960,
     "./scene": 12800,
     "./client": 512,
     "./core": 3584
@@ -105,8 +105,8 @@
     "init-only": 1536,
     "effect-only": 26624,
     "triangle-low-level": 29696,
-    "draw-recipe-box": 30720,
-    "full-root": 39424
+    "draw-recipe-box": 31232,
+    "full-root": 40960
   },
   "vgpuSceneBundleBudgetNote": "The scene barrel retains all recipe builders after the geometry redesign; direct primitive imports retain only their selected mesh, as the experience fixtures assert."
 }

--- a/packages/vgpu-api/src/bundle.ts
+++ b/packages/vgpu-api/src/bundle.ts
@@ -52,6 +52,12 @@ export function createBundle(device: { readonly gpu: GPUDevice }, opts: BundleOp
 class RecordedBundle implements Bundle, BundleBackReference {
   gpu!: GPURenderBundle;
   #staleEvent?: BundleStaleEvent;
+  /**
+   * The logical recording, retained. `record()` used to take the closure and forget it, which made
+   * re-encoding structurally impossible; keeping it is what lets `prepare(gpu, [{ bundle }])`
+   * rebuild the native bundle from the same commands with the current resources.
+   */
+  #record?: (recorder: BundleRecorder) => void;
   readonly #signatureKey: string;
   readonly #draws = new Set<InternalDraw>();
 
@@ -60,6 +66,8 @@ class RecordedBundle implements Bundle, BundleBackReference {
   }
 
   record(record: (recorder: BundleRecorder) => void): void {
+    this.#record = record;
+    this.#staleEvent = undefined;
     this.gpu = createRenderBundle(this.device, {
       label: this.id,
       colorFormats: this.signature.colors,
@@ -75,6 +83,24 @@ class RecordedBundle implements Bundle, BundleBackReference {
    * bundle.ts. The recorded bundle is its own protocol object — `gpu` and the staleness check.
    */
   get [FRAME_BUNDLE](): FrameBundleProtocol { return this; }
+
+  /**
+   * Async readiness for `prepare(gpu, [{ bundle }])`, in the trimmed scope of T04-05: a bundle made
+   * stale by an identity change is re-encoded here from the retained recording, and a bundle that is
+   * not stale is left exactly as it is (no work, same native bundle).
+   *
+   * The pipelines its draws need are compiled by the recording itself, through the ordinary encode
+   * path. What this does NOT do is the rest of contract #15 — there is no public `status`, `error`,
+   * `rebuild()` or `dispose()` yet, and a signature mismatch still throws `VGPU-R3-BUNDLE-STALE` at
+   * replay instead of auto-healing: re-recording against a different target is a different target's
+   * recording, which belongs to the bundle state machine of wave 2+.
+   *
+   * @internal
+   */
+  prepareCombination(): void {
+    if (!this.#staleEvent || !this.#record) return;
+    this.record(this.#record);
+  }
 
   markStale(event: BundleStaleEvent): void {
     if (recordingDepth > 0) return;
@@ -113,6 +139,22 @@ class ExplicitBundleRecorder implements BundleRecorder {
     this.bundle.remember(draw);
     encodeDraw(draw, this.encoder, this.bundle.signature, opts);
   }
+}
+
+/**
+ * Re-encodes `bundle` if it is stale and reports the handle `prepare()` hands back.
+ *
+ * @internal
+ */
+export function prepareBundle(bundle: Bundle): { readonly signature: TargetSignature; readonly gpu: GPURenderBundle } {
+  if (!(bundle instanceof RecordedBundle)) throw new VGPUError({
+    code: "VGPU-BUNDLE-FOREIGN",
+    message: "prepare({ bundle }) received an object this library did not record.",
+    fix: "Pass the bundle returned by bundle(gpu, { target }, record).",
+    where: "prepare",
+  });
+  bundle.prepareCombination();
+  return { signature: bundle.signature, gpu: bundle.gpu };
 }
 
 function normalizeBundleSignature(target: CompileTarget): TargetSignature {

--- a/packages/vgpu-api/src/compute.ts
+++ b/packages/vgpu-api/src/compute.ts
@@ -147,6 +147,20 @@ export class ComputePipeline implements Compute {
     this.device.gpu.queue.submit([encoder.finish()]);
   }
 
+  /**
+   * Async readiness for one compute kernel, for `prepare(gpu, [{ compute }])`.
+   *
+   * Deliberately the very same `#ensurePipelineAsync()` `dispatchOnce()` uses — same dedupe of
+   * concurrent callers, same reuse of a pipeline a previous `dispatch()` already compiled, same
+   * anti-poisoning on failure. `prepare()` is a second door to that door, never a second compile.
+   *
+   * @internal
+   */
+  prepareCombination(): Promise<GPUComputePipeline> {
+    assertDeviceUsable(this.device, `${this.label}.prepare`);
+    return this.#ensurePipelineAsync();
+  }
+
   /** Compiles the pipeline synchronously the first time it is needed, then memoizes it for every later call. */
   #ensurePipeline(): GPUComputePipeline {
     if (!this.#pipeline) this.#pipeline = this.device.gpu.createComputePipeline(this.#pipelineDescriptor);

--- a/packages/vgpu-api/src/draw.ts
+++ b/packages/vgpu-api/src/draw.ts
@@ -9,6 +9,7 @@ import { createSetCore, type BindingIdentityChange, type BindingState, type SetB
 import { bindGroupLayoutEntriesForGroup, bindGroupLayoutsForReflection, cachedBindGroupLayout, visibilityForEntries, type BindingVisibilityFn } from "./set-layouts.ts";
 import type { CompileTarget, Target, TargetSignature } from "./target.ts";
 import { normalizeConstantsOptions, normalizeSignature, pipelineKeyOf, selectEntryPoint, signatureKeyOf, validateTargetSignature, createPipelineLayoutCache, createPipelineStore, createShaderModuleCache, type PipelineLayoutCache, type PipelineStore, type ShaderModuleCache } from "./pipeline-store.ts";
+import type { PendingPipelines } from "./pending-pipelines.ts";
 import { hasStencilAspect, isTarget } from "./target-utils.ts";
 import { blendConstantInvalidError, blendInvalidError, claimedGroupNativeValidationError, colorsInvalidError, cullInvalidError, depthInvalidError, entryInvalidError, frontFaceInvalidError, indirectInvalidError, meshRangeInvalidError, multisampleInvalidError, stencilInvalidError, storageStageLimitError, surfaceNotInFrameError, targetRequiredError, unclippedDepthInvalidError, VGPUError, writeMaskInvalidError } from "./errors.ts";
 import { isFrameActive, isSurface } from "./surface.ts";
@@ -166,6 +167,15 @@ export interface DrawCallOptions {
   readonly firstInstance?: number;
   /** GPU-driven draw: read draw arguments from a buffer instead of CPU-side counts. */
   readonly indirect?: StorageBuffer | { readonly buffer: StorageBuffer; readonly offset?: number };
+  /**
+   * Call-site link of the `pendingPipelines` chain (call site → frame → gpu): what this single
+   * encode does when its `(draw, target signature)` combination has no compiled pipeline yet.
+   * Omit it and the frame's policy applies, then the gpu's `init({ pendingPipelines })` default.
+   *
+   * The policy is normally set once, at `init()` or per frame; this per-call form exists for the
+   * exceptions (one streamed mesh that may be skipped, one draw that must never stall).
+   */
+  readonly pendingPipelines?: PendingPipelines;
 }
 
 export interface DrawLayoutOptions {
@@ -447,7 +457,7 @@ export class InternalDraw implements Draw {
 
   encode(pass: GPURenderPassEncoder, target: Target | TargetSignature, opts: DrawCallOptions = {}, claimValidation?: (result: ClaimedGroupValidationResult) => void): void {
     assertDeviceUsable(drawState(this).device, `${this.label}.encode`);
-    const pipeline = this.pipelineFor(target, true);
+    const pipeline = this.#pipelineForEncode(target, opts.pendingPipelines);
     if (!pipeline) return;
     pass.setPipeline(pipeline);
     const state = drawState(this);
@@ -472,6 +482,29 @@ export class InternalDraw implements Draw {
     }
     const result = popLastClaimedGroupValidationScope(drawState(this).device);
     if (result) claimValidation(result);
+  }
+
+  /**
+   * Pipeline this encode should bind, under the resolved `pendingPipelines` policy.
+   *
+   * `opts.pendingPipelines` is the call-site link and the frame's is already folded into it by
+   * `FramePass.draw`; `undefined` hands the decision to the store's gpu-wide default. `undefined`
+   * comes back for `"skip"` (omit this command) — the exact same "no pipeline, encode nothing"
+   * shape `pipelineFor()` already returned for a failed sync compile.
+   *
+   * `where` stays `${label}.pipelineFor`: the legacy spelling is no longer called from here, but a
+   * sync compile failure raised on this path must keep reporting the same `where` it always did.
+   */
+  #pipelineForEncode(target: Target | TargetSignature, policy: PendingPipelines | undefined): GPURenderPipeline | undefined {
+    const state = drawState(this);
+    const where = `${this.label}.pipelineFor`;
+    const { key, signature, signatureKey } = this.#compileKey(target, where);
+    const pipeline = state.pipelineStore.getForPolicy(key, policy, {
+      sync: () => this.#createPipeline(signature),
+      async: () => this.#createPipelineAsync(signature),
+    }, { where, signature: signatureKey, label: this.label });
+    if (pipeline) state.resolvedPipelineKeys.add(key);
+    return pipeline;
   }
 
   compile(target?: CompileTarget): Promise<this> {
@@ -500,10 +533,10 @@ export class InternalDraw implements Draw {
   pipelineFor(target: Target | TargetSignature, allowSurface = false): GPURenderPipeline | undefined {
     void allowSurface;
     assertDeviceUsable(drawState(this).device, `${this.label}.pipelineFor`);
-    const { key, signature, signatureKey } = this.#compileKey(target, `${this.label}.pipelineFor`);
-    const pipeline = drawState(this).pipelineStore.getSync(key, () => this.#createPipeline(signature), { where: `${this.label}.pipelineFor`, signature: signatureKey });
-    if (pipeline) drawState(this).resolvedPipelineKeys.add(key);
-    return pipeline;
+    // The legacy spelling IS the "sync" policy: compile inline, return undefined when the compile
+    // failed. Routing it through the same resolver keeps one implementation of "resolve this
+    // combination for a synchronous caller" instead of two that can drift.
+    return this.#pipelineForEncode(target, "sync");
   }
 
   pipelineForAsync(target: Target | TargetSignature): Promise<GPURenderPipeline> {

--- a/packages/vgpu-api/src/errors.ts
+++ b/packages/vgpu-api/src/errors.ts
@@ -463,6 +463,51 @@ export function compileFailedError(where: string, cause: unknown, signature?: st
   });
 }
 
+/**
+ * A synchronous encode met a `(renderable, target signature)` combination whose pipeline is not
+ * ready, under `pendingPipelines: "throw"`. Nothing was compiled and nothing was encoded: the whole
+ * point of the policy is that a compilation stall is a choice, never an accident.
+ */
+export function pipelinePendingError(where: string, label: string, signature: string | undefined): VGPUError {
+  return new VGPUError({
+    code: "VGPU-PIPELINE-PENDING",
+    message: `'${label}' has no pipeline ready for target signature ${signature ?? "(unresolved)"}, and pendingPipelines is "throw", so this encode did not start compilation.`,
+    fix: "await prepare(gpu, [{draw, target}]) before drawing, or opt in to inline compilation with pendingPipelines: 'sync'",
+    where,
+    detail: signature ? { signature } : undefined,
+  });
+}
+
+/** One failed combination of a `prepare()` call: the renderable's label, its resolved signature and why it failed. */
+export interface PrepareFailure {
+  readonly label: string;
+  /** Resolved target signature key; absent for a `{compute}` request, which has no target. */
+  readonly signature?: string;
+  readonly cause: unknown;
+}
+
+/**
+ * `prepare()` rejects instead of resolving with broken handles, and it enumerates EVERY failed
+ * combination — not just the first — because a batch of combinations fails as a batch. Combinations
+ * that did compile stay cached, so re-preparing the succeeding subset is free.
+ */
+export function prepareFailedError(failures: readonly PrepareFailure[]): VGPUError {
+  const lines = failures.map((failure) => `  - '${failure.label}'${failure.signature ? ` @ ${failure.signature}` : ""}: ${failureReason(failure.cause)}`);
+  return new VGPUError({
+    code: "VGPU-PREPARE-FAILED",
+    message: `prepare() failed for ${failures.length} combination(s):\n${lines.join("\n")}`,
+    fix: "Fix the reported shaders/target signatures; prepare() always retries, and the combinations that did compile stay cached.",
+    where: "prepare",
+    cause: failures[0]?.cause,
+    detail: { failures: failures.map(({ label, signature, cause }) => ({ label, signature, cause })) },
+  });
+}
+
+function failureReason(cause: unknown): string {
+  if (cause instanceof Error) return `${(cause as VGPUError).code ? `${(cause as VGPUError).code}: ` : ""}${cause.message}`;
+  return String(cause);
+}
+
 export function compileDisposedError(where: string): VGPUError {
   return new VGPUError({
     code: "VGPU-COMPILE-DISPOSED",

--- a/packages/vgpu-api/src/frame.ts
+++ b/packages/vgpu-api/src/frame.ts
@@ -15,6 +15,7 @@ import { FRAME_PASS_ATTACHMENT, frameBundleOf, frameDrawableOf, framePassAttachm
 import { frameState } from "./frame-state.ts";
 import { liveKernel } from "./live-kernel.ts";
 import { serviceToken, type Gpu, type Kernel } from "./kernel.ts";
+import type { PendingPipelines } from "./pending-pipelines.ts";
 
 /**
  * Opens a frame on `gpu`: advances the frame clock, runs `cb` against a fresh command encoder and
@@ -25,8 +26,21 @@ import { serviceToken, type Gpu, type Kernel } from "./kernel.ts";
  * Frames are not reentrant: opening one from inside another (or from a surface resize callback)
  * throws `VGPU-FRAME-REENTRANT`.
  */
-export function frame(gpu: Gpu, cb?: (frame: Frame) => void): Frame {
-  return frameRunner(liveKernel(gpu, "frame")).frame(cb);
+export function frame(gpu: Gpu, cb?: (frame: Frame) => void, opts: FrameOptions = {}): Frame {
+  return frameRunner(liveKernel(gpu, "frame")).frame(cb, opts);
+}
+
+/** Per-frame options. Additive: `frame(gpu, cb)` keeps behaving exactly as before. */
+export interface FrameOptions {
+  /**
+   * Frame link of the `pendingPipelines` chain (call site → frame → gpu): the policy every encode
+   * in this frame uses unless it names its own. Omit it and the gpu-wide `init({ pendingPipelines })`
+   * default applies.
+   *
+   * This is the link the design expects most applications to use: set the policy once per frame
+   * (e.g. `"skip"` while streaming assets in, the default everywhere else).
+   */
+  readonly pendingPipelines?: PendingPipelines;
 }
 
 /**
@@ -48,9 +62,9 @@ function frameRunner(kernel: Kernel): FrameRunner {
   return kernel.service(frameRunnerToken, (self) => {
     const state = frameState(self);
     return new FrameRunner(
-      () => {
+      (opts) => {
         let release = () => {};
-        const frame = new Frame(self.device, undefined, (error) => self.reportError(error), (promise) => { void self.trackDelivery(promise); }, () => release());
+        const frame = new Frame(self.device, undefined, (error) => self.reportError(error), (promise) => { void self.trackDelivery(promise); }, () => release(), opts?.pendingPipelines);
         release = self.own("scheduler", () => frame.cancel());
         return frame;
       },
@@ -88,7 +102,7 @@ export interface FramePassOptions {
 }
 
 export interface FrameLoopHandle { stop(): void }
-export interface FrameLoopOptions { readonly fps?: number }
+export interface FrameLoopOptions extends FrameOptions { readonly fps?: number }
 export type FrameLoopCallback = (frame: Frame) => void;
 
 export class Frame {
@@ -124,6 +138,8 @@ export class Frame {
     private readonly errorSink?: ValidationErrorSink,
     private readonly trackSettled?: (promise: Promise<unknown>) => void,
     private readonly releaseLifecycle?: () => void,
+    /** Frame link of the pendingPipelines chain; every pass of this frame hands it to its draws. */
+    private readonly pendingPipelines?: PendingPipelines,
   ) {
     assertDeviceUsable(device, "Frame.constructor");
     this.#encoder = device.gpu.createCommandEncoder({ label: "vgpu.frame" });
@@ -212,7 +228,7 @@ export class Frame {
           // re-checks the device here instead of taking it as a separate constructor argument.
           assertDeviceUsable(this.device, where);
           if (this.#canceled) throw frameCanceledError(where);
-        }));
+        }, this.pendingPipelines));
       } finally {
         this.#passActive = false;
       }
@@ -388,12 +404,16 @@ export class Frame {
 
 export class FramePass {
   #occlusionActive = false;
-  constructor(private readonly encoder: GPURenderPassEncoder, readonly target: Target, private readonly validations: ClaimedGroupValidationResult[], private readonly depthReadOnly = false, private readonly occlusionSource?: FrameOcclusionSource, private readonly frame?: Frame, private readonly assertFrameOpen?: (where: string) => void) {}
+  constructor(private readonly encoder: GPURenderPassEncoder, readonly target: Target, private readonly validations: ClaimedGroupValidationResult[], private readonly depthReadOnly = false, private readonly occlusionSource?: FrameOcclusionSource, private readonly frame?: Frame, private readonly assertFrameOpen?: (where: string) => void, private readonly pendingPipelines?: PendingPipelines) {}
   draw(drawable: Draw | Effect, opts: DrawCallOptions = {}): void {
     this.assertFrameOpen?.("FramePass.draw");
     const encodable = frameDrawable(drawable);
     if (this.depthReadOnly) assertDrawableAllowedInReadOnlyPass(encodable, this.target);
-    encodable.encode(this.encoder, this.target, opts, (result) => this.validations.push(result));
+    // Two links of the pendingPipelines chain collapse here: the call site wins, and the frame's
+    // policy fills in for the calls that named none. The gpu-wide default is applied further down,
+    // by the pipeline store, so an encode that reaches it with `undefined` still resolves correctly.
+    const resolved = opts.pendingPipelines === undefined && this.pendingPipelines !== undefined ? { ...opts, pendingPipelines: this.pendingPipelines } : opts;
+    encodable.encode(this.encoder, this.target, resolved, (result) => this.validations.push(result));
   }
   /**
    * Wraps one or more draws in begin/endOcclusionQuery. The body ALWAYS executes; condition your
@@ -538,14 +558,14 @@ export class FrameRunner {
    * returns the untrack function the handle runs when it stops on its own, so `gpu.dispose()` can
    * stop the loops still running without holding on to the ones already stopped.
    */
-  constructor(private readonly createFrame: () => Frame, private readonly advance: () => void, private readonly trackLoop?: (handle: FrameLoopHandle) => () => void) {}
-  frame(cb?: (frame: Frame) => void): Frame {
+  constructor(private readonly createFrame: (opts?: FrameOptions) => Frame, private readonly advance: () => void, private readonly trackLoop?: (handle: FrameLoopHandle) => () => void) {}
+  frame(cb?: (frame: Frame) => void, opts?: FrameOptions): Frame {
     if (this.#running || isSurfaceResizeCallbackActive()) throw frameReentrantError();
     this.#running = true;
     enterFrame();
     try {
       this.advance();
-      const frame = this.createFrame();
+      const frame = this.createFrame(opts);
       if (cb) {
         try { cb(frame); }
         finally {
@@ -575,7 +595,7 @@ export class FrameRunner {
       if (stopped) return;
       if (shouldRunFrame(timestamp, lastFrameMs, minIntervalMs)) {
         lastFrameMs = timestamp;
-        this.frame(cb);
+        this.frame(cb, opts);
       }
       // The callback may dispose the owning gpu, which stops this loop while the current tick is
       // running. Do not enqueue one last (no-op) tick after stop() already canceled the old id.

--- a/packages/vgpu-api/src/index.ts
+++ b/packages/vgpu-api/src/index.ts
@@ -5,7 +5,7 @@ export type { Bundle, BundleOptions, BundleRecorder, Compute, ComputeOptions, Di
 export type { BlendComponentOptions, BlendOptions, BlendPreset, DepthOptions, Draw, DrawOptions, DrawCallOptions, DrawLayoutOptions, GeometryLike, StencilFaceOptions, StencilOptions } from "./draw.ts";
 export { Geometry } from "./scene/geometry-descriptor.ts";
 export type { GeometryAttributeOverride, GeometryAttributes, GeometryBuffer, GeometryBufferOptions, GeometryData, GeometryOptions, GeometrySlice, GeometrySliceOptions } from "./scene/geometry-descriptor.ts";
-export type { Frame, FramePass, FramePassOptions, FrameLoopHandle, FrameLoopOptions, FrameRunner } from "./frame.ts";
+export type { Frame, FrameOptions, FramePass, FramePassOptions, FrameLoopHandle, FrameLoopOptions, FrameRunner } from "./frame.ts";
 export type { Effect, EffectOptions } from "./effect.ts";
 export type { CompileTarget, Target, TargetOptions, TargetSignature, TargetTextureOptions } from "./target.ts";
 export { VGPUError } from "./errors.ts";
@@ -26,6 +26,9 @@ export { effect } from "./effect.ts";
 export { frame, frameLoop } from "./frame.ts";
 export type { FrameLoopCallback } from "./frame.ts";
 export { pingPong, pingPongStorage } from "./ping-pong.ts";
+export { prepare } from "./prepare.ts";
+export type { PrepareRequest, PreparedBundle, PreparedCompute, PreparedDraw, PreparedFor } from "./prepare.ts";
+export type { PendingPipelines } from "./pending-pipelines.ts";
 export { sampler } from "./sampler.ts";
 export { storage } from "./storage.ts";
 export { surface } from "./surface.ts";

--- a/packages/vgpu-api/src/kernel.ts
+++ b/packages/vgpu-api/src/kernel.ts
@@ -10,6 +10,7 @@
  */
 import { Device, validateRequiredFeatures, type RequiredDeviceLimits, type VGPUAdapter } from "@vgpu/core";
 import type { GpuErrorListener } from "./api-types.ts";
+import { DEFAULT_PENDING_PIPELINES, type PendingPipelines } from "./pending-pipelines.ts";
 import { submittedWorkDone } from "./submitted-work-done.ts";
 import { unsupportedError, VGPUError } from "./errors.ts";
 
@@ -32,6 +33,16 @@ export interface InitOptions {
   readonly requiredFeatures?: readonly GPUFeatureName[];
   readonly requiredLimits?: RequiredDeviceLimits;
   readonly label?: string;
+  /**
+   * Gpu-wide default of the `pendingPipelines` policy: what a synchronous encode does when it meets
+   * a `(renderable, target signature)` combination whose pipeline is not ready yet. The policy is
+   * resolved call site → frame → here.
+   *
+   * Omitted, it resolves to {@link DEFAULT_PENDING_PIPELINES} — `"sync"` during the 0.4 train
+   * (T04-05, index invariant 2), which is the eager-compile behavior every existing program already
+   * relies on. The frozen design's `"throw"` default lands in the cut wave, with the codemods.
+   */
+  readonly pendingPipelines?: PendingPipelines;
 }
 
 export type AdapterFactory = () => VGPUAdapter;
@@ -88,6 +99,11 @@ export interface Kernel {
   readonly device: Device;
   readonly disposed: boolean;
   /**
+   * Gpu-wide `pendingPipelines` default resolved at `init()`; the last link of the
+   * call site → frame → gpu chain. `"sync"` unless `init({ pendingPipelines })` said otherwise.
+   */
+  pendingPipelinesDefault(): PendingPipelines;
+  /**
    * Lazily creates (and memoizes) the service behind `token`. The factory lives in the calling
    * feature module, so the kernel never references it statically.
    */
@@ -130,9 +146,11 @@ class KernelImpl implements Kernel {
   readonly #settledSources = new Set<SettledSource>();
   #disposed = false;
 
-  constructor(readonly device: Device) {}
+  constructor(readonly device: Device, private readonly pendingPipelines: PendingPipelines = DEFAULT_PENDING_PIPELINES) {}
 
   get disposed(): boolean { return this.#disposed; }
+
+  pendingPipelinesDefault(): PendingPipelines { return this.pendingPipelines; }
 
   service<T>(token: ServiceToken<T>, factory: (kernel: Kernel) => T): T {
     const existing = this.#services.get(token as ServiceToken<unknown>);
@@ -211,8 +229,8 @@ class KernelImpl implements Kernel {
 }
 
 /** Builds the minimal `Gpu` for an already-created device and registers its kernel. */
-export function attachKernel(device: Device): Gpu {
-  const kernel = new KernelImpl(device);
+export function attachKernel(device: Device, opts: Pick<InitOptions, "pendingPipelines"> = {}): Gpu {
+  const kernel = new KernelImpl(device, opts.pendingPipelines ?? DEFAULT_PENDING_PIPELINES);
   const gpu: Gpu = {
     device,
     gpu: device.gpu,
@@ -227,7 +245,7 @@ export function attachKernel(device: Device): Gpu {
 
 /** Entry-agnostic core constructor: resolve a device, wrap it in the minimal `Gpu`. */
 export async function createCoreGpu(entry: EntryKind, opts: InitOptions = {}, adapterFactory?: AdapterFactory): Promise<Gpu> {
-  return attachKernel(await createDevice(entry, opts, adapterFactory));
+  return attachKernel(await createDevice(entry, opts, adapterFactory), opts);
 }
 
 export async function createDevice(entry: EntryKind, opts: InitOptions, adapterFactory?: AdapterFactory): Promise<Device> {

--- a/packages/vgpu-api/src/mock.ts
+++ b/packages/vgpu-api/src/mock.ts
@@ -9,7 +9,7 @@ export type { Bundle, BundleOptions, BundleRecorder, Compute, ComputeOptions, Di
 export type { BlendComponentOptions, BlendOptions, BlendPreset, DepthOptions, Draw, DrawOptions, DrawCallOptions, DrawLayoutOptions, GeometryLike, StencilFaceOptions, StencilOptions } from "./draw.ts";
 export { Geometry } from "./scene/geometry-descriptor.ts";
 export type { GeometryAttributeOverride, GeometryAttributes, GeometryBuffer, GeometryBufferOptions, GeometryData, GeometryOptions, GeometrySlice, GeometrySliceOptions } from "./scene/geometry-descriptor.ts";
-export type { Frame, FramePass, FramePassOptions, FrameLoopHandle, FrameLoopOptions, FrameRunner } from "./frame.ts";
+export type { Frame, FrameOptions, FramePass, FramePassOptions, FrameLoopHandle, FrameLoopOptions, FrameRunner } from "./frame.ts";
 export type { Effect, EffectOptions } from "./effect.ts";
 export type { CompileTarget, Target, TargetOptions, TargetSignature, TargetTextureOptions } from "./target.ts";
 export { VGPUError } from "./errors.ts";
@@ -30,6 +30,9 @@ export { effect } from "./effect.ts";
 export { frame, frameLoop } from "./frame.ts";
 export type { FrameLoopCallback } from "./frame.ts";
 export { pingPong, pingPongStorage } from "./ping-pong.ts";
+export { prepare } from "./prepare.ts";
+export type { PrepareRequest, PreparedBundle, PreparedCompute, PreparedDraw, PreparedFor } from "./prepare.ts";
+export type { PendingPipelines } from "./pending-pipelines.ts";
 export { sampler } from "./sampler.ts";
 export { storage } from "./storage.ts";
 export { surface } from "./surface.ts";

--- a/packages/vgpu-api/src/node.ts
+++ b/packages/vgpu-api/src/node.ts
@@ -7,7 +7,7 @@ export type { Bundle, BundleOptions, BundleRecorder, Compute, ComputeOptions, Di
 export type { BlendComponentOptions, BlendOptions, BlendPreset, DepthOptions, Draw, DrawOptions, DrawCallOptions, DrawLayoutOptions, GeometryLike, StencilFaceOptions, StencilOptions } from "./draw.ts";
 export { Geometry } from "./scene/geometry-descriptor.ts";
 export type { GeometryAttributeOverride, GeometryAttributes, GeometryBuffer, GeometryBufferOptions, GeometryData, GeometryOptions, GeometrySlice, GeometrySliceOptions } from "./scene/geometry-descriptor.ts";
-export type { Frame, FramePass, FramePassOptions, FrameLoopHandle, FrameLoopOptions, FrameRunner } from "./frame.ts";
+export type { Frame, FrameOptions, FramePass, FramePassOptions, FrameLoopHandle, FrameLoopOptions, FrameRunner } from "./frame.ts";
 export type { Effect, EffectOptions } from "./effect.ts";
 export type { CompileTarget, Target, TargetOptions, TargetSignature, TargetTextureOptions } from "./target.ts";
 export { VGPUError } from "./errors.ts";
@@ -30,6 +30,9 @@ export { effect } from "./effect.ts";
 export { frame, frameLoop } from "./frame.ts";
 export type { FrameLoopCallback } from "./frame.ts";
 export { pingPong, pingPongStorage } from "./ping-pong.ts";
+export { prepare } from "./prepare.ts";
+export type { PrepareRequest, PreparedBundle, PreparedCompute, PreparedDraw, PreparedFor } from "./prepare.ts";
+export type { PendingPipelines } from "./pending-pipelines.ts";
 export { sampler } from "./sampler.ts";
 export { storage } from "./storage.ts";
 export { surface } from "./surface.ts";

--- a/packages/vgpu-api/src/pending-pipelines.ts
+++ b/packages/vgpu-api/src/pending-pipelines.ts
@@ -1,0 +1,32 @@
+/**
+ * The one compilation policy shared by every synchronous encode context.
+ *
+ * A render pipeline cannot exist without a target signature, so readiness is a property of a
+ * *combination* — `(renderable, target signature)` — never of an object. When a synchronous encode
+ * meets a combination whose pipeline is not ready yet, this policy decides what happens:
+ *
+ * - `"throw"`: does **not** start compilation and throws `VGPU-PIPELINE-PENDING` immediately.
+ * - `"skip"`: starts (or continues) async compilation in the background, omits the command this
+ *   frame, and never throws per frame.
+ * - `"sync"`: performs immediate pipeline creation inline — the only synchronous-compilation
+ *   opt-in, and the only one that can stall.
+ *
+ * The value is resolved **call site → frame → gpu** (`DrawCallOptions.pendingPipelines` →
+ * `frame(gpu, cb, { pendingPipelines })` / `FrameLoopOptions` → `init({ pendingPipelines })`).
+ *
+ * This module is types plus one constant on purpose: `kernel.ts` must not import a feature module,
+ * and every consumer (draw, frame, pipeline store, prepare) needs the same vocabulary.
+ */
+export type PendingPipelines = "throw" | "skip" | "sync";
+
+/**
+ * Effective default of the whole train (T04-05, index invariant 2): **`"sync"`, not `"throw"`**.
+ *
+ * The frozen design (AC #3) mandates `"throw"` as the final default, and this branch implements the
+ * complete mechanism — three values, full call site → frame → gpu resolution chain. What it does
+ * NOT do is flip the default: zero call sites have migrated to `prepare()` yet, so `"throw"` would
+ * break every existing program at once. `"sync"` is exactly the eager-compile behavior the corpus
+ * has today, which keeps this wave purely additive. The flip to `"throw"` belongs to the cut wave,
+ * together with the codemods that migrate the call sites.
+ */
+export const DEFAULT_PENDING_PIPELINES: PendingPipelines = "sync";

--- a/packages/vgpu-api/src/pipeline-store.ts
+++ b/packages/vgpu-api/src/pipeline-store.ts
@@ -2,11 +2,14 @@ import { bindGroupLayoutMetadata, type Device } from "@vgpu/core";
 import type { EntryPointInfo, OverrideInfo } from "@vgpu/wgsl/reflect-source";
 import type { Target, CompileTarget, TargetSignature } from "./target.ts";
 import { isTarget } from "./target-utils.ts";
-import { compileDisposedError, compileFailedError, compileSignatureInvalidError, constantsInvalidError, entryInvalidError, pipelineLayoutGapError, type VGPUError } from "./errors.ts";
+import { compileDisposedError, compileFailedError, compileSignatureInvalidError, constantsInvalidError, entryInvalidError, pipelineLayoutGapError, pipelinePendingError, type VGPUError } from "./errors.ts";
+import { DEFAULT_PENDING_PIPELINES, type PendingPipelines } from "./pending-pipelines.ts";
 
 export interface ErrorCtx {
   readonly where: string;
   readonly signature?: string;
+  /** Renderable label, used by the policy errors that name the combination to the caller. */
+  readonly label?: string;
 }
 
 export type ErrorSink = (error: VGPUError) => void | Promise<void>;
@@ -22,10 +25,29 @@ export type PipelineEntry = {
   };
 };
 
+/** The two ways one combination can be compiled, handed to {@link PipelineStore.getForPolicy} together. */
+export interface PipelineCreators {
+  readonly sync: () => GPURenderPipeline;
+  readonly async: () => Promise<GPURenderPipeline>;
+}
+
 export interface PipelineStore {
   getReady(key: string): GPURenderPipeline | undefined;
   getSync(key: string, create: () => GPURenderPipeline, ctx: ErrorCtx): GPURenderPipeline | undefined;
   getAsync(key: string, create: () => Promise<GPURenderPipeline>, ctx: ErrorCtx): Promise<GPURenderPipeline>;
+  /**
+   * Resolves one combination for a SYNCHRONOUS encode under the `pendingPipelines` policy.
+   *
+   * `policy` is the already-resolved call site → frame link of the chain; `undefined` means "nobody
+   * asked", and the store applies the gpu-wide default it was created with (the last link). A
+   * pipeline that is already ready is returned under every policy — the policy only decides what
+   * happens when it is NOT ready:
+   * - `"sync"`: compiles inline (exactly `getSync`, today's behavior).
+   * - `"throw"`: throws `VGPU-PIPELINE-PENDING` and starts nothing.
+   * - `"skip"`: starts (or continues) the async compile in the background and returns `undefined`,
+   *   which the caller reads as "omit this command this frame".
+   */
+  getForPolicy(key: string, policy: PendingPipelines | undefined, create: PipelineCreators, ctx: ErrorCtx): GPURenderPipeline | undefined;
   dispose(): void;
 }
 
@@ -42,6 +64,8 @@ export interface PipelineLayoutCache {
 export interface PipelineStoreOptions {
   readonly errorSink?: ErrorSink;
   readonly registerSettledSource?: RegisterSettledSource;
+  /** Gpu-wide `pendingPipelines` default (the last link of the chain). Defaults to {@link DEFAULT_PENDING_PIPELINES}. */
+  readonly pendingPipelines?: PendingPipelines;
 }
 
 let nextShaderModuleId = 1;
@@ -248,11 +272,22 @@ class DevicePipelineStore implements PipelineStore {
   readonly #entries = new Map<string, PipelineEntry>();
   readonly #tracked = new Set<Promise<unknown>>();
   readonly #errorSink: ErrorSink;
+  readonly #pendingPipelines: PendingPipelines;
+  /**
+   * Keys whose background ("skip") compile failed. A deterministic failure — an invalid shader —
+   * would otherwise be re-reported on every single frame that skips it, so the failure is delivered
+   * to `gpu.onError` exactly once and the key keeps being skipped silently afterwards.
+   *
+   * This set is consulted ONLY on the `"skip"` path: `prepare()` goes through `getAsync`, so it
+   * always retries a failed combination and can never be poisoned by a skip failure.
+   */
+  readonly #skipFailures = new Set<string>();
   readonly #unregisterSettledSource?: () => void;
   #disposed = false;
 
   constructor(private readonly device: Device, opts: PipelineStoreOptions) {
     this.#errorSink = opts.errorSink ?? (() => undefined);
+    this.#pendingPipelines = opts.pendingPipelines ?? DEFAULT_PENDING_PIPELINES;
     this.#unregisterSettledSource = opts.registerSettledSource?.(() => [...this.#tracked]);
   }
 
@@ -316,9 +351,36 @@ class DevicePipelineStore implements PipelineStore {
     return pending.promise;
   }
 
+  getForPolicy(key: string, policy: PendingPipelines | undefined, create: PipelineCreators, ctx: ErrorCtx): GPURenderPipeline | undefined {
+    this.#assertUsable(ctx.where);
+    const ready = this.#entries.get(key)?.pipeline;
+    if (ready) return ready;
+    const resolved = policy ?? this.#pendingPipelines;
+    if (resolved === "sync") return this.getSync(key, create.sync, ctx);
+    if (resolved === "throw") throw pipelinePendingError(ctx.label ? `${ctx.label}.draw` : ctx.where, ctx.label ?? ctx.where, ctx.signature);
+    this.#startBackgroundCompile(key, create.async, ctx);
+    return undefined;
+  }
+
+  /**
+   * Starts the `"skip"` compile, or lets an in-flight one continue: `getAsync` already dedupes by
+   * key, and a key that already failed once is not retried here (see {@link #skipFailures}). The
+   * whole chain — compile plus error delivery — joins `gpu.settled()`, so a test that awaits it sees
+   * the failure recorded, not a half-delivered one.
+   */
+  #startBackgroundCompile(key: string, create: () => Promise<GPURenderPipeline>, ctx: ErrorCtx): void {
+    if (this.#skipFailures.has(key) || this.#entries.get(key)?.pending) return;
+    const chain = this.getAsync(key, create, ctx).then(() => undefined, (error: unknown) => {
+      this.#skipFailures.add(key);
+      return this.#errorSink(error as VGPUError);
+    });
+    this.#track(chain);
+  }
+
   dispose(): void {
     if (this.#disposed) return;
     this.#disposed = true;
+    this.#skipFailures.clear();
     const error = compileDisposedError("gpu.dispose");
     for (const entry of this.#entries.values()) entry.pending?.reject(error);
     this.#entries.clear();

--- a/packages/vgpu-api/src/prepare.ts
+++ b/packages/vgpu-api/src/prepare.ts
@@ -1,0 +1,144 @@
+/**
+ * `prepare()` — the one spelling for readiness.
+ *
+ * **Readiness is a property of a combination, never of an object.** The unit of preparation is
+ * `(renderable, target signature)`: a `Draw` can be ready for the screen, uncompiled for an HDR
+ * target and failed for a `depth24plus-stencil8` target at the same time. No `Draw`/`Effect`/
+ * `Compute` carries `ready`/`pending`/`failed` fields, and no per-target status map is exposed:
+ * `prepare()` **is** the query — idempotent, O(1) on an already-prepared combination, and it
+ * rejects with the failure. Every other pipeline-affecting input (geometry vertex layout,
+ * topology/strip format, cull/front face, depth/stencil/multisample/blend state, pipeline
+ * constants, entry points) is fixed at construction of the renderable, so `(renderable, signature)`
+ * is a complete key — that is why `prepare()` needs no `geometry:` or state axis. The internal
+ * pipeline cache key is **not** public API (it embeds process-local module/layout ids).
+ *
+ * **`prepare()` request keys mirror the encode call they warm.** `p.draw(Draw | Effect)` →
+ * `{ draw, target }`; `f.compute(c)` → `{ compute }`; `p.bundles(b)` → `{ bundle }`. There is no
+ * `{ effect }` branch (the `draw:` key takes `Draw | Effect`, exactly like `p.draw()`) and no
+ * `render:` spelling (no encode API is called `render` at object granularity). A `{ bundle }`
+ * request carries no `target` — a bundle froze its target signature at construction.
+ */
+import { prepareBundle } from "./bundle.ts";
+import { ComputePipeline } from "./compute.ts";
+import type { Draw, InternalDraw } from "./draw.ts";
+import { effectDraw, InternalEffect, type Effect } from "./effect.ts";
+import type { Bundle } from "./bundle.ts";
+import type { Compute } from "./api-types.ts";
+import type { Gpu } from "./kernel.ts";
+import type { CompileTarget, TargetSignature } from "./target.ts";
+import { normalizeSignature, signatureKeyOf } from "./pipeline-store.ts";
+import { prepareFailedError, unsupportedError, type PrepareFailure } from "./errors.ts";
+import { liveKernel } from "./live-kernel.ts";
+
+export type PrepareRequest =
+  | { readonly draw: Draw | Effect; readonly target: CompileTarget }
+  | { readonly compute: Compute }
+  | { readonly bundle: Bundle };
+
+export type PreparedDraw = { readonly draw: Draw | Effect; readonly signature: TargetSignature; readonly gpu: GPURenderPipeline };
+export type PreparedCompute = { readonly compute: Compute; readonly gpu: GPUComputePipeline };
+export type PreparedBundle = { readonly bundle: Bundle; readonly signature: TargetSignature; readonly gpu: GPURenderBundle };
+
+export type PreparedFor<R> =
+  R extends { compute: Compute } ? PreparedCompute :
+  R extends { bundle: Bundle } ? PreparedBundle : PreparedDraw;
+
+/**
+ * Compiles every requested combination and hands back one handle per request.
+ *
+ * ```ts
+ * const [cube, sim] = await prepare(gpu, [
+ *   { draw: cubeDraw, target: screen },
+ *   { compute: simulation },
+ * ]);
+ *
+ * cube.draw;       // the renderable, echoed back — the handle identifies the combination
+ * cube.signature;  // resolved TargetSignature { colors, depth, sampleCount }
+ * cube.gpu;        // GPURenderPipeline — the same-agent low-level escape hatch
+ * sim.gpu;         // GPUComputePipeline (a compute request has no target signature)
+ * ```
+ *
+ * Rules:
+ * - **Handles are data, not state.** There is no `prepared.status`: `prepare()` **rejects** if any
+ *   requested combination fails, with `VGPU-PREPARE-FAILED` enumerating every failure (renderable
+ *   label + resolved signature + `cause`). Combinations that did compile stay cached, so
+ *   re-preparing the good subset is free. Ignoring the result stays valid — the happy path is
+ *   unchanged.
+ * - The array form preserves request order and tuple inference; the single-request form returns one
+ *   handle.
+ * - `prepared.gpu` is the low-level pipeline escape hatch, and it is same-agent only — like every
+ *   device-local object.
+ *
+ * A `{ draw, target }` request against a `Surface` is legal **outside** `frame()`: a surface
+ * signature comes from its configuration, not from the current presentation texture, so the
+ * signature resolved here is the very one the encode path uses inside a frame.
+ */
+// Overload order is public API surface (see the same note on `effect`/`compute`): the single-object
+// form is declared first so it is the one call sites read first; an array literal never matches it,
+// so call resolution is unambiguous either way.
+export function prepare<const R extends PrepareRequest>(gpu: Gpu, request: R): Promise<PreparedFor<R>>;
+export function prepare<const R extends readonly PrepareRequest[]>(gpu: Gpu, requests: R): Promise<{ [K in keyof R]: PreparedFor<R[K]> }>;
+export async function prepare(gpu: Gpu, request: PrepareRequest | readonly PrepareRequest[]): Promise<unknown> {
+  // Same entry guard as every other factory: a disposed gpu fails here, not deep inside a driver call.
+  liveKernel(gpu, "prepare");
+  const requests: readonly PrepareRequest[] = Array.isArray(request) ? request : [request as PrepareRequest];
+  // Parallel, and settled rather than raced: a batch of combinations fails as a batch, so every
+  // failure must be reported — not just whichever one happened to reject first.
+  const settled = await Promise.allSettled(requests.map((entry) => prepareOne(entry)));
+  const failures: PrepareFailure[] = [];
+  settled.forEach((result, index) => {
+    if (result.status === "rejected") failures.push({ label: labelOf(requests[index]!), signature: signatureKeyFor(requests[index]!), cause: result.reason });
+  });
+  if (failures.length) throw prepareFailedError(failures);
+  const handles = settled.map((result) => (result as PromiseFulfilledResult<unknown>).value);
+  return Array.isArray(request) ? handles : handles[0];
+}
+
+async function prepareOne(request: PrepareRequest): Promise<PreparedDraw | PreparedCompute | PreparedBundle> {
+  if ("draw" in request) {
+    const drawable = request.draw;
+    const internal = drawable instanceof InternalEffect ? effectDraw(drawable) : drawable as InternalDraw;
+    // Deliberately the draw's own async resolution path — same signature normalization, same
+    // pipeline key, same store dedupe. `prepare()` is a second door to it, never a second compile.
+    const gpu = await internal.pipelineForAsync(request.target);
+    return { draw: drawable, signature: normalizeSignature(request.target), gpu };
+  }
+  if ("compute" in request) {
+    return { compute: request.compute, gpu: await asComputePipeline(request.compute).prepareCombination() };
+  }
+  if ("bundle" in request) {
+    const { signature, gpu } = prepareBundle(request.bundle);
+    return { bundle: request.bundle, signature, gpu };
+  }
+  throw unsupportedError("prepare", "a prepare() request must be { draw, target }, { compute } or { bundle }.");
+}
+
+function asComputePipeline(compute: Compute): ComputePipeline {
+  if (compute instanceof ComputePipeline) return compute;
+  throw unsupportedError("prepare", "prepare({ compute }) received an object this library did not create; pass the compute returned by compute(gpu, ...).");
+}
+
+/** Best-effort label for the failure list; never the reason a report is lost. */
+function labelOf(request: PrepareRequest): string {
+  if ("draw" in request) {
+    const drawable = request.draw;
+    return (drawable instanceof InternalEffect ? effectDraw(drawable) : drawable as InternalDraw).label ?? "draw";
+  }
+  if ("compute" in request) return (request.compute as Partial<ComputePipeline>).label ?? "compute";
+  if ("bundle" in request) return request.bundle?.id ?? "bundle";
+  return "request";
+}
+
+/**
+ * Resolved signature key of a failed combination, for the report only. A request whose target is
+ * itself the problem cannot name a signature, and that must not shadow the real failure.
+ */
+function signatureKeyFor(request: PrepareRequest): string | undefined {
+  if ("draw" in request) {
+    try { return signatureKeyOf(normalizeSignature(request.target)); }
+    catch { return undefined; }
+  }
+  if ("bundle" in request) return undefined;
+  // A compute pipeline has no target signature — asymmetry by platform fact, not inconsistency.
+  return undefined;
+}

--- a/packages/vgpu-api/src/render-service.ts
+++ b/packages/vgpu-api/src/render-service.ts
@@ -33,6 +33,8 @@ function createRenderService(kernel: Kernel): RenderService {
   const pipelines = createPipelineStore(device, {
     errorSink: (error) => kernel.reportError(error),
     registerSettledSource: (source) => kernel.registerSettledSource(source),
+    // Last link of the pendingPipelines chain: the gpu-wide default from init().
+    pendingPipelines: kernel.pendingPipelinesDefault(),
   });
   const shaderModules = createShaderModuleCache(device);
   const pipelineLayouts = createPipelineLayoutCache(device);

--- a/packages/vgpu-api/tests/pending-pipelines.test.ts
+++ b/packages/vgpu-api/tests/pending-pipelines.test.ts
@@ -1,0 +1,234 @@
+import { expect, test, vi } from "vitest";
+import { getMockGPUDeviceInstrumentation } from "@vgpu/core";
+import { draw, effect, frame, init, prepare, target } from "../src/mock.ts";
+
+const WGSL = `
+@vertex fn vs_main(@builtin(vertex_index) vi: u32) -> @builtin(position) vec4f {
+  var pos = array<vec2f, 3>(vec2f(-1.0, -1.0), vec2f(3.0, -1.0), vec2f(-1.0, 3.0));
+  return vec4f(pos[vi], 0.0, 1.0);
+}
+@fragment fn fs_main() -> @location(0) vec4f { return vec4f(1.0); }
+`;
+
+const FRAGMENT_ONLY = `
+@fragment fn fs_main() -> @location(0) vec4f { return vec4f(1.0); }
+`;
+
+/** The exact actionable text the design mandates for VGPU-PIPELINE-PENDING. */
+const PENDING_FIX = "await prepare(gpu, [{draw, target}]) before drawing, or opt in to inline compilation with pendingPipelines: 'sync'";
+
+function countPipelines(gpu: { device: { gpu: GPUDevice } }): { sync: number; async: number } {
+  const mock = getMockGPUDeviceInstrumentation(gpu.device.gpu);
+  return { sync: mock.calls.createRenderPipeline, async: mock.calls.createRenderPipelineAsync };
+}
+
+/** Returns the error a synchronous call threw, so assertions can pin `code` instead of message text. */
+function caught(fn: () => unknown): { code?: string; fix?: string; message?: string } | undefined {
+  try { fn(); }
+  catch (error) { return error as { code?: string; fix?: string; message?: string }; }
+  return undefined;
+}
+
+function boundPipelines(device: GPUDevice): GPURenderPipeline[] {
+  const bound: GPURenderPipeline[] = [];
+  const createCommandEncoder = device.createCommandEncoder.bind(device);
+  vi.spyOn(device, "createCommandEncoder").mockImplementation((desc?: GPUCommandEncoderDescriptor) => {
+    const encoder = createCommandEncoder(desc);
+    const beginRenderPass = encoder.beginRenderPass.bind(encoder);
+    encoder.beginRenderPass = (passDesc: GPURenderPassDescriptor) => {
+      const pass = beginRenderPass(passDesc);
+      const setPipeline = pass.setPipeline.bind(pass);
+      pass.setPipeline = (pipeline: GPURenderPipeline) => { bound.push(pipeline); setPipeline(pipeline); };
+      return pass;
+    };
+    return encoder;
+  });
+  return bound;
+}
+
+// The train's invariant 2: the mechanism is complete, but the effective default stays "sync" until
+// the cut wave, so every unmigrated call site keeps compiling inline exactly like today.
+test("the effective default with no policy anywhere is \"sync\": an unprepared draw compiles inline", async () => {
+  const gpu = await init();
+  const colorTarget = target(gpu, { size: [4, 4] });
+  const drawable = draw(gpu, { shader: WGSL, label: "defaultSync" });
+  const bound = boundPipelines(gpu.device.gpu);
+
+  expect(() => frame(gpu, (f) => f.pass(colorTarget, (p) => p.draw(drawable)))).not.toThrow();
+
+  expect(countPipelines(gpu)).toEqual({ sync: 1, async: 0 });
+  expect(bound).toHaveLength(1);
+  gpu.dispose();
+});
+
+test("\"throw\" does not start compilation and reports the actionable VGPU-PIPELINE-PENDING message", async () => {
+  const gpu = await init({ pendingPipelines: "throw" });
+  const colorTarget = target(gpu, { size: [4, 4] });
+  const drawable = draw(gpu, { shader: WGSL, label: "unprepared" });
+  const bound = boundPipelines(gpu.device.gpu);
+
+  let thrown: { code?: string; fix?: string; message?: string } | undefined;
+  try { frame(gpu, (f) => f.pass(colorTarget, (p) => p.draw(drawable))); }
+  catch (error) { thrown = error as { code?: string; fix?: string }; }
+
+  expect(thrown?.code).toBe("VGPU-PIPELINE-PENDING");
+  expect(thrown?.fix).toBe(PENDING_FIX);
+  expect(thrown?.message).toContain("unprepared");
+  expect(thrown?.message).toContain("rgba8unorm:none:1");
+  // "does not start compilation": neither the sync nor the async native call happened.
+  expect(countPipelines(gpu)).toEqual({ sync: 0, async: 0 });
+  expect(bound).toEqual([]);
+  gpu.dispose();
+});
+
+test("\"throw\" lets a prepared combination draw normally", async () => {
+  const gpu = await init({ pendingPipelines: "throw" });
+  const colorTarget = target(gpu, { size: [4, 4] });
+  const drawable = draw(gpu, { shader: WGSL, label: "readyUnderThrow" });
+
+  const prepared = await prepare(gpu, { draw: drawable, target: colorTarget });
+  const bound = boundPipelines(gpu.device.gpu);
+
+  expect(() => frame(gpu, (f) => f.pass(colorTarget, (p) => p.draw(drawable)))).not.toThrow();
+  expect(bound).toEqual([prepared.gpu]);
+  expect(countPipelines(gpu)).toEqual({ sync: 0, async: 1 });
+  gpu.dispose();
+});
+
+test("\"skip\" omits the draw without throwing and starts background compilation", async () => {
+  const gpu = await init({ pendingPipelines: "skip" });
+  const colorTarget = target(gpu, { size: [4, 4] });
+  const drawable = draw(gpu, { shader: WGSL, label: "streamed" });
+  const bound = boundPipelines(gpu.device.gpu);
+
+  expect(() => frame(gpu, (f) => f.pass(colorTarget, (p) => p.draw(drawable)))).not.toThrow();
+
+  expect(bound).toEqual([]);
+  expect(countPipelines(gpu)).toEqual({ sync: 0, async: 1 });
+
+  // A second frame before the compile lands continues the same compilation, never a second one.
+  expect(() => frame(gpu, (f) => f.pass(colorTarget, (p) => p.draw(drawable)))).not.toThrow();
+  expect(countPipelines(gpu).async).toBe(1);
+
+  await gpu.settled();
+
+  // Once it landed, the same "skip" policy draws it — no inline compile ever happened.
+  expect(() => frame(gpu, (f) => f.pass(colorTarget, (p) => p.draw(drawable)))).not.toThrow();
+  expect(bound).toHaveLength(1);
+  expect(countPipelines(gpu)).toEqual({ sync: 0, async: 1 });
+  gpu.dispose();
+});
+
+test("\"skip\" reports a deterministic compile failure once through gpu.onError and keeps skipping", async () => {
+  const gpu = await init({ pendingPipelines: "skip" });
+  const colorTarget = target(gpu, { size: [4, 4] });
+  const drawable = draw(gpu, { shader: WGSL, label: "brokenSkip" });
+  const nativeError = new Error("shader is broken");
+  const errors: { code: string }[] = [];
+  gpu.onError((error) => errors.push(error as unknown as { code: string }));
+  vi.spyOn(gpu.device.gpu, "createRenderPipelineAsync").mockRejectedValue(nativeError);
+
+  for (let i = 0; i < 3; i++) {
+    expect(() => frame(gpu, (f) => f.pass(colorTarget, (p) => p.draw(drawable)))).not.toThrow();
+    await gpu.settled();
+  }
+
+  expect(errors).toHaveLength(1);
+  expect(errors[0]).toMatchObject({ code: "VGPU-COMPILE-FAILED", cause: nativeError });
+  gpu.dispose();
+});
+
+test("a \"skip\" failure never poisons prepare(): the retry is a fresh compile", async () => {
+  const gpu = await init({ pendingPipelines: "skip" });
+  const colorTarget = target(gpu, { size: [4, 4] });
+  const drawable = draw(gpu, { shader: WGSL, label: "skipThenPrepare" });
+  const createAsync = gpu.device.gpu.createRenderPipelineAsync.bind(gpu.device.gpu);
+  let fail = true;
+  gpu.onError(() => undefined);
+  vi.spyOn(gpu.device.gpu, "createRenderPipelineAsync").mockImplementation((desc: GPURenderPipelineDescriptor) => {
+    if (fail) return Promise.reject(new Error("transient"));
+    return createAsync(desc);
+  });
+
+  frame(gpu, (f) => f.pass(colorTarget, (p) => p.draw(drawable)));
+  await gpu.settled();
+  fail = false;
+
+  await expect(prepare(gpu, { draw: drawable, target: colorTarget })).resolves.toBeDefined();
+  gpu.dispose();
+});
+
+test("the policy chain resolves call site over frame over gpu default", async () => {
+  const gpu = await init({ pendingPipelines: "throw" });
+  const colorTarget = target(gpu, { size: [4, 4] });
+  const drawable = draw(gpu, { shader: WGSL, label: "chained" });
+
+  // frame beats the gpu default: "sync" here compiles inline where the gpu default would throw.
+  expect(() => frame(gpu, (f) => f.pass(colorTarget, (p) => p.draw(drawable)), { pendingPipelines: "sync" })).not.toThrow();
+  expect(countPipelines(gpu)).toEqual({ sync: 1, async: 0 });
+
+  // A different blend => a different pipeline key: two draws with identical state share ONE
+  // combination, and a combination the previous frame already compiled is ready under every policy.
+  const other = draw(gpu, { shader: WGSL, label: "chainedCallSite", blend: "additive" });
+  // call site beats the frame: "throw" here throws inside a "sync" frame.
+  let thrown: { code?: string } | undefined;
+  try {
+    frame(gpu, (f) => f.pass(colorTarget, (p) => p.draw(other, { pendingPipelines: "throw" })), { pendingPipelines: "sync" });
+  } catch (error) { thrown = error as { code?: string }; }
+  expect(thrown?.code).toBe("VGPU-PIPELINE-PENDING");
+  expect(countPipelines(gpu)).toEqual({ sync: 1, async: 0 });
+
+  // ...and the call site also beats a frame that would throw.
+  expect(() => frame(gpu, (f) => f.pass(colorTarget, (p) => p.draw(other, { pendingPipelines: "sync" })), { pendingPipelines: "throw" })).not.toThrow();
+  expect(countPipelines(gpu)).toEqual({ sync: 2, async: 0 });
+  gpu.dispose();
+});
+
+test("the frame policy survives a manually driven frame (no callback)", async () => {
+  const gpu = await init({ pendingPipelines: "throw" });
+  const colorTarget = target(gpu, { size: [4, 4] });
+  const drawable = draw(gpu, { shader: WGSL, label: "manualFrame" });
+
+  const f = frame(gpu, undefined, { pendingPipelines: "sync" });
+  expect(() => f.pass(colorTarget, (p) => p.draw(drawable))).not.toThrow();
+  f.submit();
+
+  expect(countPipelines(gpu)).toEqual({ sync: 1, async: 0 });
+  gpu.dispose();
+});
+
+test("the call-site policy reaches the one-shot draw()/effect draw path too", async () => {
+  const gpu = await init();
+  const colorTarget = target(gpu, { size: [4, 4] });
+  const drawable = draw(gpu, { shader: WGSL, label: "oneShot" });
+  const shader = effect(gpu, FRAGMENT_ONLY, { label: "oneShotFx" });
+
+  expect(caught(() => drawable.draw({ target: colorTarget, pendingPipelines: "throw" }))?.code).toBe("VGPU-PIPELINE-PENDING");
+  expect(caught(() => shader.draw({ target: colorTarget, pendingPipelines: "throw" }))?.code).toBe("VGPU-PIPELINE-PENDING");
+  expect(countPipelines(gpu)).toEqual({ sync: 0, async: 0 });
+
+  expect(() => drawable.draw({ target: colorTarget, pendingPipelines: "skip" })).not.toThrow();
+  expect(countPipelines(gpu)).toEqual({ sync: 0, async: 1 });
+  gpu.dispose();
+});
+
+test("frameLoop accepts the same policy option as frame()", async () => {
+  const gpu = await init({ pendingPipelines: "throw" });
+  const colorTarget = target(gpu, { size: [4, 4] });
+  const drawable = draw(gpu, { shader: WGSL, label: "loopPolicy" });
+  const frames: number[] = [];
+  const { frameLoop } = await import("../src/mock.ts");
+
+  const handle = frameLoop(gpu, (f) => {
+    frames.push(1);
+    f.pass(colorTarget, (p) => p.draw(drawable));
+    handle.stop();
+  }, { pendingPipelines: "sync" });
+
+  await new Promise((resolve) => setTimeout(resolve, 40));
+  handle.stop();
+
+  expect(frames.length).toBeGreaterThan(0);
+  expect(countPipelines(gpu)).toEqual({ sync: 1, async: 0 });
+  gpu.dispose();
+});

--- a/packages/vgpu-api/tests/prepare.test.ts
+++ b/packages/vgpu-api/tests/prepare.test.ts
@@ -1,0 +1,454 @@
+import { expect, test, vi } from "vitest";
+import { getMockGPUDeviceInstrumentation } from "@vgpu/core";
+import { bundle, compute, draw, effect, frame, init, prepare, storage, surface, target } from "../src/mock.ts";
+import { normalizeSignature } from "../src/pipeline-store.ts";
+
+const WGSL = `
+@vertex fn vs_main(@builtin(vertex_index) vi: u32) -> @builtin(position) vec4f {
+  var pos = array<vec2f, 3>(vec2f(-1.0, -1.0), vec2f(3.0, -1.0), vec2f(-1.0, 3.0));
+  return vec4f(pos[vi], 0.0, 1.0);
+}
+@fragment fn fs_main() -> @location(0) vec4f { return vec4f(1.0); }
+`;
+
+const FRAGMENT_ONLY = `
+@fragment fn fs_main() -> @location(0) vec4f { return vec4f(1.0); }
+`;
+
+const BOUND_WGSL = `
+@group(0) @binding(0) var<storage, read> data: array<f32>;
+@vertex fn vs_main(@builtin(vertex_index) vi: u32) -> @builtin(position) vec4f {
+  return vec4f(data[vi], 0.0, 0.0, 1.0);
+}
+@fragment fn fs_main() -> @location(0) vec4f { return vec4f(1.0); }
+`;
+
+const COMPUTE_WGSL = `
+@group(0) @binding(0) var<storage, read_write> data: array<f32>;
+@compute @workgroup_size(1) fn main(@builtin(global_invocation_id) id: vec3u) { data[id.x] = 1.0; }
+`;
+
+function surfaceCanvas(): HTMLCanvasElement {
+  const canvas: Record<string, unknown> = { width: 4, height: 4 };
+  canvas.getContext = (kind: string) => kind === "webgpu" ? {
+    configure: () => undefined,
+    getCurrentTexture: () => ({ createView: () => ({}) }),
+  } : null;
+  return canvas as HTMLCanvasElement;
+}
+
+/**
+ * Records every pipeline the encode path binds, so `prepared.gpu` can be asserted by IDENTITY
+ * against the object a real `pass.draw()` uses — not against a call count.
+ */
+/** Returns the error a synchronous call threw, so assertions can pin `code` instead of message text. */
+function caught(fn: () => unknown): { code?: string; message?: string } | undefined {
+  try { fn(); }
+  catch (error) { return error as { code?: string; message?: string }; }
+  return undefined;
+}
+
+function recordEncodedPipelines(device: GPUDevice): GPURenderPipeline[] {
+  const bound: GPURenderPipeline[] = [];
+  const createCommandEncoder = device.createCommandEncoder.bind(device);
+  vi.spyOn(device, "createCommandEncoder").mockImplementation((desc?: GPUCommandEncoderDescriptor) => {
+    const encoder = createCommandEncoder(desc);
+    const beginRenderPass = encoder.beginRenderPass.bind(encoder);
+    encoder.beginRenderPass = (passDesc: GPURenderPassDescriptor) => {
+      const pass = beginRenderPass(passDesc);
+      const setPipeline = pass.setPipeline.bind(pass);
+      pass.setPipeline = (pipeline: GPURenderPipeline) => { bound.push(pipeline); setPipeline(pipeline); };
+      return pass;
+    };
+    return encoder;
+  });
+  return bound;
+}
+
+// Contract #2 — "After a completed prepare() on a {draw, target} combination, encoding that
+// combination in a frame() creates no pipelines."
+test("contract #2: a prepared {draw, target} encodes in frame() without creating any pipeline", async () => {
+  const gpu = await init();
+  const colorTarget = target(gpu, { size: [4, 4] });
+  const drawable = draw(gpu, { shader: WGSL, label: "prepared" });
+  const mock = getMockGPUDeviceInstrumentation(gpu.device.gpu);
+
+  await prepare(gpu, { draw: drawable, target: colorTarget });
+  const asyncAfterPrepare = mock.calls.createRenderPipelineAsync;
+  expect(asyncAfterPrepare).toBe(1);
+  expect(mock.calls.createRenderPipeline).toBe(0);
+
+  frame(gpu, (f) => f.pass(colorTarget, (p) => p.draw(drawable)));
+
+  expect(mock.calls.createRenderPipeline).toBe(0);
+  expect(mock.calls.createRenderPipelineAsync).toBe(asyncAfterPrepare);
+  gpu.dispose();
+});
+
+test("contract #2: a prepared {effect, target} encodes in frame() without creating any pipeline", async () => {
+  const gpu = await init();
+  const colorTarget = target(gpu, { size: [4, 4] });
+  const shader = effect(gpu, FRAGMENT_ONLY, { label: "preparedFx" });
+  const mock = getMockGPUDeviceInstrumentation(gpu.device.gpu);
+
+  const prepared = await prepare(gpu, { draw: shader, target: colorTarget });
+  expect(prepared.draw).toBe(shader);
+  expect(mock.calls.createRenderPipelineAsync).toBe(1);
+
+  frame(gpu, (f) => f.pass(colorTarget, (p) => p.draw(shader)));
+
+  expect(mock.calls.createRenderPipeline).toBe(0);
+  expect(mock.calls.createRenderPipelineAsync).toBe(1);
+  gpu.dispose();
+});
+
+// Contract #6 — combination-scoped readiness.
+test("contract #6: preparing {draw, a} does not prepare {draw, b}", async () => {
+  const gpu = await init();
+  const plain = target(gpu, { size: [4, 4] });
+  const depthTarget = target(gpu, { size: [4, 4], depth: true });
+  const drawable = draw(gpu, { shader: WGSL, label: "scoped" });
+  const mock = getMockGPUDeviceInstrumentation(gpu.device.gpu);
+
+  const preparedA = await prepare(gpu, { draw: drawable, target: plain });
+  expect(mock.calls.createRenderPipelineAsync).toBe(1);
+
+  // The other combination is NOT ready: encoding it with the default "sync" policy has to compile.
+  frame(gpu, (f) => f.pass(depthTarget, (p) => p.draw(drawable)));
+  expect(mock.calls.createRenderPipeline).toBe(1);
+
+  const preparedB = await prepare(gpu, { draw: drawable, target: depthTarget });
+  expect(preparedB.gpu).not.toBe(preparedA.gpu);
+  expect(preparedA.signature.depth).toBeUndefined();
+  expect(preparedB.signature.depth).toBe("depth24plus");
+  gpu.dispose();
+});
+
+test("contract #6: a failure on {draw, b} neither throws for {draw, a} nor mutates state observable through the draw", async () => {
+  const gpu = await init();
+  const plain = target(gpu, { size: [4, 4] });
+  const depthTarget = target(gpu, { size: [4, 4], depth: true });
+  const drawable = draw(gpu, { shader: WGSL, label: "isolated" });
+  const nativeError = new Error("depth pipeline rejected");
+  const mock = getMockGPUDeviceInstrumentation(gpu.device.gpu);
+  const createAsync = gpu.device.gpu.createRenderPipelineAsync.bind(gpu.device.gpu);
+  vi.spyOn(gpu.device.gpu, "createRenderPipelineAsync").mockImplementation((desc: GPURenderPipelineDescriptor) => {
+    if (desc.depthStencil) return Promise.reject(nativeError);
+    return createAsync(desc);
+  });
+
+  const preparedA = await prepare(gpu, { draw: drawable, target: plain });
+  expect(preparedA.gpu).toBeDefined();
+  const pipelineA = drawable.gpu;
+
+  await expect(prepare(gpu, { draw: drawable, target: depthTarget })).rejects.toMatchObject({ code: "VGPU-PREPARE-FAILED" });
+
+  // The good combination is untouched: same pipeline object, still encodes with zero new pipelines.
+  expect(drawable.gpu).toBe(pipelineA);
+  const before = { sync: mock.calls.createRenderPipeline, async: mock.calls.createRenderPipelineAsync };
+  expect(() => frame(gpu, (f) => f.pass(plain, (p) => p.draw(drawable)))).not.toThrow();
+  expect(mock.calls.createRenderPipeline).toBe(before.sync);
+  expect(mock.calls.createRenderPipelineAsync).toBe(before.async);
+  await expect(prepare(gpu, { draw: drawable, target: plain })).resolves.toMatchObject({ gpu: preparedA.gpu });
+  gpu.dispose();
+});
+
+// Contract #7 — handles.
+test("contract #7: the array form preserves order, and prepared.gpu is the object the encode path binds", async () => {
+  const gpu = await init();
+  const colorTarget = target(gpu, { size: [4, 4] });
+  const first = draw(gpu, { shader: WGSL, label: "first" });
+  const second = effect(gpu, FRAGMENT_ONLY, { label: "second" });
+  const kernel = compute(gpu, COMPUTE_WGSL, { label: "kernel" });
+  kernel.set({ data: storage(gpu, 16) });
+  const bound = recordEncodedPipelines(gpu.device.gpu);
+
+  const [a, b, c] = await prepare(gpu, [
+    { draw: first, target: colorTarget },
+    { draw: second, target: colorTarget },
+    { compute: kernel },
+  ]);
+
+  // Order preserved, and each handle echoes the renderable it was requested with.
+  expect(a.draw).toBe(first);
+  expect(b.draw).toBe(second);
+  expect(c.compute).toBe(kernel);
+  expect(a.gpu).not.toBe(b.gpu);
+
+  frame(gpu, (f) => f.pass(colorTarget, (p) => { p.draw(first); p.draw(second); }));
+
+  // Identity, not counts: the encode path bound exactly the handles prepare() returned.
+  expect(bound).toEqual([a.gpu, b.gpu]);
+  gpu.dispose();
+});
+
+test("contract #7: prepare() rejects with VGPU-PREPARE-FAILED listing every failed combination", async () => {
+  const gpu = await init();
+  const plain = target(gpu, { size: [4, 4] });
+  const depthTarget = target(gpu, { size: [4, 4], depth: true });
+  const ok = draw(gpu, { shader: WGSL, label: "ok" });
+  const bad = draw(gpu, { shader: WGSL, label: "bad" });
+  const nativeError = new Error("nope");
+  const createAsync = gpu.device.gpu.createRenderPipelineAsync.bind(gpu.device.gpu);
+  vi.spyOn(gpu.device.gpu, "createRenderPipelineAsync").mockImplementation((desc: GPURenderPipelineDescriptor) => {
+    if (desc.depthStencil) return Promise.reject(nativeError);
+    return createAsync(desc);
+  });
+
+  const rejection = await prepare(gpu, [
+    { draw: ok, target: plain },
+    { draw: bad, target: depthTarget },
+    { draw: ok, target: depthTarget },
+  ]).then(() => undefined, (error: unknown) => error) as { code: string; message: string; detail: { failures: { label: string; signature?: string; cause: { code?: string; cause?: unknown } }[] } };
+
+  expect(rejection.code).toBe("VGPU-PREPARE-FAILED");
+  // Every failed combination is enumerated — both of them, in request order, with the signature
+  // each one resolved to. The succeeding one is NOT in the list.
+  expect(rejection.detail.failures.map(({ label, signature }) => ({ label, signature }))).toEqual([
+    { label: "bad", signature: "rgba8unorm:depth24plus:1" },
+    { label: "ok", signature: "rgba8unorm:depth24plus:1" },
+  ]);
+  // Each failure keeps the whole diagnosis chain: the vgpu compile error, carrying the native cause.
+  for (const failure of rejection.detail.failures) {
+    expect(failure.cause).toMatchObject({ code: "VGPU-COMPILE-FAILED", cause: nativeError });
+  }
+  expect(rejection.message).toContain("bad");
+  expect(rejection.message).toContain("rgba8unorm:depth24plus:1");
+
+  const mock = getMockGPUDeviceInstrumentation(gpu.device.gpu);
+  const asyncCalls = mock.calls.createRenderPipelineAsync;
+  // The subset that did compile stays cached: re-preparing it performs no new pipeline creation.
+  await expect(prepare(gpu, [{ draw: ok, target: plain }])).resolves.toHaveLength(1);
+  expect(mock.calls.createRenderPipelineAsync).toBe(asyncCalls);
+  expect(mock.calls.createRenderPipeline).toBe(0);
+  gpu.dispose();
+});
+
+test("contract #7: a failed combination is retried by a later prepare(), never poisoned", async () => {
+  const gpu = await init();
+  const colorTarget = target(gpu, { size: [4, 4] });
+  const drawable = draw(gpu, { shader: WGSL, label: "retry" });
+  const createAsync = gpu.device.gpu.createRenderPipelineAsync.bind(gpu.device.gpu);
+  let fail = true;
+  vi.spyOn(gpu.device.gpu, "createRenderPipelineAsync").mockImplementation((desc: GPURenderPipelineDescriptor) => {
+    if (fail) return Promise.reject(new Error("transient"));
+    return createAsync(desc);
+  });
+
+  await expect(prepare(gpu, { draw: drawable, target: colorTarget })).rejects.toMatchObject({ code: "VGPU-PREPARE-FAILED" });
+  fail = false;
+  const prepared = await prepare(gpu, { draw: drawable, target: colorTarget });
+  expect(prepared.gpu).toBeDefined();
+  gpu.dispose();
+});
+
+test("contract #7: two concurrent prepare() calls on the same combination share one native compile", async () => {
+  const gpu = await init();
+  const colorTarget = target(gpu, { size: [4, 4] });
+  const drawable = draw(gpu, { shader: WGSL, label: "concurrent" });
+  const mock = getMockGPUDeviceInstrumentation(gpu.device.gpu);
+
+  const [a, b] = await Promise.all([
+    prepare(gpu, { draw: drawable, target: colorTarget }),
+    prepare(gpu, { draw: drawable, target: colorTarget }),
+  ]);
+
+  expect(a.gpu).toBe(b.gpu);
+  expect(mock.calls.createRenderPipelineAsync).toBe(1);
+  expect(mock.calls.createRenderPipeline).toBe(0);
+  gpu.dispose();
+});
+
+// Contract #8 — Surface outside frame().
+test("contract #8: prepare() against a Surface outside frame() resolves with the in-frame signature", async () => {
+  const gpu = await init();
+  const canvasSurface = surface(gpu, surfaceCanvas());
+  const drawable = draw(gpu, { shader: WGSL, label: "surfaced" });
+  const mock = getMockGPUDeviceInstrumentation(gpu.device.gpu);
+  const bound = recordEncodedPipelines(gpu.device.gpu);
+
+  const prepared = await prepare(gpu, { draw: drawable, target: canvasSurface });
+
+  expect(prepared.signature).toEqual(normalizeSignature(canvasSurface));
+  expect(mock.calls.createRenderPipelineAsync).toBe(1);
+
+  // Same signature inside a frame => the prepared pipeline is reused verbatim.
+  frame(gpu, (f) => f.pass(canvasSurface, (p) => p.draw(drawable)));
+  expect(bound).toEqual([prepared.gpu]);
+  expect(mock.calls.createRenderPipeline).toBe(0);
+  gpu.dispose();
+});
+
+// Contract #4 (the half T04-04 left open): {compute} in prepare().
+test("contract #4: prepare({ compute }) compiles with createComputePipelineAsync and dispatch reuses it", async () => {
+  const gpu = await init();
+  const kernel = compute(gpu, COMPUTE_WGSL, { label: "sim" });
+  kernel.set({ data: storage(gpu, 16) });
+  const mock = getMockGPUDeviceInstrumentation(gpu.device.gpu);
+
+  const prepared = await prepare(gpu, { compute: kernel });
+
+  expect(prepared.compute).toBe(kernel);
+  expect(prepared.gpu).toBeDefined();
+  expect(mock.calls.createComputePipelineAsync).toBe(1);
+  expect(mock.calls.createComputePipeline).toBe(0);
+
+  kernel.dispatch(1);
+  expect(mock.calls.createComputePipeline).toBe(0);
+  expect(mock.calls.createComputePipelineAsync).toBe(1);
+
+  // Idempotent: re-preparing a ready compute creates nothing.
+  await expect(prepare(gpu, { compute: kernel })).resolves.toMatchObject({ gpu: prepared.gpu });
+  expect(mock.calls.createComputePipelineAsync).toBe(1);
+  gpu.dispose();
+});
+
+test("contract #4: prepare({ compute }) does not recompile a kernel a previous dispatch already compiled", async () => {
+  const gpu = await init();
+  const kernel = compute(gpu, COMPUTE_WGSL, { label: "warmed" });
+  kernel.set({ data: storage(gpu, 16) });
+  const mock = getMockGPUDeviceInstrumentation(gpu.device.gpu);
+
+  kernel.dispatch(1);
+  expect(mock.calls.createComputePipeline).toBe(1);
+
+  await prepare(gpu, { compute: kernel });
+  expect(mock.calls.createComputePipelineAsync).toBe(0);
+  expect(mock.calls.createComputePipeline).toBe(1);
+  gpu.dispose();
+});
+
+test("prepare() reports a failed compute combination through VGPU-PREPARE-FAILED", async () => {
+  const gpu = await init();
+  const kernel = compute(gpu, COMPUTE_WGSL, { label: "brokenSim" });
+  kernel.set({ data: storage(gpu, 16) });
+  const nativeError = new Error("compute compile failed");
+  vi.spyOn(gpu.device.gpu, "createComputePipelineAsync").mockRejectedValue(nativeError);
+
+  await expect(prepare(gpu, [{ compute: kernel }])).rejects.toMatchObject({
+    code: "VGPU-PREPARE-FAILED",
+    detail: { failures: [{ label: "brokenSim", cause: nativeError }] },
+  });
+  gpu.dispose();
+});
+
+test("prepare() rejects a disposed gpu and an unknown request shape", async () => {
+  const gpu = await init();
+  const colorTarget = target(gpu, { size: [4, 4] });
+  const drawable = draw(gpu, { shader: WGSL, label: "guarded" });
+
+  await expect(prepare(gpu, { draw: drawable } as never)).rejects.toMatchObject({ code: "VGPU-PREPARE-FAILED" });
+
+  gpu.dispose();
+  await expect(prepare(gpu, { draw: drawable, target: colorTarget })).rejects.toMatchObject({ code: "VGPU-GPU-DISPOSED" });
+});
+
+test("gpu.dispose() with a prepare() in flight rejects it instead of leaving it hanging", async () => {
+  const gpu = await init();
+  const colorTarget = target(gpu, { size: [4, 4] });
+  const drawable = draw(gpu, { shader: WGSL, label: "disposedMidFlight" });
+  vi.spyOn(gpu.device.gpu, "createRenderPipelineAsync").mockImplementation(() => new Promise<GPURenderPipeline>(() => undefined));
+  const unhandled: unknown[] = [];
+  const onUnhandled = (reason: unknown) => { unhandled.push(reason); };
+  process.on("unhandledRejection", onUnhandled);
+
+  try {
+    const pending = prepare(gpu, { draw: drawable, target: colorTarget });
+    gpu.dispose();
+
+    const rejection = await pending.then(() => undefined, (error: unknown) => error) as { code: string; detail: { failures: { cause: { code?: string } }[] } };
+    expect(rejection.code).toBe("VGPU-PREPARE-FAILED");
+    expect(rejection.detail.failures[0]?.cause).toMatchObject({ code: "VGPU-COMPILE-DISPOSED" });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(unhandled).toEqual([]);
+  } finally {
+    process.off("unhandledRejection", onUnhandled);
+  }
+});
+
+// The T04-02 interaction: a surface signature comes from its configuration, so a resize landing
+// while prepare() is resolving cannot change the signature the combination was keyed on.
+test("a Surface resize while prepare() is in flight does not change the resolved signature", async () => {
+  const gpu = await init();
+  const canvas = surfaceCanvas();
+  const canvasSurface = surface(gpu, canvas);
+  const drawable = draw(gpu, { shader: WGSL, label: "resizedMidFlight" });
+  let resolveNative!: (pipeline: GPURenderPipeline) => void;
+  const createAsync = gpu.device.gpu.createRenderPipelineAsync.bind(gpu.device.gpu);
+  vi.spyOn(gpu.device.gpu, "createRenderPipelineAsync").mockImplementation(async (desc: GPURenderPipelineDescriptor) => {
+    const real = await createAsync(desc);
+    return new Promise<GPURenderPipeline>((resolve) => { resolveNative = () => resolve(real); });
+  });
+  const signatureBefore = normalizeSignature(canvasSurface);
+
+  const pending = prepare(gpu, { draw: drawable, target: canvasSurface });
+  await Promise.resolve();
+  (canvas as { width: number }).width = 16;
+  (canvas as { height: number }).height = 16;
+  frame(gpu, () => undefined);
+  resolveNative({} as GPURenderPipeline);
+
+  const prepared = await pending;
+  expect(prepared.signature).toEqual(signatureBefore);
+  expect(prepared.signature).toEqual(normalizeSignature(canvasSurface));
+
+  // And the resized surface still encodes with that very pipeline: no new one is created.
+  const mock = getMockGPUDeviceInstrumentation(gpu.device.gpu);
+  const before = mock.calls.createRenderPipeline;
+  frame(gpu, (f) => f.pass(canvasSurface, (p) => p.draw(drawable)));
+  expect(mock.calls.createRenderPipeline).toBe(before);
+  gpu.dispose();
+});
+
+// Trimmed bundle scope: prepare() re-encodes a stale bundle from its retained recording.
+test("prepare({ bundle }) re-encodes a bundle made stale by a binding identity change", async () => {
+  const gpu = await init();
+  const colorTarget = target(gpu, { size: [4, 4] });
+  const drawable = draw(gpu, { shader: BOUND_WGSL, label: "bundled" });
+  drawable.set({ data: storage(gpu, 16) });
+  const recorded = bundle(gpu, { target: colorTarget, label: "forest" }, (r) => r.draw(drawable));
+  const mock = getMockGPUDeviceInstrumentation(gpu.device.gpu);
+  const encodersAfterRecord = mock.calls.createRenderBundleEncoder;
+  const nativeBefore = recorded.gpu;
+
+  drawable.set({ data: storage(gpu, 16) });
+  expect(caught(() => frame(gpu, (f) => f.pass(colorTarget, (p) => p.bundles(recorded))))?.code).toBe("VGPU-R3-BUNDLE-STALE");
+
+  const prepared = await prepare(gpu, { bundle: recorded });
+
+  expect(mock.calls.createRenderBundleEncoder).toBe(encodersAfterRecord + 1);
+  expect(prepared.bundle).toBe(recorded);
+  expect(prepared.gpu).toBe(recorded.gpu);
+  expect(recorded.gpu).not.toBe(nativeBefore);
+  expect(() => frame(gpu, (f) => f.pass(colorTarget, (p) => p.bundles(recorded)))).not.toThrow();
+  gpu.dispose();
+});
+
+test("prepare({ bundle }) on a fresh bundle is a no-op that returns the recorded native bundle", async () => {
+  const gpu = await init();
+  const colorTarget = target(gpu, { size: [4, 4] });
+  const drawable = draw(gpu, { shader: WGSL, label: "fresh" });
+  const recorded = bundle(gpu, { target: colorTarget, label: "freshBundle" }, (r) => r.draw(drawable));
+  const mock = getMockGPUDeviceInstrumentation(gpu.device.gpu);
+  const encoders = mock.calls.createRenderBundleEncoder;
+
+  const prepared = await prepare(gpu, { bundle: recorded });
+
+  expect(prepared.gpu).toBe(recorded.gpu);
+  expect(prepared.signature).toEqual(normalizeSignature(colorTarget));
+  expect(mock.calls.createRenderBundleEncoder).toBe(encoders);
+  gpu.dispose();
+});
+
+test("prepare({ bundle }) does not auto-heal a real signature mismatch", async () => {
+  const gpu = await init();
+  const colorTarget = target(gpu, { size: [4, 4] });
+  const otherTarget = target(gpu, { size: [4, 4], depth: true });
+  const drawable = draw(gpu, { shader: WGSL, label: "mismatch" });
+  const recorded = bundle(gpu, { target: colorTarget, label: "mismatchBundle" }, (r) => r.draw(drawable));
+
+  await prepare(gpu, { bundle: recorded });
+
+  expect(caught(() => frame(gpu, (f) => f.pass(otherTarget, (p) => p.bundles(recorded))))?.code).toBe("VGPU-R3-BUNDLE-STALE");
+  gpu.dispose();
+});


### PR DESCRIPTION
Implements **T04-05** (ola 1, lane A) of the vgpu 0.4 train: `prepare()`, the `pendingPipelines`
policy chain, the two new error codes, and the trimmed bundle re-encode.

Contracts covered (issue #320 body rev6): **#2**, **#3 (mechanism)**, **#4 (the `{compute}` half)**,
**#6**, **#7**, **#8**.

## What lands

- **`pending-pipelines.ts`** (new leaf) — the `PendingPipelines` vocabulary plus the wave default.
  Types + one constant on purpose, so `kernel.ts` never imports a feature module.
- **`pipeline-store.ts`** (exclusive to this branch) — new `getForPolicy(key, policy, creators, ctx)`.
  `getReady`/`getSync`/`getAsync` are untouched and still serve
  `compile`/`compileSync`/`pipelineFor`/`pipelineForAsync` verbatim.
- **Resolution chain** call site → frame → gpu: `DrawCallOptions.pendingPipelines` →
  `frame(gpu, cb, { pendingPipelines })` / `FrameLoopOptions` → `init({ pendingPipelines })`.
  The frame link is an **instance field on `Frame`**, so a manually driven frame (no callback)
  keeps its policy and no policy leaks between frames.
- **`prepare.ts`** (new public module) — `{draw|effect, target}`, `{compute}`, `{bundle}`;
  single/array overloads with tuple inference; `Promise.allSettled` so a batch of combinations
  fails as a batch.
- **`errors.ts`** — `VGPU-PIPELINE-PENDING` (the body's exact actionable `fix` text) and
  `VGPU-PREPARE-FAILED` (enumerates **every** failed combination: label + resolved signature + cause).
- **`@vgpu/core`** — `VGPUErrorDetail.failures`, purely additive (optional field; `VGPUErrorDetail`
  has no consumer outside `packages/core` itself).

> ### Deliberate deviation — the effective default is `"sync"`, not `"throw"`
> AC #3 mandates `"throw"` as the final default. This branch implements the **whole mechanism**
> (three values, full chain) but keeps the effective default at `"sync"` — index invariant 2. Zero
> call sites have migrated to `prepare()` yet, so `"throw"` would break every existing program at
> once. The flip belongs to the cut wave, with the codemods. Documented next to the constant in
> `pending-pipelines.ts`.

### Trimmed scope — bundles
`RecordedBundle` now retains its recording closure, and `prepare(gpu, [{ bundle }])` re-encodes a
`stale` bundle from it (semantics G1). **Not** implemented, per the ticket: `Bundle.status`,
`Bundle.error`, `dispose()`, `rebuild()`, the `failed`/`disposed` states — i.e. contract #15 stays
in **wave 2+**. A real signature mismatch still throws `VGPU-R3-BUNDLE-STALE` instead of auto-healing.

## Compatibility

`pipelineFor` / `pipelineForAsync` / `compile` / `compileSync` / `DrawOptions.targets` all survive
untouched (invariant 3). `pipelineFor()` now delegates to the shared resolver with a hard-coded
`"sync"` — one implementation of "resolve this combination for a synchronous caller" instead of two
that can drift. `encode()` keeps reporting `where: "<label>.pipelineFor"` on a sync compile failure.
No call site in the corpus changed.

## Budgets

Re-baselined in 6dfc6918, measured with a full rebuild on **both** sides (`bundle-check` reads
`dist/`). ~390-410 B in every draw/effect bundle is the policy chain; ~750 B more in the full
entries is `prepare.ts`. Only the budgets that actually fail are raised, each to the next 512 B
multiple strictly above measured — `effect-only`, `triangle-low-level` and `init-only` still fit and
are left untouched. `vgpu/node` was already +46 B over its (warning-only) budget on the base commit;
this re-baseline absorbs that too.

## Tests

28 new tests (`prepare.test.ts` 18, `pending-pipelines.test.ts` 10); whole monorepo green
(1963 passed) and `tsc -b` clean.
