### PR TITLE
feat(api): ownership fixed at construction — { values, bindings }, .set(binding, value), .bind() and uniform()

### DIFF
--- a/packages/vgpu-api/package.json
+++ b/packages/vgpu-api/package.json
@@ -91,9 +91,9 @@
     "./core": "client"
   },
   "vgpuExportBundleBudgetsGzipBytes": {
-    ".": 39424,
-    "./node": 39424,
-    "./mock": 39424,
+    ".": 40448,
+    "./node": 40448,
+    "./mock": 40448,
     "./scene": 12800,
     "./client": 512,
     "./core": 3584
@@ -103,10 +103,10 @@
   },
   "vgpuExperienceBundleBudgetsGzipBytes": {
     "init-only": 1536,
-    "effect-only": 26624,
-    "triangle-low-level": 29696,
-    "draw-recipe-box": 30720,
-    "full-root": 39424
+    "effect-only": 27136,
+    "triangle-low-level": 30208,
+    "draw-recipe-box": 31232,
+    "full-root": 40448
   },
   "vgpuSceneBundleBudgetNote": "The scene barrel retains all recipe builders after the geometry redesign; direct primitive imports retain only their selected mesh, as the experience fixtures assert."
 }

--- a/packages/vgpu-api/package.json
+++ b/packages/vgpu-api/package.json
@@ -91,9 +91,9 @@
     "./core": "client"
   },
   "vgpuExportBundleBudgetsGzipBytes": {
-    ".": 40960,
-    "./node": 40960,
-    "./mock": 40960,
+    ".": 41472,
+    "./node": 41472,
+    "./mock": 41472,
     "./scene": 12800,
     "./client": 512,
     "./core": 3584
@@ -103,10 +103,10 @@
   },
   "vgpuExperienceBundleBudgetsGzipBytes": {
     "init-only": 1536,
-    "effect-only": 27136,
-    "triangle-low-level": 30208,
-    "draw-recipe-box": 31232,
-    "full-root": 40960
+    "effect-only": 27648,
+    "triangle-low-level": 30720,
+    "draw-recipe-box": 31744,
+    "full-root": 41472
   },
   "vgpuSceneBundleBudgetNote": "The scene barrel retains all recipe builders after the geometry redesign; direct primitive imports retain only their selected mesh, as the experience fixtures assert."
 }

--- a/packages/vgpu-api/src/api-types.ts
+++ b/packages/vgpu-api/src/api-types.ts
@@ -11,6 +11,16 @@ import type { Target } from "./target.ts";
 export interface ComputeOptions {
   readonly label?: string;
   readonly set?: Record<string, unknown>;
+  /**
+   * Initial values for instance-owned bindings, keyed by WGSL binding name. Declaring a binding here
+   * pins it value-owned at construction: its storage is created here and only `.set()` writes it.
+   */
+  readonly values?: Record<string, unknown>;
+  /**
+   * Externally-owned resources, keyed by WGSL binding name. A binding declared here is external from
+   * construction — `.set()` on it throws VGPU-R1-EXTERNAL-BINDING and `.bind()` swaps its identity.
+   */
+  readonly bindings?: Record<string, unknown>;
   /** Values for WGSL `override` constants, keyed by name (or by numeric id as a string when the override has @id). Immutable after construction. */
   readonly constants?: Readonly<Record<string, number | boolean>>;
   /** Compute entry point to use when the shader has several. Defaults to the first @compute entry point. */
@@ -23,7 +33,13 @@ export interface DispatchOptions {
   readonly indirect: StorageBuffer | { readonly buffer: StorageBuffer; readonly offset?: number };
 }
 export interface Compute {
+  /** Binding-scoped write: names a complete instance-owned binding and writes its bytes. */
+  set(binding: string, value: unknown): this;
+  // Overload order is public API surface: `Parameters<Compute["set"]>` resolves to the LAST overload,
+  // so the legacy flat bag stays last and every type derived from it keeps its current shape.
   set(values: Record<string, unknown>): this;
+  /** Identity swap of an externally-owned binding. Dedupes by identity; rebuilds exactly that group. */
+  bind(binding: string, resource: unknown): this;
   dispatch(x: number, y?: number, z?: number): void;
   dispatch(opts: DispatchOptions): void;
   dispatchOnce(x: number, y?: number, z?: number): Promise<void>;

--- a/packages/vgpu-api/src/compute.ts
+++ b/packages/vgpu-api/src/compute.ts
@@ -85,15 +85,26 @@ export class ComputePipeline implements Compute {
       layout: this.pipelineLayout,
       compute: { module: this.shaderModule, entryPoint: this.entryPoint, ...(constants ? { constants } : {}) },
     };
-    this.setCore = createSetCore({ device, label: this.label, drawId: this.id, reflection: this.reflection, bindGroupLayouts: this.bindGroupLayouts, cache: this.cache });
+    // Ownership is fixed here, before any set(): the engine applies `bindings` (external) and
+    // `values` (instance-owned) while it builds the binding state machine.
+    this.setCore = createSetCore({ device, label: this.label, drawId: this.id, reflection: this.reflection, bindGroupLayouts: this.bindGroupLayouts, cache: this.cache, values: opts.values, bindings: opts.bindings });
     const active = new Set(entryMetadata(entry, "bindings", this.label).map((binding) => `${binding.group}:${binding.binding}`));
     this.#storageBindings = this.reflection.bindings.filter((binding) => binding.kind === "buffer" && binding.addressSpace === "storage" && active.has(`${binding.group}:${binding.binding}`));
     if (opts.set) this.set(opts.set);
   }
 
-  set(values: SetBag): this {
+  set(binding: string, value: unknown): this;
+  set(values: SetBag): this;
+  set(bindingOrValues: string | SetBag, value?: unknown): this {
     assertDeviceUsable(this.device, `${this.label}.set`);
-    this.setCore.set(values);
+    if (typeof bindingOrValues === "string") this.setCore.setScoped(bindingOrValues, value);
+    else this.setCore.set(bindingOrValues);
+    return this;
+  }
+
+  bind(binding: string, resource: unknown): this {
+    assertDeviceUsable(this.device, `${this.label}.bind`);
+    this.setCore.bind(binding, resource);
     return this;
   }
 

--- a/packages/vgpu-api/src/draw.ts
+++ b/packages/vgpu-api/src/draw.ts
@@ -105,6 +105,16 @@ export interface DrawOptions {
   readonly shader: string | ShaderSource;
   readonly geometry?: GeometryLike;
   readonly set?: SetBag;
+  /**
+   * Initial values for instance-owned bindings, keyed by WGSL binding name. Declaring a binding here
+   * pins it value-owned at construction: its storage is created here and only `.set()` writes it.
+   */
+  readonly values?: Record<string, unknown>;
+  /**
+   * Externally-owned resources, keyed by WGSL binding name. A binding declared here is external from
+   * construction — `.set()` on it throws VGPU-R1-EXTERNAL-BINDING and `.bind()` swaps its identity.
+   */
+  readonly bindings?: Record<string, unknown>;
   readonly label?: string;
   readonly targets?: readonly Target[];
   /** Default instance count for every draw call. Overridden by per-call opts. Use 0 for a valid no-instance draw. */
@@ -254,7 +264,13 @@ const drawStates = new WeakMap<Draw, DrawState>();
 export interface Draw {
   readonly gpu: GPURenderPipeline | undefined;
   readonly targets: readonly Target[] | undefined;
+  /** Binding-scoped write: names a complete instance-owned binding and writes its bytes. */
+  set(binding: string, value: unknown): this;
+  // Overload order is public API surface: `Parameters<Draw["set"]>` resolves to the LAST overload,
+  // so the legacy flat bag stays last and every type derived from it keeps resolving to `[SetBag]`.
   set(values: SetBag): this;
+  /** Identity swap of an externally-owned binding. Dedupes by identity; rebuilds exactly that group. */
+  bind(binding: string, resource: unknown): this;
   group(n: number, bindGroup: GPUBindGroup): this;
   layout(n: number, opts?: DrawLayoutOptions): GPUBindGroupLayout;
   draw(target?: Target | DrawCallOptions): void;
@@ -316,6 +332,10 @@ export class InternalDraw implements Draw {
       bindGroupLayouts,
       cache,
       onIdentityChange: (change) => recordedIn.markStale({ kind: "binding-identity", drawLabel: this.label, ...change }),
+      // Ownership is fixed here, before any set(): the engine applies `bindings` (external) and
+      // `values` (instance-owned) while it builds the binding state machine.
+      values: opts.values,
+      bindings: opts.bindings,
     });
     drawStates.set(this, { id, device, opts, vertexBufferLayouts, cache, defaultTarget, reflection, visibility, vertexEntry: vertexEntry?.name ?? "vs_main", fragmentEntry: fragmentEntry?.name ?? "fs_main", entryKey, setCore, bindGroupLayouts, pipelineLayout, shaderModule, pipelineStore, pipelineLayouts, errorSink, trackSettled, resolvedPipelineKeys: new Set(), recordedIn, ...fragmentState, ...blendConstantOptions, ...primitiveOptions, ...depthOptions, ...stencilOptions, ...multisampleOptions, ...constantsOptions });
     if (opts.set) this.set(opts.set);
@@ -343,10 +363,21 @@ export class InternalDraw implements Draw {
   /** @internal Frame drawable protocol; see {@link drawStencilWritingOps}. */
   stencilWritingOps(): readonly string[] { return drawStencilWritingOps(this); }
 
-  set(values: SetBag): this {
+  set(binding: string, value: unknown): this;
+  set(values: SetBag): this;
+  set(bindingOrValues: string | SetBag, value?: unknown): this {
     const state = drawState(this);
     assertDeviceUsable(state.device, `${this.label}.set`);
-    for (const change of state.setCore.set(values)) state.recordedIn.markStale({ kind: "binding-identity", drawLabel: this.label, ...change });
+    const changes = typeof bindingOrValues === "string" ? state.setCore.setScoped(bindingOrValues, value) : state.setCore.set(bindingOrValues);
+    for (const change of changes) state.recordedIn.markStale({ kind: "binding-identity", drawLabel: this.label, ...change });
+    return this;
+  }
+
+  bind(binding: string, resource: unknown): this {
+    const state = drawState(this);
+    assertDeviceUsable(state.device, `${this.label}.bind`);
+    // A dedup hit returns no change, so a repeated rebind never marks a bundle stale either.
+    for (const change of state.setCore.bind(binding, resource)) state.recordedIn.markStale({ kind: "binding-identity", drawLabel: this.label, ...change });
     return this;
   }
 

--- a/packages/vgpu-api/src/effect.ts
+++ b/packages/vgpu-api/src/effect.ts
@@ -55,6 +55,16 @@ export function effect(gpu: Gpu, input: string | ShaderSource | EffectOptions, o
 
 export interface EffectOptions {
   readonly set?: SetBag;
+  /**
+   * Initial values for instance-owned bindings, keyed by WGSL binding name. Declaring a binding here
+   * pins it value-owned at construction: its storage is created here and only `.set()` writes it.
+   */
+  readonly values?: Record<string, unknown>;
+  /**
+   * Externally-owned resources, keyed by WGSL binding name. A binding declared here is external from
+   * construction — `.set()` on it throws VGPU-R1-EXTERNAL-BINDING and `.bind()` swaps its identity.
+   */
+  readonly bindings?: Record<string, unknown>;
   readonly label?: string;
   /** Blend state applied to every color target of this effect's pipelines. Preset or explicit components. Immutable after construction. */
   readonly blend?: BlendPreset | BlendOptions;
@@ -68,7 +78,13 @@ const effectImpls = new WeakMap<Effect, InternalDraw>();
 
 export interface Effect {
   readonly gpu: GPURenderPipeline | undefined;
+  /** Binding-scoped write: names a complete instance-owned binding and writes its bytes. */
+  set(binding: string, value: unknown): this;
+  // Overload order is public API surface: `Parameters<Effect["set"]>` resolves to the LAST overload,
+  // so the legacy flat bag stays last and every type derived from it keeps resolving to `[SetBag]`.
   set(values: SetBag): this;
+  /** Identity swap of an externally-owned binding. Dedupes by identity; rebuilds exactly that group. */
+  bind(binding: string, resource: unknown): this;
   draw(target?: Target | DrawCallOptions): void;
   /** @throws VGPU-SURFACE-NOT-IN-FRAME when passed a Surface outside frame(gpu). */
   compile(target?: CompileTarget): Promise<this>;
@@ -81,11 +97,19 @@ export class InternalEffect implements Effect {
 
   constructor(device: Device, source: string, opts: EffectOptions = {}, cache?: BindGroupCache, defaultTarget?: Target, pipelineStore?: PipelineStore, shaderModules?: ShaderModuleCache, pipelineLayouts?: PipelineLayoutCache, errorSink?: ValidationErrorSink, trackSettled?: (promise: Promise<unknown>) => void) {
     const shader = fullscreenSource(source);
-    const impl = new InternalDraw(device, shader, { shader, set: opts.set, label: opts.label ?? "effect", blend: opts.blend, writeMask: opts.writeMask }, cache, defaultTarget, pipelineStore, shaderModules, pipelineLayouts, errorSink, trackSettled);
+    const impl = new InternalDraw(device, shader, { shader, set: opts.set, values: opts.values, bindings: opts.bindings, label: opts.label ?? "effect", blend: opts.blend, writeMask: opts.writeMask }, cache, defaultTarget, pipelineStore, shaderModules, pipelineLayouts, errorSink, trackSettled);
     effectImpls.set(this, impl);
   }
 
-  set(values: SetBag): this { effectImpl(this).set(values); return this; }
+  set(binding: string, value: unknown): this;
+  set(values: SetBag): this;
+  set(bindingOrValues: string | SetBag, value?: unknown): this {
+    if (typeof bindingOrValues === "string") effectImpl(this).set(bindingOrValues, value);
+    else effectImpl(this).set(bindingOrValues);
+    return this;
+  }
+
+  bind(binding: string, resource: unknown): this { effectImpl(this).bind(binding, resource); return this; }
   draw(target: Target | DrawCallOptions = {}): void { effectImpl(this).draw(isTarget(target) ? { target } : target); }
   compile(target?: CompileTarget): Promise<this> { return effectImpl(this).compile(target).then(() => this); }
   compileSync(target?: CompileTarget): this { effectImpl(this).compileSync(target); return this; }

--- a/packages/vgpu-api/src/errors.ts
+++ b/packages/vgpu-api/src/errors.ts
@@ -49,6 +49,21 @@ export function ownershipFlipError(name: string, previous: "lib" | "user"): VGPU
   });
 }
 
+/**
+ * Ownership is fixed at construction: a binding listed in `bindings` (or swapped with `.bind()`)
+ * holds a resource the instance does not own, so `.set()` — which writes bytes — has nothing to
+ * write into. The fix names both alternatives: update the resource, or swap identity with `.bind()`.
+ */
+export function externalBindingError(where: string, label: string, binding: string): VGPUError {
+  return new VGPUError({
+    code: "VGPU-R1-EXTERNAL-BINDING",
+    message: `\`${binding}\` in '${label}' is bound to an external resource; set() writes bytes on instance-owned bindings only.`,
+    fix: `Update the resource itself (resource.set({ ... })), or swap its identity with ${label}.bind("${binding}", resource).`,
+    where,
+    detail: { bindingName: binding },
+  });
+}
+
 export function claimedGroupSetError(label: string, group: number): VGPUError {
   return new VGPUError({
     code: "VGPU-R4-GROUP-CLAIMED",

--- a/packages/vgpu-api/src/index.ts
+++ b/packages/vgpu-api/src/index.ts
@@ -32,7 +32,7 @@ export { surface } from "./surface.ts";
 export type { SurfaceCanvas } from "./surface.ts";
 export { target } from "./target-offscreen.ts";
 export { timer } from "./timer.ts";
-export { uniforms } from "./uniforms.ts";
+export { uniform, uniforms } from "./uniforms.ts";
 export { visibility } from "./visibility.ts";
 export { geometry } from "./scene/geometry-descriptor.ts";
 export type { GeometryRecipe, GeometryRecipeOf } from "./scene/geometry-recipe.ts";

--- a/packages/vgpu-api/src/mock.ts
+++ b/packages/vgpu-api/src/mock.ts
@@ -36,7 +36,7 @@ export { surface } from "./surface.ts";
 export type { SurfaceCanvas } from "./surface.ts";
 export { target } from "./target-offscreen.ts";
 export { timer } from "./timer.ts";
-export { uniforms } from "./uniforms.ts";
+export { uniform, uniforms } from "./uniforms.ts";
 export { visibility } from "./visibility.ts";
 export { geometry } from "./scene/geometry-descriptor.ts";
 export type { GeometryRecipe, GeometryRecipeOf } from "./scene/geometry-recipe.ts";

--- a/packages/vgpu-api/src/node.ts
+++ b/packages/vgpu-api/src/node.ts
@@ -36,7 +36,7 @@ export { surface } from "./surface.ts";
 export type { SurfaceCanvas } from "./surface.ts";
 export { target } from "./target-offscreen.ts";
 export { timer } from "./timer.ts";
-export { uniforms } from "./uniforms.ts";
+export { uniform, uniforms } from "./uniforms.ts";
 export { visibility } from "./visibility.ts";
 export { geometry } from "./scene/geometry-descriptor.ts";
 export type { GeometryRecipe, GeometryRecipeOf } from "./scene/geometry-recipe.ts";

--- a/packages/vgpu-api/src/set-core.ts
+++ b/packages/vgpu-api/src/set-core.ts
@@ -2,7 +2,7 @@ import { bindGroupLayoutMetadata, bindGroupMetadataFor, type Buffer, type Device
 import type { BindingInfo, Reflection } from "@vgpu/wgsl/reflect-source";
 import { identityKey, type BindGroupCache, type BindGroupIdentityPart } from "./bind-cache.ts";
 import { entryMetadata } from "./entry-metadata.ts";
-import { claimedGroupIncompatibleError, claimedGroupSetError, neverSetError, ownershipFlipError, unsupportedError } from "./errors.ts";
+import { claimedGroupIncompatibleError, claimedGroupSetError, externalBindingError, neverSetError, ownershipFlipError, unsupportedError } from "./errors.ts";
 import { bindGroupLayoutEntriesForGroup, bindGroupLayoutsForReflection, pipelineLayoutFor } from "./set-layouts.ts";
 import { isPlainObject, isPlainValue, normalizeResource } from "./set-resources.ts";
 import { writeLayoutValue } from "./set-packing.ts";
@@ -18,6 +18,17 @@ export interface SetCoreOptions {
   readonly bindGroupLayouts: ReadonlyMap<number, GPUBindGroupLayout>;
   readonly cache: BindGroupCache;
   readonly onIdentityChange?: (change: BindingIdentityChange) => void;
+  /**
+   * Initial values for instance-owned (value-owned) bindings, keyed by WGSL binding name.
+   * Declaring a binding here pins it value-owned at construction — it never latches by call order.
+   */
+  readonly values?: Readonly<Record<string, unknown>>;
+  /**
+   * Externally-owned resources, keyed by WGSL binding name. A binding declared here is external
+   * from construction: `.set()` on it fails with VGPU-R1-EXTERNAL-BINDING, and only `.bind()`
+   * swaps its identity.
+   */
+  readonly bindings?: Readonly<Record<string, unknown>>;
 }
 
 export interface BindingIdentityChange {
@@ -33,6 +44,17 @@ export interface BindingIdentityChange {
 export interface SetCore {
   readonly groups: readonly number[];
   set(values: SetBag): readonly BindingIdentityChange[];
+  /**
+   * Binding-scoped write: `binding` names a complete WGSL binding (never a struct member) owned by
+   * this instance, `value` is a partial for a struct binding and the complete value otherwise.
+   * One call is one buffer write.
+   */
+  setScoped(binding: string, value: unknown): readonly BindingIdentityChange[];
+  /**
+   * Identity swap for an externally-owned binding. Dedupes by resource identity — rebinding the same
+   * resource is free and rebuilds nothing.
+   */
+  bind(binding: string, resource: unknown): readonly BindingIdentityChange[];
   claimGroup(group: number, bindGroup: GPUBindGroup, expectedLayout: GPUBindGroupLayout): string | undefined;
   layout(group: number): GPUBindGroupLayout;
   bindGroups(): readonly { readonly group: number; readonly bindGroup: GPUBindGroup; readonly offsets: readonly number[]; readonly claimValidation?: { readonly label: string; readonly group: number } }[];
@@ -49,6 +71,15 @@ export interface BindingState {
 type MutableBindingState = {
   readonly info: BindingInfo;
   ownership?: BindingOwnership;
+  /**
+   * Construction-time (or `.bind()`-time) declaration that the resource behind this binding belongs
+   * to someone else. Distinct from `ownership === "user"`, which the legacy flat bag latches by call
+   * order: `external` is never inferred from a value, so VGPU-R1-EXTERNAL-BINDING can only fire for
+   * the `{ bindings }` / `.bind()` forms.
+   */
+  external?: boolean;
+  /** Last resource passed to `.bind()`, kept for the free identity dedup of a repeated rebind. */
+  boundValue?: unknown;
   readonly memberOwnership: Map<string, BindingOwnership>;
   buffer?: Buffer;
   bytes?: ArrayBuffer;
@@ -71,6 +102,74 @@ export function createSetCore(options: SetCoreOptions): SetCore {
     return changes;
   }
 
+  /**
+   * Construction-time ownership. `bindings` entries become external immediately (no latch, so
+   * VGPU-R1-OWNERSHIP-FLIP is unreachable for them) and `values` entries become value-owned with
+   * their storage created and written right here.
+   */
+  function declareOwnership(): void {
+    const declaredValues = options.values ?? {};
+    for (const [name, resource] of Object.entries(options.bindings ?? {})) {
+      if (Object.hasOwn(declaredValues, name)) throw unsupportedError(options.label, `Binding '${name}' is declared in both values and bindings of '${options.label}'.`, "Ownership is fixed at construction: declare it in exactly one of them.");
+      bindExternal(requiredBindingByName(name, "bindings"), resource);
+    }
+    for (const [name, value] of Object.entries(declaredValues)) setScoped(name, value);
+  }
+
+  function bindExternal(state: MutableBindingState, resource: unknown): void {
+    state.external = true;
+    state.ownership = "user";
+    state.boundValue = resource;
+    setUserOwned(state, resource);
+  }
+
+  /**
+   * Binding-scoped write. Resolves `name` as a complete binding only — the member-name shortcut of
+   * the flat bag does not exist here (design §6: "no member-name shortcut"), and a member name gets
+   * an error that names the binding to use instead.
+   */
+  function setScoped(name: string, value: unknown): readonly BindingIdentityChange[] {
+    const state = requiredBindingByName(name, "set");
+    // The external check comes first: naming an externally-bound resource is the interesting
+    // mistake, and its fix-it is more useful than "this is not a JS value".
+    ensureNotExternal(state, name);
+    if (ownershipFor(state.info, value) !== "lib") {
+      throw unsupportedError(`${options.label}.set`, `Binding '${name}' in '${options.label}' received a resource; set() writes bytes.`, `Swap resource identity with ${options.label}.bind("${name}", resource).`);
+    }
+    // Same write path as the flat bag once the name is resolved: a struct merges the partial on the
+    // CPU and rewrites completely (one buffer write), a non-struct value replaces wholesale.
+    return setBinding(state, name, value);
+  }
+
+  /**
+   * Identity swap. Dedupes on the resource reference first (the per-frame rebind of the same object
+   * is free) and then on the normalized resource identity, so a rebind that resolves to the same
+   * GPU resource reports no change and the bind group cache keeps its entry.
+   */
+  function bind(name: string, resource: unknown): readonly BindingIdentityChange[] {
+    const state = requiredBindingByName(name, "bind");
+    ensureGroupSettable(state.info.group);
+    // Owned -> external transitions are not supported (design §6): recreate the instance instead.
+    if (!state.external && state.ownership === "lib") throw ownershipFlipError(name, "lib");
+    if (state.resource && Object.is(state.boundValue, resource)) return [];
+    const before = identityString(state.identity);
+    bindExternal(state, resource);
+    return bindingIsActive(state) ? identityChangeFor(state, before) : [];
+  }
+
+  /**
+   * Resolves a complete binding by name. A struct member name is not a binding here (design §6: no
+   * member-name shortcut), so it gets the fix-it that names the binding to use instead — reusing the
+   * flat bag's member lookup, which already reports an ambiguous member name.
+   */
+  function requiredBindingByName(name: string, verb: string): MutableBindingState {
+    const state = bindings.get(name);
+    if (state) return state;
+    const owner = findMemberBinding(name, bindings, options.label);
+    const fix = owner ? `'${name}' is a member of binding '${owner.info.name}': ${options.label}.set("${owner.info.name}", { ${name}: value }).` : undefined;
+    throw unsupportedError(`${options.label}.${verb}`, `Binding '${name}' does not exist in '${options.label}'.`, fix);
+  }
+
   function bindingIsActive(state: MutableBindingState): boolean {
     const layout = options.bindGroupLayouts.get(state.info.group);
     return !!layout && !!bindGroupLayoutMetadata(layout)?.entries.some((entry) => entry.binding === state.info.binding);
@@ -86,6 +185,7 @@ export function createSetCore(options: SetCoreOptions): SetCore {
 
   function setBinding(state: MutableBindingState, name: string, value: unknown): readonly BindingIdentityChange[] {
     ensureGroupSettable(state.info.group);
+    ensureNotExternal(state, name);
     const ownership = ownershipFor(state.info, value);
     latchBindingOwnership(state, name, ownership);
     const before = identityString(state.identity);
@@ -96,6 +196,7 @@ export function createSetCore(options: SetCoreOptions): SetCore {
 
   function setBindingMember(state: MutableBindingState, memberName: string, value: unknown): readonly BindingIdentityChange[] {
     ensureGroupSettable(state.info.group);
+    ensureNotExternal(state, state.info.name);
     const ownership = ownershipFor(state.info, value);
     latchBindingOwnership(state, memberName, ownership);
     latchMemberOwnership(state, memberName, ownership);
@@ -204,6 +305,10 @@ export function createSetCore(options: SetCoreOptions): SetCore {
     if (claimedGroups.has(group)) throw claimedGroupSetError(options.label, group);
   }
 
+  function ensureNotExternal(state: MutableBindingState, name: string): void {
+    if (state.external) throw externalBindingError(`${options.label}.set`, options.label, name);
+  }
+
   function createLibBuffer(state: MutableBindingState, size: number): void {
     state.buffer = options.device.createBuffer({ size, usage: ["uniform", "copy_dst"], label: `${options.label}.${state.info.name}` });
     state.resource = { buffer: state.buffer.gpu, offset: 0, size };
@@ -216,9 +321,13 @@ export function createSetCore(options: SetCoreOptions): SetCore {
     return state.info.layout as NonNullable<BindingInfo["layout"]> & { readonly size: number };
   }
 
+  declareOwnership();
+
   return {
     get groups() { return groups; },
     set,
+    setScoped,
+    bind,
     claimGroup,
     layout,
     bindGroups,

--- a/packages/vgpu-api/src/set-core.ts
+++ b/packages/vgpu-api/src/set-core.ts
@@ -149,8 +149,12 @@ export function createSetCore(options: SetCoreOptions): SetCore {
   function bind(name: string, resource: unknown): readonly BindingIdentityChange[] {
     const state = requiredBindingByName(name, "bind");
     ensureGroupSettable(state.info.group);
-    // Owned -> external transitions are not supported (design §6): recreate the instance instead.
-    if (!state.external && state.ownership === "lib") throw ownershipFlipError(name, "lib");
+    // Ownership is fixed at construction, never by call order (design §6). Only a binding declared
+    // in `bindings` is external, so `.bind()` on anything else flips ownership and is refused —
+    // including a binding nobody has touched yet, whose value-owned storage is merely lazy (A-3).
+    // Without this, `.bind()` on a virgin binding would silently promote it and resurrect exactly
+    // the order-dependent latch the design makes unrepresentable.
+    if (!state.external) throw ownershipFlipError(name, state.ownership === "user" ? "user" : "lib");
     if (state.resource && Object.is(state.boundValue, resource)) return [];
     const before = identityString(state.identity);
     bindExternal(state, resource);

--- a/packages/vgpu-api/src/uniforms.ts
+++ b/packages/vgpu-api/src/uniforms.ts
@@ -137,6 +137,18 @@ export function uniforms<T extends Record<string, unknown>>(gpu: Gpu, values: T)
   return ownResource(kernel, new SharedUniformsImpl(kernel.device, values), (shared) => shared.destroy());
 }
 
+/**
+ * One shared uniform/storage resource for this gpu, bindable from several pipelines at once
+ * (`bindings: { globals }`): one `set()` updates every consumer through a single buffer, and the
+ * storage is zero-initialized, so initial values are optional.
+ *
+ * Singular spelling of {@link uniforms} and exactly the same mechanism — the receiver *is* the
+ * binding, so its `set()` keeps the one-argument form. `uniforms()` (plural) stays until the cut.
+ */
+export function uniform<T extends Record<string, unknown>>(gpu: Gpu, values: T): SharedUniforms<T> {
+  return uniforms(gpu, values);
+}
+
 function ensureBufferBinding(binding: BindingInfo): void {
   if (binding.bindingLayout?.kind === "buffer") return;
   throw unsupportedError("uniforms", `Binding '${binding.name}' does not accept shared uniforms; the shader reflected ${binding.bindingLayout?.kind ?? "none"}.`);

--- a/packages/vgpu-api/tests/entrypoint-parity.test.ts
+++ b/packages/vgpu-api/tests/entrypoint-parity.test.ts
@@ -1,0 +1,18 @@
+import { expect, test } from "vitest";
+import * as index from "../src/index.ts";
+import * as mock from "../src/mock.ts";
+import * as node from "../src/node.ts";
+
+// `vgpu/mock` is the documented testing path and `vgpu/node` the documented headless one, so a
+// value export that only leaves the root entrypoint is broken for both without anything failing at
+// build time. That is how `uniform()` shipped bound to `.` alone while its sibling `uniforms()`
+// worked everywhere, and it is a mistake every new API of the train can repeat for free.
+//
+// The check is one-directional on purpose: `./mock` and `./node` legitimately add their own exports
+// (createMockAdapter, initFromDevice), they just may never be MISSING one.
+for (const [name, entrypoint] of [["mock", mock] as const, ["node", node] as const]) {
+  test(`./${name} re-exports every value export of the root entrypoint`, () => {
+    const missing = Object.keys(index).filter((exported) => !(exported in entrypoint));
+    expect(missing, `missing from ./${name}: ${missing.join(", ")}`).toEqual([]);
+  });
+}

--- a/packages/vgpu-api/tests/ownership.test.ts
+++ b/packages/vgpu-api/tests/ownership.test.ts
@@ -1,5 +1,6 @@
 import { expect, test, vi } from "vitest";
 import { getMockGPUDeviceInstrumentation } from "@vgpu/core";
+import { bundle } from "../src/bundle.ts";
 import { compute } from "../src/compute.ts";
 import { draw } from "../src/draw.ts";
 import { effect } from "../src/effect.ts";
@@ -64,7 +65,7 @@ struct Globals { time: f32 }
 
 function codeOf(fn: () => unknown): string {
   try { fn(); } catch (error) { return (error as { code?: string }).code ?? String(error); }
-  throw new Error("expected a VGPUError, none was thrown");
+  return "NO-THROW";
 }
 
 function messageOf(fn: () => unknown): string {
@@ -158,14 +159,67 @@ test("contract #9: .set() of an externally-bound name fails with VGPU-R1-EXTERNA
   gpu.dispose();
 });
 
-test("a binding promoted by .bind() also rejects .set() with VGPU-R1-EXTERNAL-BINDING", async () => {
+test("external ownership comes from the constructor, not from .bind(): a binding absent from bindings refuses .bind()", async () => {
   const gpu = await init();
   const source = target(gpu, { size: [4, 4] });
   const globals = uniform(gpu, { time: 0 });
+  // `src` is not declared anywhere, so it is value-owned by default — its storage is merely lazy.
   const fx = effect(gpu, { shader: OWNERSHIP_SHADER, label: "fx", values: { params: { intensity: 1 } }, bindings: { globals } });
 
-  fx.bind("src", source);
-  expect(codeOf(() => fx.set("src", source))).toBe("VGPU-R1-EXTERNAL-BINDING");
+  expect(codeOf(() => fx.bind("src", source))).toBe("VGPU-R1-OWNERSHIP-FLIP");
+  // Promotion to external is a construction-time decision, and then .bind() works and .set() does not.
+  const promoted = effect(gpu, { shader: OWNERSHIP_SHADER, label: "promoted", values: { params: { intensity: 1 } }, bindings: { src: source, globals } });
+  promoted.bind("src", target(gpu, { size: [4, 4] }));
+  expect(codeOf(() => promoted.set("src", source))).toBe("VGPU-R1-EXTERNAL-BINDING");
+  gpu.dispose();
+});
+
+test("ownership is fixed at construction: .bind() on a virgin binding never promotes it", async () => {
+  const gpu = await init();
+  const source = target(gpu, { size: [4, 4] });
+  const fx = effect(gpu, { shader: OWNERSHIP_SHADER, label: "fx" });
+
+  // Virgin: never set, absent from both values and bindings. Lazy storage must not read as "no
+  // owner yet" — that is exactly the order-dependent latch the design makes unrepresentable.
+  expect(codeOf(() => fx.bind("src", source))).toBe("VGPU-R1-OWNERSHIP-FLIP");
+  // ...and it stays refused after the binding has been written, so neither order promotes it.
+  fx.set("params", { intensity: 1 });
+  expect(codeOf(() => fx.bind("src", source))).toBe("VGPU-R1-OWNERSHIP-FLIP");
+  gpu.dispose();
+});
+
+test("ownership is order-independent: bind-then-set and set-then-bind give the same verdicts", async () => {
+  const gpu = await init();
+  const source = target(gpu, { size: [4, 4] });
+  const shader = GLOBALS_ONLY_SHADER;
+
+  const bindFirst = effect(gpu, { shader, label: "bindFirst" });
+  const bindThenSet = [codeOf(() => bindFirst.bind("globals", uniform(gpu, { time: 0 }))), codeOf(() => bindFirst.set("globals", { time: 1 }))];
+
+  const setFirst = effect(gpu, { shader, label: "setFirst" });
+  const setThenBind = [codeOf(() => setFirst.set("globals", { time: 1 })), codeOf(() => setFirst.bind("globals", uniform(gpu, { time: 0 })))];
+
+  // The pair of verdicts is the same set regardless of which call came first: the write succeeds,
+  // the bind is refused. Call order decides nothing.
+  expect(bindThenSet).toEqual(["VGPU-R1-OWNERSHIP-FLIP", "NO-THROW"]);
+  expect(setThenBind).toEqual(["NO-THROW", "VGPU-R1-OWNERSHIP-FLIP"]);
+  gpu.dispose();
+});
+
+test("a single .bind() never locks the legacy flat bag out of a binding it used to own", async () => {
+  const gpu = await init();
+  const screen = target(gpu, { size: [4, 4] });
+  const first = target(gpu, { size: [4, 4] });
+  const second = target(gpu, { size: [4, 4] });
+  const fx = effect(gpu, OWNERSHIP_SHADER, { label: "fx" });
+
+  // The flat bag latches `src` user-owned by call order (legacy behavior, alive until the cut).
+  fx.set({ src: first, params: { intensity: 1 }, globals: { time: 0 } });
+  // .bind() must not hijack it: the binding was never declared external.
+  expect(codeOf(() => fx.bind("src", second))).toBe("VGPU-R1-OWNERSHIP-FLIP");
+  // ...and the flat bag still owns it afterwards, exactly as on next/0.4.
+  fx.set({ src: second });
+  frame(gpu, (f) => f.pass({ target: screen }, (p) => p.draw(fx)));
   gpu.dispose();
 });
 
@@ -203,8 +257,22 @@ test("declaring the same binding in values and bindings fails at construction", 
   const gpu = await init();
   const globals = uniform(gpu, { time: 0 });
 
-  expect(messageOf(() => effect(gpu, { shader: GLOBALS_ONLY_SHADER, label: "fx", values: { globals: { time: 0 } }, bindings: { globals } })))
-    .toMatch(/globals/);
+  const construct = () => effect(gpu, { shader: GLOBALS_ONLY_SHADER, label: "fx", values: { globals: { time: 0 } }, bindings: { globals } });
+  // The code matters: a missing duplicate guard would still fail later with EXTERNAL-BINDING, and
+  // that failure would arrive at the first .set() instead of at the contradictory declaration.
+  expect(codeOf(construct)).toBe("VGPU-RING1-UNSUPPORTED");
+  expect(messageOf(construct)).toMatch(/globals/);
+  gpu.dispose();
+});
+
+test("the scoped set() refuses a resource on a value-owned binding and points at .bind()", async () => {
+  const gpu = await init();
+  const source = target(gpu, { size: [4, 4] });
+  const fx = effect(gpu, { shader: OWNERSHIP_SHADER, label: "fx" });
+
+  // Value-owned (not external), so this is the bytes-vs-identity mistake, not the ownership one.
+  expect(codeOf(() => fx.set("src", source))).toBe("VGPU-RING1-UNSUPPORTED");
+  expect(messageOf(() => fx.set("src", source))).toMatch(/bind\("src"/);
   gpu.dispose();
 });
 
@@ -268,14 +336,18 @@ test("contract #10: a struct binding merges partials on the CPU and rewrites the
   const gpu = await init();
   const fx = effect(gpu, { shader: CAMERA_SHADER, label: "cam" });
 
-  fx.set("camera", { viewProjection: new Array(16).fill(0), exposure: 2 });
+  fx.set("camera", { viewProjection: new Array(16).fill(7), exposure: 2 });
   const writeBuffer = vi.spyOn(gpu.device.gpu.queue, "writeBuffer");
   fx.set("camera", { exposure: 3 });
 
   expect(writeBuffer).toHaveBeenCalledTimes(1);
   const [, , data] = writeBuffer.mock.calls[0]!;
-  // 16 floats of viewProjection then exposure: the absent field kept its previous value.
-  expect(new Float32Array(data as ArrayBuffer)[16]).toBe(3);
+  const written = new Float32Array(data as ArrayBuffer);
+  // 16 floats of viewProjection then exposure: the named field moved...
+  expect(written[16]).toBe(3);
+  // ...and the field absent from this call kept the value of the previous one, which is what makes
+  // the single write a complete struct rewrite rather than a partial one.
+  expect([...written.slice(0, 16)]).toEqual(new Array(16).fill(7));
   writeBuffer.mockRestore();
   gpu.dispose();
 });
@@ -448,5 +520,43 @@ test(".set() and .bind() reject a name that is not a binding", async () => {
 
   expect(messageOf(() => fx.set("nope", 1))).toMatch(/'nope'/);
   expect(messageOf(() => fx.bind("nope", globals))).toMatch(/'nope'/);
+  gpu.dispose();
+});
+
+// ---------------------------------------------------------------------------
+// .bind() and recorded bundles — the identity swap must reach replay
+// ---------------------------------------------------------------------------
+
+const TEXTURE_SHADER = `
+@group(0) @binding(0) var src: texture_2d<f32>;
+@fragment fn main(@location(0) uv: vec2f) -> @location(0) vec4f { return textureLoad(src, vec2u(0, 0), 0) + vec4f(uv, 0.0, 0.0); }
+`;
+
+test(".bind() to a different resource marks a recorded bundle stale", async () => {
+  const gpu = await init();
+  const screen = target(gpu, { size: [4, 4], format: "rgba8unorm" });
+  const first = target(gpu, { size: [4, 4] });
+  const second = target(gpu, { size: [4, 4] });
+  const fx = effect(gpu, { shader: TEXTURE_SHADER, label: "fx", bindings: { src: first } });
+  const recorded = bundle(gpu, { target: { colors: ["rgba8unorm"] }, label: "bnd" }, (r) => r.draw(fx));
+
+  fx.bind("src", second);
+
+  // Replaying a bundle whose binding identity moved must fail loudly instead of drawing `first`.
+  expect(codeOf(() => frame(gpu, (f) => f.pass({ target: screen }, (p) => p.bundles(recorded))))).toBe("VGPU-R3-BUNDLE-STALE");
+  gpu.dispose();
+});
+
+test(".bind() to the same resource leaves a recorded bundle replayable", async () => {
+  const gpu = await init();
+  const screen = target(gpu, { size: [4, 4], format: "rgba8unorm" });
+  const source = target(gpu, { size: [4, 4] });
+  const fx = effect(gpu, { shader: TEXTURE_SHADER, label: "fx", bindings: { src: source } });
+  const recorded = bundle(gpu, { target: { colors: ["rgba8unorm"] }, label: "bnd" }, (r) => r.draw(fx));
+
+  // The per-frame rebind of an unchanged resource is the ≥42-call-site case: it must stay free.
+  for (let i = 0; i < 5; i++) fx.bind("src", source);
+
+  expect(codeOf(() => frame(gpu, (f) => f.pass({ target: screen }, (p) => p.bundles(recorded))))).toBe("NO-THROW");
   gpu.dispose();
 });

--- a/packages/vgpu-api/tests/ownership.test.ts
+++ b/packages/vgpu-api/tests/ownership.test.ts
@@ -560,3 +560,23 @@ test(".bind() to the same resource leaves a recorded bundle replayable", async (
   expect(codeOf(() => frame(gpu, (f) => f.pass({ target: screen }, (p) => p.bundles(recorded))))).toBe("NO-THROW");
   gpu.dispose();
 });
+
+test(".bind() of an unchanged resource does not re-normalize it", async () => {
+  const gpu = await init();
+  const source = target(gpu, { size: [4, 4] });
+  const other = target(gpu, { size: [4, 4] });
+  const fx = effect(gpu, { shader: TEXTURE_SHADER, label: "fx", bindings: { src: source } });
+
+  const sourceView = vi.spyOn(source.color, "createView");
+  const otherView = vi.spyOn(other.color, "createView");
+  for (let index = 0; index < 5; index += 1) fx.bind("src", source);
+
+  // Skipping the bind group rebuild is not enough: normalizing allocates a fresh texture view and
+  // re-subscribes the destroy callback, so a per-frame rebind of the same resource would churn both
+  // every frame across the >=42 call sites that do exactly that. The dedup happens BEFORE the work.
+  expect(sourceView).not.toHaveBeenCalled();
+  // A real swap still normalizes exactly once — the fast path skips work, never a change.
+  fx.bind("src", other);
+  expect(otherView).toHaveBeenCalledTimes(1);
+  gpu.dispose();
+});

--- a/packages/vgpu-api/tests/ownership.test.ts
+++ b/packages/vgpu-api/tests/ownership.test.ts
@@ -1,0 +1,452 @@
+import { expect, test, vi } from "vitest";
+import { getMockGPUDeviceInstrumentation } from "@vgpu/core";
+import { compute } from "../src/compute.ts";
+import { draw } from "../src/draw.ts";
+import { effect } from "../src/effect.ts";
+import { frame } from "../src/frame.ts";
+import { init } from "../src/mock.ts";
+import { storage } from "../src/storage.ts";
+import { target } from "../src/target-offscreen.ts";
+import { uniform, uniforms } from "../src/uniforms.ts";
+
+/**
+ * Ownership contracts (#9, #10, #11 of issue #320 rev6 §6): `{ values, bindings }` fixes ownership at
+ * construction, `.set(binding, value)` writes bytes, `.bind(binding, resource)` swaps identity.
+ *
+ * The assertions below are semantic (which group was rebuilt, which buffer received the bytes, which
+ * error code fired) rather than raw call tallies wherever a tally would not pin the behavior down.
+ */
+
+const OWNERSHIP_SHADER = `
+struct Params { intensity: f32, tint: vec3f }
+@group(0) @binding(0) var<uniform> params: Params;
+@group(0) @binding(1) var src: texture_2d<f32>;
+struct Globals { time: f32 }
+@group(1) @binding(0) var<uniform> globals: Globals;
+@fragment fn main(@location(0) uv: vec2f) -> @location(0) vec4f {
+  return textureLoad(src, vec2u(0, 0), 0) * params.intensity * globals.time + vec4f(params.tint, 1.0) + vec4f(uv, 0.0, 0.0);
+}
+`;
+
+const MAT_SHADER = `
+@group(0) @binding(0) var<uniform> mvp: mat4x4f;
+@fragment fn main(@location(0) uv: vec2f) -> @location(0) vec4f { return mvp * vec4f(uv, 0.0, 1.0); }
+`;
+
+const CAMERA_SHADER = `
+struct Camera { viewProjection: mat4x4f, exposure: f32 }
+@group(0) @binding(0) var<uniform> camera: Camera;
+@fragment fn main(@location(0) uv: vec2f) -> @location(0) vec4f {
+  return camera.viewProjection * vec4f(uv, 0.0, camera.exposure);
+}
+`;
+
+const AMBIGUOUS_SHADER = `
+struct A { time: f32 }
+struct B { time: f32 }
+@group(0) @binding(0) var<uniform> a: A;
+@group(0) @binding(1) var<uniform> b: B;
+@fragment fn main(@location(0) uv: vec2f) -> @location(0) vec4f { return vec4f(a.time, b.time, uv); }
+`;
+
+const SIM_SHADER = `
+struct Sim { dt: f32 }
+@group(0) @binding(0) var<uniform> sim: Sim;
+@group(0) @binding(1) var<storage, read_write> particles: array<f32>;
+@compute @workgroup_size(1) fn main() { particles[0] = sim.dt; }
+`;
+
+const GLOBALS_ONLY_SHADER = `
+struct Globals { time: f32 }
+@group(0) @binding(0) var<uniform> globals: Globals;
+@fragment fn main(@location(0) uv: vec2f) -> @location(0) vec4f { return vec4f(globals.time, uv, 1.0); }
+`;
+
+function codeOf(fn: () => unknown): string {
+  try { fn(); } catch (error) { return (error as { code?: string }).code ?? String(error); }
+  throw new Error("expected a VGPUError, none was thrown");
+}
+
+function messageOf(fn: () => unknown): string {
+  try { fn(); } catch (error) { return `${(error as Error).message} ${(error as { fix?: string }).fix ?? ""}`; }
+  throw new Error("expected a VGPUError, none was thrown");
+}
+
+function groupLabels(mock: ReturnType<typeof getMockGPUDeviceInstrumentation>): string[] {
+  return mock.createBindGroupDescriptors.map((descriptor) => descriptor.label ?? "");
+}
+
+// ---------------------------------------------------------------------------
+// Contract #9 — .set() is bytes, .bind() is identity
+// ---------------------------------------------------------------------------
+
+test("contract #9: .set() on a value-owned binding never rebuilds a bind group", async () => {
+  const gpu = await init();
+  const source = target(gpu, { size: [4, 4] });
+  const globals = uniform(gpu, { time: 0 });
+  const screen = target(gpu, { size: [4, 4] });
+  const fx = effect(gpu, {
+    shader: OWNERSHIP_SHADER,
+    label: "fx",
+    values: { params: { intensity: 1 } },
+    bindings: { src: source, globals },
+  });
+  const mock = getMockGPUDeviceInstrumentation(gpu.device.gpu);
+
+  frame(gpu, (f) => f.pass({ target: screen }, (p) => p.draw(fx)));
+  const afterFirstFrame = mock.calls.createBindGroup;
+  expect(afterFirstFrame).toBe(2);
+
+  fx.set("params", { intensity: 0.5 });
+  fx.set("params", { intensity: 0.25 });
+  frame(gpu, (f) => f.pass({ target: screen }, (p) => p.draw(fx)));
+
+  expect(mock.calls.createBindGroup).toBe(afterFirstFrame);
+  gpu.dispose();
+});
+
+test("contract #9: .bind() rebuilds exactly the affected group", async () => {
+  const gpu = await init();
+  const source = target(gpu, { size: [4, 4] });
+  const next = target(gpu, { size: [4, 4] });
+  const globals = uniform(gpu, { time: 0 });
+  const screen = target(gpu, { size: [4, 4] });
+  const fx = effect(gpu, { shader: OWNERSHIP_SHADER, label: "fx", values: { params: { intensity: 1 } }, bindings: { src: source, globals } });
+  const mock = getMockGPUDeviceInstrumentation(gpu.device.gpu);
+
+  frame(gpu, (f) => f.pass({ target: screen }, (p) => p.draw(fx)));
+  expect(groupLabels(mock)).toEqual(["fx.group0", "fx.group1"]);
+
+  fx.bind("src", next);
+  frame(gpu, (f) => f.pass({ target: screen }, (p) => p.draw(fx)));
+
+  // Exactly the group holding `src` is rebuilt; group1 keeps its cached bind group.
+  expect(groupLabels(mock)).toEqual(["fx.group0", "fx.group1", "fx.group0"]);
+  gpu.dispose();
+});
+
+test("contract #9: .bind() dedupes by identity", async () => {
+  const gpu = await init();
+  const source = target(gpu, { size: [4, 4] });
+  const globals = uniform(gpu, { time: 0 });
+  const screen = target(gpu, { size: [4, 4] });
+  const fx = effect(gpu, { shader: OWNERSHIP_SHADER, label: "fx", values: { params: { intensity: 1 } }, bindings: { src: source, globals } });
+  const mock = getMockGPUDeviceInstrumentation(gpu.device.gpu);
+
+  frame(gpu, (f) => f.pass({ target: screen }, (p) => p.draw(fx)));
+  const baseline = mock.calls.createBindGroup;
+
+  for (let i = 0; i < 5; i++) fx.bind("src", source);
+  frame(gpu, (f) => f.pass({ target: screen }, (p) => p.draw(fx)));
+
+  expect(mock.calls.createBindGroup).toBe(baseline);
+  gpu.dispose();
+});
+
+test("contract #9: .set() of an externally-bound name fails with VGPU-R1-EXTERNAL-BINDING", async () => {
+  const gpu = await init();
+  const source = target(gpu, { size: [4, 4] });
+  const other = target(gpu, { size: [4, 4] });
+  const globals = uniform(gpu, { time: 0 });
+  const fx = effect(gpu, { shader: OWNERSHIP_SHADER, label: "fx", bindings: { src: source, globals } });
+
+  expect(codeOf(() => fx.set("src", other))).toBe("VGPU-R1-EXTERNAL-BINDING");
+  expect(codeOf(() => fx.set("globals", { time: 1 }))).toBe("VGPU-R1-EXTERNAL-BINDING");
+  // The message must name the binding and point at the resource to update instead.
+  expect(messageOf(() => fx.set("globals", { time: 1 }))).toMatch(/globals/);
+  expect(messageOf(() => fx.set("globals", { time: 1 }))).toMatch(/bind\(|\.set\(/);
+  gpu.dispose();
+});
+
+test("a binding promoted by .bind() also rejects .set() with VGPU-R1-EXTERNAL-BINDING", async () => {
+  const gpu = await init();
+  const source = target(gpu, { size: [4, 4] });
+  const globals = uniform(gpu, { time: 0 });
+  const fx = effect(gpu, { shader: OWNERSHIP_SHADER, label: "fx", values: { params: { intensity: 1 } }, bindings: { globals } });
+
+  fx.bind("src", source);
+  expect(codeOf(() => fx.set("src", source))).toBe("VGPU-R1-EXTERNAL-BINDING");
+  gpu.dispose();
+});
+
+test("the flat bag also refuses an externally declared binding", async () => {
+  const gpu = await init();
+  const source = target(gpu, { size: [4, 4] });
+  const other = target(gpu, { size: [4, 4] });
+  const globals = uniform(gpu, { time: 0 });
+  const fx = effect(gpu, { shader: OWNERSHIP_SHADER, label: "fx", bindings: { src: source, globals } });
+
+  expect(codeOf(() => fx.set({ src: other }))).toBe("VGPU-R1-EXTERNAL-BINDING");
+  gpu.dispose();
+});
+
+test("owned -> external is not supported: .bind() on a value-owned binding throws", async () => {
+  const gpu = await init();
+  const globals = uniform(gpu, { time: 0 });
+  const fx = effect(gpu, { shader: GLOBALS_ONLY_SHADER, label: "fx" });
+
+  fx.set("globals", { time: 0.5 });
+  expect(codeOf(() => fx.bind("globals", globals))).toBe("VGPU-R1-OWNERSHIP-FLIP");
+  gpu.dispose();
+});
+
+test("a binding declared in values is value-owned from construction and refuses .bind()", async () => {
+  const gpu = await init();
+  const globals = uniform(gpu, { time: 0 });
+  const fx = effect(gpu, { shader: GLOBALS_ONLY_SHADER, label: "fx", values: { globals: { time: 0 } } });
+
+  expect(codeOf(() => fx.bind("globals", globals))).toBe("VGPU-R1-OWNERSHIP-FLIP");
+  gpu.dispose();
+});
+
+test("declaring the same binding in values and bindings fails at construction", async () => {
+  const gpu = await init();
+  const globals = uniform(gpu, { time: 0 });
+
+  expect(messageOf(() => effect(gpu, { shader: GLOBALS_ONLY_SHADER, label: "fx", values: { globals: { time: 0 } }, bindings: { globals } })))
+    .toMatch(/globals/);
+  gpu.dispose();
+});
+
+test("a binding declared in bindings never latches ownership: VGPU-R1-OWNERSHIP-FLIP is unreachable for it", async () => {
+  const gpu = await init();
+  const globals = uniform(gpu, { time: 0 });
+  const fx = effect(gpu, { shader: GLOBALS_ONLY_SHADER, label: "fx", bindings: { globals } });
+
+  // The legacy latch would report OWNERSHIP-FLIP here; construction-time ownership reports
+  // EXTERNAL-BINDING instead, and it does so from the very first call.
+  expect(codeOf(() => fx.set({ globals: { time: 1 } }))).toBe("VGPU-R1-EXTERNAL-BINDING");
+  // ...and it stays EXTERNAL-BINDING on the second call too: there is no latch to flip.
+  expect(codeOf(() => fx.set({ globals: { time: 2 } }))).toBe("VGPU-R1-EXTERNAL-BINDING");
+  gpu.dispose();
+});
+
+// ---------------------------------------------------------------------------
+// Contract #10 — binding-scoped .set()
+// ---------------------------------------------------------------------------
+
+test("contract #10: a non-struct binding accepts its complete value", async () => {
+  const gpu = await init();
+  const screen = target(gpu, { size: [4, 4] });
+  const fx = effect(gpu, { shader: MAT_SHADER, label: "mat" });
+  const writeBuffer = vi.spyOn(gpu.device.gpu.queue, "writeBuffer");
+
+  const identity = [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1];
+  fx.set("mvp", identity);
+
+  expect(writeBuffer).toHaveBeenCalledTimes(1);
+  const [, offset, data] = writeBuffer.mock.calls[0]!;
+  expect(offset).toBe(0);
+  expect(new Float32Array(data as ArrayBuffer)).toEqual(new Float32Array(identity));
+  frame(gpu, (f) => f.pass({ target: screen }, (p) => p.draw(fx)));
+  writeBuffer.mockRestore();
+  gpu.dispose();
+});
+
+test("contract #10: one call carrying N fields of a struct produces exactly one buffer write", async () => {
+  const gpu = await init();
+  const fx = effect(gpu, { shader: CAMERA_SHADER, label: "cam" });
+  const writeBuffer = vi.spyOn(gpu.device.gpu.queue, "writeBuffer");
+
+  fx.set("camera", { viewProjection: new Array(16).fill(0), exposure: 2 });
+
+  expect(writeBuffer).toHaveBeenCalledTimes(1);
+  writeBuffer.mockRestore();
+  gpu.dispose();
+});
+
+test("contract #10: the binding-scoped form has no member-name shortcut", async () => {
+  const gpu = await init();
+  const fx = effect(gpu, { shader: CAMERA_SHADER, label: "cam" });
+
+  // `exposure` is a member of `camera`; the scoped form only accepts binding names and says so.
+  expect(messageOf(() => fx.set("exposure", 2))).toMatch(/camera/);
+  gpu.dispose();
+});
+
+test("contract #10: a struct binding merges partials on the CPU and rewrites the complete struct", async () => {
+  const gpu = await init();
+  const fx = effect(gpu, { shader: CAMERA_SHADER, label: "cam" });
+
+  fx.set("camera", { viewProjection: new Array(16).fill(0), exposure: 2 });
+  const writeBuffer = vi.spyOn(gpu.device.gpu.queue, "writeBuffer");
+  fx.set("camera", { exposure: 3 });
+
+  expect(writeBuffer).toHaveBeenCalledTimes(1);
+  const [, , data] = writeBuffer.mock.calls[0]!;
+  // 16 floats of viewProjection then exposure: the absent field kept its previous value.
+  expect(new Float32Array(data as ArrayBuffer)[16]).toBe(3);
+  writeBuffer.mockRestore();
+  gpu.dispose();
+});
+
+test("a binding absent from bindings is value-owned by default and takes .set() with no values declared", async () => {
+  const gpu = await init();
+  const screen = target(gpu, { size: [4, 4] });
+  const cube = draw(gpu, { shader: CAMERA_SHADER, label: "cube", vertices: 3 });
+  const mock = getMockGPUDeviceInstrumentation(gpu.device.gpu);
+
+  cube.set("camera", { viewProjection: new Array(16).fill(1), exposure: 1 });
+  frame(gpu, (f) => f.pass({ target: screen }, (p) => p.draw(cube)));
+  const baseline = mock.calls.createBindGroup;
+  cube.set("camera", { exposure: 2 });
+  frame(gpu, (f) => f.pass({ target: screen }, (p) => p.draw(cube)));
+
+  expect(baseline).toBe(1);
+  expect(mock.calls.createBindGroup).toBe(baseline);
+  gpu.dispose();
+});
+
+test("values declared at construction are written once, before any draw", async () => {
+  const gpu = await init();
+  const writeBuffer = vi.spyOn(gpu.device.gpu.queue, "writeBuffer");
+  const fx = effect(gpu, { shader: CAMERA_SHADER, label: "cam", values: { camera: { exposure: 4 } } });
+
+  expect(fx).toBeDefined();
+  expect(writeBuffer).toHaveBeenCalledTimes(1);
+  const [, , data] = writeBuffer.mock.calls[0]!;
+  expect(new Float32Array(data as ArrayBuffer)[16]).toBe(4);
+  writeBuffer.mockRestore();
+  gpu.dispose();
+});
+
+// ---------------------------------------------------------------------------
+// Contract #11 — uniform() shared across pipelines
+// ---------------------------------------------------------------------------
+
+test("contract #11: uniform() shared across two pipelines updates both with one write", async () => {
+  const gpu = await init();
+  const screen = target(gpu, { size: [4, 4] });
+  const globals = uniform(gpu, { time: 0 });
+  const a = effect(gpu, { shader: GLOBALS_ONLY_SHADER, label: "a", bindings: { globals } });
+  const b = effect(gpu, { shader: GLOBALS_ONLY_SHADER, label: "b", bindings: { globals } });
+  const mock = getMockGPUDeviceInstrumentation(gpu.device.gpu);
+
+  frame(gpu, (f) => f.pass({ target: screen }, (p) => { p.draw(a); p.draw(b); }));
+  const writeBuffer = vi.spyOn(gpu.device.gpu.queue, "writeBuffer");
+  globals.set({ time: 1 });
+
+  expect(writeBuffer).toHaveBeenCalledTimes(1);
+  // One shared buffer behind both pipelines, and no bind group churn from the write.
+  const bindGroups = mock.createBindGroupDescriptors.filter((descriptor) => descriptor.label === "a.group0" || descriptor.label === "b.group0");
+  expect(bindGroups).toHaveLength(2);
+  const buffers = bindGroups.map((descriptor) => ([...descriptor.entries][0]!.resource as GPUBufferBinding).buffer);
+  expect(buffers[0]).toBe(buffers[1]);
+  writeBuffer.mockRestore();
+  gpu.dispose();
+});
+
+test("contract #11: uniform() storage is zero-initialized", async () => {
+  const gpu = await init();
+  const screen = target(gpu, { size: [4, 4] });
+  const globals = uniform(gpu, {});
+  const fx = effect(gpu, { shader: GLOBALS_ONLY_SHADER, label: "fx", bindings: { globals } });
+  const mock = getMockGPUDeviceInstrumentation(gpu.device.gpu);
+
+  // No .set() anywhere: the shared storage must already read as zeros.
+  frame(gpu, (f) => f.pass({ target: screen }, (p) => p.draw(fx)));
+  const descriptor = mock.createBindGroupDescriptors.find((entry) => entry.label === "fx.group0");
+  const buffer = ([...descriptor!.entries][0]!.resource as GPUBufferBinding).buffer as unknown as { __vgpuMockBytes: Uint8Array };
+  expect(buffer.__vgpuMockBytes.length).toBeGreaterThan(0);
+  expect([...buffer.__vgpuMockBytes].every((byte) => byte === 0)).toBe(true);
+  gpu.dispose();
+});
+
+test("uniform() and uniforms() are the same mechanism under two spellings", async () => {
+  const gpu = await init();
+  const singular = uniform(gpu, { time: 1 });
+  const plural = uniforms(gpu, { time: 1 });
+
+  expect(Object.getPrototypeOf(singular)).toBe(Object.getPrototypeOf(plural));
+  gpu.dispose();
+});
+
+// ---------------------------------------------------------------------------
+// Legacy regressions — the flat bag survives untouched
+// ---------------------------------------------------------------------------
+
+test("regression: the flat bag still sets several members at once", async () => {
+  const gpu = await init();
+  const screen = target(gpu, { size: [4, 4] });
+  const fx = effect(gpu, CAMERA_SHADER, { label: "cam" });
+  const mock = getMockGPUDeviceInstrumentation(gpu.device.gpu);
+
+  fx.set({ viewProjection: new Array(16).fill(0), exposure: 1 });
+  frame(gpu, (f) => f.pass({ target: screen }, (p) => p.draw(fx)));
+  fx.set({ exposure: 2 });
+  frame(gpu, (f) => f.pass({ target: screen }, (p) => p.draw(fx)));
+
+  expect(mock.calls.createBuffer).toBe(1);
+  expect(mock.calls.createBindGroup).toBe(1);
+  gpu.dispose();
+});
+
+test("regression: the flat bag still reports an ambiguous member name", async () => {
+  const gpu = await init();
+  const fx = effect(gpu, AMBIGUOUS_SHADER, { label: "amb" });
+
+  expect(messageOf(() => fx.set({ time: 1 }))).toMatch(/ambiguous/);
+  gpu.dispose();
+});
+
+test("regression: the legacy latch still fires for the flat bag", async () => {
+  const gpu = await init();
+  const globals = uniform(gpu, { time: 0 });
+  const fx = effect(gpu, GLOBALS_ONLY_SHADER, { label: "fx" });
+
+  fx.set({ globals: { time: 1 } });
+  expect(codeOf(() => fx.set({ globals }))).toBe("VGPU-R1-OWNERSHIP-FLIP");
+  gpu.dispose();
+});
+
+// ---------------------------------------------------------------------------
+// compute() carries the same ownership surface
+// ---------------------------------------------------------------------------
+
+test("compute accepts values/bindings and the binding-scoped set()", async () => {
+  const gpu = await init();
+  const particles = storage(gpu, 64);
+  const sim = compute(gpu, { shader: SIM_SHADER, label: "sim", values: { sim: { dt: 0.016 } }, bindings: { particles } });
+  const writeBuffer = vi.spyOn(gpu.device.gpu.queue, "writeBuffer");
+
+  sim.set("sim", { dt: 0.032 });
+
+  expect(writeBuffer).toHaveBeenCalledTimes(1);
+  expect(codeOf(() => sim.set("particles", particles))).toBe("VGPU-R1-EXTERNAL-BINDING");
+  writeBuffer.mockRestore();
+  sim.dispatch(1);
+  gpu.dispose();
+});
+
+test("compute .bind() swaps a storage buffer identity", async () => {
+  const gpu = await init();
+  const first = storage(gpu, 64);
+  const second = storage(gpu, 64);
+  const sim = compute(gpu, { shader: SIM_SHADER, label: "sim", values: { sim: { dt: 0.016 } }, bindings: { particles: first } });
+  const mock = getMockGPUDeviceInstrumentation(gpu.device.gpu);
+
+  sim.dispatch(1);
+  const baseline = mock.calls.createBindGroup;
+  sim.bind("particles", first);
+  sim.dispatch(1);
+  expect(mock.calls.createBindGroup).toBe(baseline);
+
+  sim.bind("particles", second);
+  sim.dispatch(1);
+  expect(mock.calls.createBindGroup).toBe(baseline + 1);
+  gpu.dispose();
+});
+
+// ---------------------------------------------------------------------------
+// Unknown names stay actionable
+// ---------------------------------------------------------------------------
+
+test(".set() and .bind() reject a name that is not a binding", async () => {
+  const gpu = await init();
+  const globals = uniform(gpu, { time: 0 });
+  const fx = effect(gpu, { shader: GLOBALS_ONLY_SHADER, label: "fx" });
+
+  expect(messageOf(() => fx.set("nope", 1))).toMatch(/'nope'/);
+  expect(messageOf(() => fx.bind("nope", globals))).toMatch(/'nope'/);
+  gpu.dispose();
+});


### PR DESCRIPTION
Ticket **T04-06** (ola 1, lane B) — contracts **#9 / #10 / #11** of §5/§6.

Ownership becomes a property of construction instead of a consequence of call order. A binding is either **value-owned** (`values`, or the default) and takes `.set()`, which writes bytes and never rebuilds a bind group; or **externally owned** (`bindings`) and takes `.bind()`, which swaps identity and rebuilds exactly the affected group. Everything here is **additive**: the flat bag `.set({ ... })`, `SetBag`, `findMemberBinding`, `VGPU-R1-OWNERSHIP-FLIP` and `uniforms()` all keep working untouched, and no call site is migrated.

```ts
const globals = uniform(gpu, { time: 0 });               // one resource, many pipelines
const fx = effect(gpu, {
  ...bloom,
  values:   { params: { intensity: 1 } },                // instance-owned bytes
  bindings: { globals, src: sceneTarget },               // someone else's resources
});

fx.set("params", { intensity: 2 });                      // bytes: no bind group rebuild
fx.bind("src", otherTarget);                             // identity: rebuilds fx.group0 only
fx.set("src", otherTarget);                              // VGPU-R1-EXTERNAL-BINDING
globals.set({ time: t });                                // one write, every consumer sees it
```

## What is in

- **`set-core.ts`** — `{ values, bindings }` applied at construction, plus `setScoped(binding, value)` and `bind(binding, resource)`. `.bind()` dedupes on the resource reference *before* normalizing, then on the normalized identity.
- **`draw.ts` / `effect.ts` / `compute.ts` / `api-types.ts`** — the options fields, the additive `set(binding, value)` overload and `bind()`. **Overload order is public API surface**: the binding-scoped form is declared first so `Parameters<Draw["set"]>` keeps resolving to `[SetBag]` and no derived type in the corpus moves.
- **`uniform()`** — singular spelling of `uniforms()`, exported from `.`, `./mock` and `./node`.
- **`errors.ts`** — `VGPU-R1-EXTERNAL-BINDING`, which names the binding and offers both exits (update the resource, or `.bind()` it).
- **Tests** — `tests/ownership.test.ts` (32) written before the implementation, and `tests/entrypoint-parity.test.ts` (2).

Untouched: `pipeline-store.ts`, `prepare.ts` and the compile/encode paths of `draw.ts`/`effect.ts` (T04-05 territory, merged here from `next/0.4`). `set-layouts.ts` and `set-resources.ts` needed no changes — ownership turned out to be purely a runtime/identity concern, and `bindings` reuses `normalizeResource` as is.

## Adversarial QA

An earlier revision of this branch shipped a real bug that the harness caught: with lazy value-owned storage, a binding nobody had written yet had no owner recorded, so `.bind()` silently promoted it and **the order-dependent latch came back** — `bind→set` and `set→bind` gave different verdicts for the same two calls, and one `.bind()` locked the legacy flat bag out of a binding it already owned. Fixed: lazy storage is not "no owner yet", and the only way into external ownership is declaring the binding in `bindings`. Re-validated at **23/23 probes, `ORDER-DEPENDENT = false`, 13/15 mutants killed** (including a regression mutant that reverts the fix).

The two surviving mutants are declared, not hidden:

- **MUT6** — the bind cache key drops the group number. Pre-existing in `bind-cache.ts`, untouched by this branch; a separate coverage ticket is open.
- **MUT4** — resolved by measurement rather than opinion, and now pinned: dropping the `.bind()` fast path is invisible to a `createBindGroup` tally, but normalizing a resource allocates a fresh texture view and re-subscribes its destroy callback, which a per-frame rebind would churn every frame across the ≥42 call sites that do exactly that. The test spies on the view allocation, so the dedup must happen *before* the work.

## Deviations and accepted costs

**Contract #10, the type-level clause, is falsified.** *"Naming a member without naming the binding is a type error"* cannot hold in this repo: `ShaderSource` is `{ version: 1; wgsl: string }` and carries no binding information (`packages/wgsl/src/types.ts`, whose own comment reserves a `bindings` field for a future version bump). Shaders are strings at runtime and reflection is a runtime pass, so `set(binding: string, …)` cannot type binding names without typed reflection (OQ2 / a loader version bump). It is enforced at runtime instead: naming a member throws an error that names the binding to use and spells out the call. The other two clauses of #10 — a non-struct binding takes its complete value, and N fields of a struct produce exactly one write — hold and are tested.

**Deviation from amendment A-3: value-owned storage is lazy, not eager.** Creating a buffer at construction for every undeclared binding would change `createBuffer` counts across the corpus and break the flat bag's user-owned path (`.set({ src: texture })`). The observable cost: encoding a value-owned binding that was **never set** throws `VGPU-R1-BINDING-NEVER-SET` instead of rendering the zero-initialized storage §6 promises. That is a loud failure, not a silent one — nothing draws garbage, the error names the binding — and the zero-init default lands at the cut, when the flat bag dies and the default can become eager without breaking anyone. `uniform()` does honour zero-init today, which is where §5 actually promises it (tested).

**A pre-existing `vgpu/node` warning is silenced as a side effect.** On `next/0.4` that tooling entry was already over budget (39470 B / 39424 B, +46 B, warning-only within the 5% growth threshold). Raising the `./node` export budget alongside `.` and `./mock` puts it back in the green, so the signal is covered rather than resolved. If the warning is worth keeping, `./node` should get a budget of its own instead of tracking `.`.

## Bundle budgets

Measured on the merged tree against `next/0.4` @ `0d17ff4a`, rebuilding both sides, gzip:

| experience | 0d17ff4a | this PR | delta | new budget |
|---|---|---|---|---|
| init-only | 1106 | 1106 | +0 | 1536 (unchanged) |
| effect-only | 26577 | 27173 | +596 | 27648 |
| triangle-low-level | 29633 | 30262 | +629 | 30720 |
| draw-recipe-box | 30882 | 31500 | +618 | 31744 |
| full-root | 40537 | 41194 | +657 | 41472 |

The growth is the ownership engine itself, which lives in `set-core.ts` and therefore ships with every draw and effect — nothing can tree-shake it. It was first measured at +693 B on effect-only and trimmed to +579 B (pre-merge) by folding the scoped write onto the existing flat-bag write path and reusing the existing member lookup. Budgets follow the documented convention (next 512-byte multiple strictly above measured); conflicts with #329 resolved as the union's max.

## Verification

```bash
pnpm typecheck && pnpm test && pnpm build && pnpm bundle-check
```

1997 passed / 139 skipped, typecheck clean, all client budgets green.
