### PR TITLE
feat(frame): unify compute, copy and raw in one frame submit

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "build": "tsc -b && node packages/vgpu-api/scripts/copy-cli.mjs && node -e \"require('fs').copyFileSync('packages/wgsl/src/wgsl-types.d.ts', 'packages/wgsl/dist/wgsl-types.d.ts')\"",
     "typecheck": "tsc -b && pnpm run typecheck:fixtures",
-    "typecheck:fixtures": "tsc -p packages/core/tests/tsconfig.create-sampler-types.json && tsc -p packages/core/tests/tsconfig.types.json && tsc -p packages/vgpu-api/tests/uniforms/tsconfig.types.json && tsc -p packages/vgpu-api/tests/compute/tsconfig.types.json",
+    "typecheck:fixtures": "tsc -p packages/core/tests/tsconfig.create-sampler-types.json && tsc -p packages/core/tests/tsconfig.types.json && tsc -p packages/vgpu-api/tests/uniforms/tsconfig.types.json && tsc -p packages/vgpu-api/tests/compute/tsconfig.types.json && tsc -p packages/vgpu-api/tests/frame/tsconfig.types.json",
     "docs:verify-snippets": "node scripts/verify-docs-snippets.mjs",
     "test": "vitest run",
     "test:fast": "vitest run packages/adapter-mock packages/core packages/wgsl packages/render scripts",

--- a/packages/vgpu-api/package.json
+++ b/packages/vgpu-api/package.json
@@ -91,9 +91,9 @@
     "./core": "client"
   },
   "vgpuExportBundleBudgetsGzipBytes": {
-    ".": 41472,
-    "./node": 41472,
-    "./mock": 41472,
+    ".": 42496,
+    "./node": 43008,
+    "./mock": 42496,
     "./scene": 12800,
     "./client": 512,
     "./core": 3584
@@ -103,10 +103,10 @@
   },
   "vgpuExperienceBundleBudgetsGzipBytes": {
     "init-only": 1536,
-    "effect-only": 27648,
-    "triangle-low-level": 30720,
-    "draw-recipe-box": 31744,
-    "full-root": 41472
+    "effect-only": 28672,
+    "triangle-low-level": 31744,
+    "draw-recipe-box": 32768,
+    "full-root": 43008
   },
   "vgpuSceneBundleBudgetNote": "The scene barrel retains all recipe builders after the geometry redesign; direct primitive imports retain only their selected mesh, as the experience fixtures assert."
 }

--- a/packages/vgpu-api/src/api-types.ts
+++ b/packages/vgpu-api/src/api-types.ts
@@ -52,7 +52,23 @@ export interface StorageOptions {
   /** Adds the "indirect" buffer usage so the buffer can supply GPU-read draw/dispatch arguments. Defaults to false. */
   readonly indirect?: boolean;
 }
-export interface StorageBuffer { readonly size: number; readonly access: StorageAccess; read(): Promise<ArrayBuffer>; write(data: BufferSource): void }
+export interface StorageBuffer {
+  readonly size: number;
+  readonly access: StorageAccess;
+  /**
+   * The underlying `GPUBuffer` — the single `.gpu` accessor spelling every vgpu object uses
+   * (`gpu.gpu` is the `GPUDevice`, `Texture.gpu` a `GPUTexture`, `prepared.gpu` the pipeline). It is
+   * what makes this buffer usable with `f.copyBuffer()` and inside an `f.raw()` block, and with raw
+   * WebGPU calls vgpu does not wrap.
+   *
+   * It is a real handle, so `destroy()` is reachable through it: the same trade-off `Buffer.gpu` and
+   * `Texture.gpu` already accept. Destroying it by hand leaves the owning `StorageBuffer` pointing at
+   * a destroyed buffer — let `gpu.dispose()` own the lifetime instead.
+   */
+  readonly gpu: GPUBuffer;
+  read(): Promise<ArrayBuffer>;
+  write(data: BufferSource): void;
+}
 export interface PingPongTargets { readonly read: Target; readonly write: Target; swap(): void }
 export interface PingPongStorage { readonly read: StorageBuffer; readonly write: StorageBuffer; swap(): void }
 export interface SharedUniforms<T extends Record<string, unknown> = Record<string, unknown>> { set(values: Partial<T>): void }

--- a/packages/vgpu-api/src/compute.ts
+++ b/packages/vgpu-api/src/compute.ts
@@ -7,8 +7,10 @@ import { createSetCore, bindGroupLayoutsForReflection, pipelineLayoutFor, type S
 import { visibilityForEntries } from "./set-layouts.ts";
 import type { Compute, ComputeOptions, DispatchOptions } from "./api-types.ts";
 import { normalizeConstantsOptions, selectEntryPoint } from "./pipeline-store.ts";
-import { dispatchCountInvalidError, indirectInvalidError, unsupportedError, writableStorageAliasingError } from "./errors.ts";
+import { dispatchCountInvalidError, indirectInvalidError, pipelinePendingError, unsupportedError, writableStorageAliasingError, type VGPUError } from "./errors.ts";
+import { FRAME_COMPUTABLE, type FrameComputableProtocol } from "./frame-protocols.ts";
 import { assertDeviceUsable } from "./lifecycle.ts";
+import { DEFAULT_PENDING_PIPELINES, type PendingPipelines } from "./pending-pipelines.ts";
 import type { Gpu } from "./kernel.ts";
 import { liveKernel } from "./live-kernel.ts";
 import { renderService } from "./render-service.ts";
@@ -35,7 +37,9 @@ export function compute(gpu: Gpu, source: string | ShaderSource, opts: ComputeOp
 export function compute(gpu: Gpu, input: string | ShaderSource | ComputeOptions, opts: ComputeOptions = {}): Compute {
   const [source, resolvedOpts] = resolveShaderInput("compute", input, opts);
   const kernel = liveKernel(gpu, "compute");
-  return new ComputePipeline(kernel.device, toWgsl(source), resolvedOpts, renderService(kernel).binds);
+  // Same wiring render-service.ts gives createPipelineStore: the gpu-wide pendingPipelines default
+  // (last link of the call site → frame → gpu chain) and the gpu's error sink.
+  return new ComputePipeline(kernel.device, toWgsl(source), resolvedOpts, renderService(kernel).binds, kernel.pendingPipelinesDefault(), (error) => { void kernel.reportError(error); });
 }
 
 let nextComputeId = 1;
@@ -58,12 +62,26 @@ export class ComputePipeline implements Compute {
   readonly #pipelineDescriptor: GPUComputePipelineDescriptor;
   #pipeline?: GPUComputePipeline;
   #pipelinePending?: Promise<GPUComputePipeline>;
+  /**
+   * `"skip"` never throws per frame, so a background compile failure has exactly one channel:
+   * `gpu.onError`. Reported once per instance — a frame loop would otherwise flood the sink with the
+   * same rejection every tick.
+   */
+  #skipFailureReported = false;
 
   constructor(
     private readonly device: Device,
     readonly source: string,
     readonly opts: ComputeOptions = {},
     private readonly cache: BindGroupCache = createBindGroupCache(),
+    /**
+     * Last link of the pendingPipelines chain (call site → frame → gpu) for `f.compute()`: the
+     * gpu-wide default from `init()`. Defaults to the train-wide default so the legacy
+     * `new ComputePipeline(device, source)` shape keeps working unchanged.
+     */
+    private readonly pendingPipelinesDefault: PendingPipelines = DEFAULT_PENDING_PIPELINES,
+    /** Error sink of the owning gpu, for the one channel a `"skip"` background compile can report on. */
+    private readonly reportError: (error: VGPUError) => void = () => undefined,
   ) {
     assertDeviceUsable(device, "Compute.constructor");
     this.label = opts.label ?? "compute";
@@ -156,6 +174,60 @@ export class ComputePipeline implements Compute {
     else pass.dispatchWorkgroups(x as number, y ?? 1, z ?? 1);
     pass.end();
     this.device.gpu.queue.submit([encoder.finish()]);
+  }
+
+  /**
+   * Nominal `FrameComputable` protocol, so `frame.ts` never imports this module: a program that only
+   * uses `frame()` / `f.pass()` must not pay for the whole compute package (pay-for-what-you-import).
+   *
+   * @internal
+   */
+  get [FRAME_COMPUTABLE](): FrameComputableProtocol {
+    return this;
+  }
+
+  /**
+   * Third encoding path of this class, for `f.compute()`: it records one compute pass into an encoder
+   * it does **not** own — the frame's — so it never calls `encoder.finish()` nor `queue.submit()`.
+   * That is what puts the dispatch inside the frame's single submit, in program order (contract #1),
+   * which `dispatch()`/`dispatchOnce()` structurally cannot do: both open their own encoder.
+   *
+   * Validation is the very same private code the legacy paths use — `#validateCounts` (contract #17)
+   * and `#preflightAliasing` (writable-storage double-bind guard) — never a reimplementation.
+   *
+   * @internal
+   */
+  encodeForFrame(encoder: GPUCommandEncoder, x: number, y: number | undefined, z: number | undefined, policy: PendingPipelines | undefined): void {
+    const where = `${this.label}.compute`;
+    assertDeviceUsable(this.device, where);
+    this.#validateCounts(x, y, z, where);
+    this.#preflightAliasing(where);
+    const resolved = policy ?? this.pendingPipelinesDefault;
+    let pipeline = this.#pipeline;
+    if (!pipeline) {
+      // "throw": does not start compilation and throws immediately. `signature` is undefined because a
+      // compute pipeline has no target signature — the same asymmetry prepare()'s signatureKeyFor has.
+      if (resolved === "throw") throw pipelinePendingError(where, this.label, undefined);
+      // "skip": start (or continue) the async compile in the background, omit the dispatch this frame,
+      // and never throw per frame. Deliberately the same #ensurePipelineAsync() dispatchOnce()/
+      // prepare() use — same dedupe, same anti-poisoning — so the compile it starts is the one a later
+      // dispatchOnce()/prepare() awaits, never a second one.
+      if (resolved === "skip") {
+        void this.#ensurePipelineAsync().catch((error: unknown) => {
+          if (this.#skipFailureReported) return;
+          this.#skipFailureReported = true;
+          this.reportError(error as VGPUError);
+        });
+        return;
+      }
+      // "sync": immediate createComputePipeline(), exactly like legacy dispatch().
+      pipeline = this.#ensurePipeline();
+    }
+    const pass = encoder.beginComputePass({ label: `${this.label}.pass` });
+    pass.setPipeline(pipeline);
+    for (const binding of this.setCore.bindGroups()) pass.setBindGroup(binding.group, binding.bindGroup, binding.offsets);
+    pass.dispatchWorkgroups(x, y ?? 1, z ?? 1);
+    pass.end();
   }
 
   /**

--- a/packages/vgpu-api/src/errors.ts
+++ b/packages/vgpu-api/src/errors.ts
@@ -686,6 +686,68 @@ export function frameAlreadySubmittedError(where: string): VGPUError {
   });
 }
 
+/**
+ * `f.raw()` while the frame's command encoder is not free: a managed render/compute pass is open, or
+ * another `f.raw()` callback is still borrowing it.
+ *
+ * Design §2, normative clause: `f.raw()` "is legal only while the frame's command encoder is open and
+ * no managed render/compute pass and no other `f.raw()` callback is active. [...] throws
+ * VGPU-FRAME-ENCODER-LOCKED before the callback is invoked — no borrowed encoder is handed out and
+ * nothing is encoded."
+ */
+export function frameEncoderLockedError(where: string): VGPUError {
+  return new VGPUError({
+    code: "VGPU-FRAME-ENCODER-LOCKED",
+    message: "the frame's command encoder is already lent out: this call is legal only between managed passes. Nothing was encoded.",
+    fix: "Return from the frame.pass(...) / f.raw(...) callback first, then make this call between passes.",
+    where,
+  });
+}
+
+/**
+ * Runtime contract for JavaScript / `any` (design §2a): "if the callback returns a thenable, vgpu
+ * closes the borrowed `Frame`, discards that frame's command encoder without submitting it, and
+ * throws `VGPU-ASYNC-FRAME-CALLBACK`. Any later call through an escaped `Frame` reference throws
+ * `VGPU-FRAME-CLOSED`. No partial frame is submitted."
+ *
+ * This discard is the one explicit exception to the rule that a managed frame submits itself when its
+ * callback returns: the "one frame, one ordered command list, exactly one `queue.submit()`" guarantee
+ * is kept by submitting nothing at all rather than a prefix of the intended work.
+ */
+export function asyncFrameCallbackError(where: string): VGPUError {
+  return new VGPUError({
+    code: "VGPU-ASYNC-FRAME-CALLBACK",
+    message: "the callback returned a thenable, but a frame callback is synchronous. The frame was closed and its command encoder discarded: no partial frame was submitted.",
+    fix: "Do the async work (await prepare(gpu, [...])) before entering the frame, then record synchronously inside it.",
+    where,
+  });
+}
+
+/** Using a `Frame` that escaped its own callback: the frame was closed and its encoder discarded. */
+export function frameClosedError(where: string): VGPUError {
+  return new VGPUError({
+    code: "VGPU-FRAME-CLOSED",
+    message: "the frame is closed: its callback returned a thenable, so the frame was aborted without submitting.",
+    fix: "Do not retain the Frame past its callback: open one frame(gpu, cb) per tick and keep the callback synchronous.",
+    where,
+  });
+}
+
+/**
+ * A `f.copyBuffer()` call that WebGPU's own `copyBufferToBuffer` validation would reject. One code
+ * covers the four violation shapes of contract #18 (4-byte alignment, source range, destination
+ * range, `source === destination`), with the offending values in the message — the same shape
+ * `passViewportInvalidError`/`passScissorInvalidError` already use for their families.
+ */
+export function copyBufferInvalidError(where: string, detail: string): VGPUError {
+  return new VGPUError({
+    code: "VGPU-COPY-BUFFER-INVALID",
+    message: `f.copyBuffer() ${detail}`,
+    fix: "WebGPU's copyBufferToBuffer rules apply verbatim: size and both offsets are multiples of 4, each offset + size fits its buffer, and source and destination differ. An omitted size is the source remainder, never a truncated copy.",
+    where,
+  });
+}
+
 export function incompatibleResourceError(binding: BindingInfo, expected: string, fix?: string): VGPUError {
   return new VGPUError({
     code: "VGPU-R1-BINDING-INCOMPATIBLE-RESOURCE",

--- a/packages/vgpu-api/src/frame-protocols.ts
+++ b/packages/vgpu-api/src/frame-protocols.ts
@@ -18,6 +18,7 @@
 import type { Device } from "@vgpu/core";
 import type { ClaimedGroupValidationResult } from "./claim-validation.ts";
 import type { DrawCallOptions } from "./draw.ts";
+import type { PendingPipelines } from "./pending-pipelines.ts";
 import type { Target } from "./target.ts";
 
 /**
@@ -68,6 +69,32 @@ export interface FrameBundleLike {
 
 export function frameBundleOf(value: unknown): FrameBundleProtocol | undefined {
   return (value as Partial<FrameBundleLike> | null | undefined)?.[FRAME_BUNDLE];
+}
+
+// ---------------------------------------------------------------------------
+// Computable: what `Frame.compute()` encodes (compute.ts).
+// ---------------------------------------------------------------------------
+
+export const FRAME_COMPUTABLE: unique symbol = Symbol("vgpu.frame.computable");
+
+export interface FrameComputableProtocol {
+  /**
+   * Encodes one compute pass into the frame's **borrowed** encoder: it opens and ends its own
+   * `GPUComputePass`, and never calls `encoder.finish()` nor `queue.submit()` — the frame owns both,
+   * which is what keeps `f.compute()` inside the frame's single submit (contract #1).
+   *
+   * `policy` is the already-resolved link of the `pendingPipelines` chain (call site → frame);
+   * `undefined` means "no link named one", so the implementation applies its own gpu-wide default.
+   */
+  encodeForFrame(encoder: GPUCommandEncoder, x: number, y: number | undefined, z: number | undefined, policy: PendingPipelines | undefined): void;
+}
+
+export interface FrameComputable {
+  readonly [FRAME_COMPUTABLE]: FrameComputableProtocol;
+}
+
+export function frameComputableOf(value: unknown): FrameComputableProtocol | undefined {
+  return (value as Partial<FrameComputable> | null | undefined)?.[FRAME_COMPUTABLE];
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/vgpu-api/src/frame.ts
+++ b/packages/vgpu-api/src/frame.ts
@@ -6,12 +6,13 @@ import type { Draw, DrawCallOptions } from "./draw.ts";
 import type { Effect } from "./effect.ts";
 import type { Target } from "./target.ts";
 import { assertDeviceUsable } from "./lifecycle.ts";
-import { claimedGroupNativeValidationError, frameAlreadySubmittedError, frameCanceledError, framePassActiveError, frameReentrantError, passClearDepthInvalidError, passClearStencilInvalidError, passDepthReadOnlyError, passDepthReadOnlyMsaaError, passPreserveClearDepthError, passPreserveClearStencilError, passPreserveMsaaError, passScissorInvalidError, passViewportInvalidError, queryNestedError, queryNoVisibilityError, surfaceNotInFrameError, targetRequiredError, timerInvalidError, VGPUError, visibilityInvalidError } from "./errors.ts";
+import { asyncFrameCallbackError, claimedGroupNativeValidationError, copyBufferInvalidError, frameAlreadySubmittedError, frameCanceledError, frameClosedError, frameEncoderLockedError, framePassActiveError, frameReentrantError, passClearDepthInvalidError, passClearStencilInvalidError, passDepthReadOnlyError, passDepthReadOnlyMsaaError, passPreserveClearDepthError, passPreserveClearStencilError, passPreserveMsaaError, passScissorInvalidError, passViewportInvalidError, queryNestedError, queryNoVisibilityError, surfaceNotInFrameError, targetRequiredError, timerInvalidError, VGPUError, visibilityInvalidError } from "./errors.ts";
 import { enterFrame, isSurface, isSurfaceResizeCallbackActive, leaveFrame } from "./surface.ts";
 import { BUILT_IN_CLEAR_COLOR, hasStencilAspect, isTarget, type ClearColor } from "./target-utils.ts";
 import type { TimerSpan } from "./timer.ts";
 import type { Visibility, VisibilityQuery } from "./visibility.ts";
-import { FRAME_PASS_ATTACHMENT, frameBundleOf, frameDrawableOf, framePassAttachmentOf, type FrameDrawableProtocol, type FrameOcclusionSource, type FrameOwner, type FramePassAttachResult } from "./frame-protocols.ts";
+import { FRAME_PASS_ATTACHMENT, frameBundleOf, frameComputableOf, frameDrawableOf, framePassAttachmentOf, type FrameComputableProtocol, type FrameDrawableProtocol, type FrameOcclusionSource, type FrameOwner, type FramePassAttachResult } from "./frame-protocols.ts";
+import type { Compute } from "./api-types.ts";
 import { frameState } from "./frame-state.ts";
 import { liveKernel } from "./live-kernel.ts";
 import { serviceToken, type Gpu, type Kernel } from "./kernel.ts";
@@ -26,8 +27,62 @@ import type { PendingPipelines } from "./pending-pipelines.ts";
  * Frames are not reentrant: opening one from inside another (or from a surface resize callback)
  * throws `VGPU-FRAME-REENTRANT`.
  */
-export function frame(gpu: Gpu, cb?: (frame: Frame) => void, opts: FrameOptions = {}): Frame {
+export function frame<R>(gpu: Gpu, cb?: FrameCallback<R>, opts: FrameOptions = {}): Frame {
   return frameRunner(liveKernel(gpu, "frame")).frame(cb, opts);
+}
+
+/**
+ * A `Frame` borrows one command encoder for exactly the dynamic extent of its callback, so `frame()`
+ * and `frameLoop()` accept **synchronous functions only**: the callback must finish recording before
+ * it returns, and a borrowed `Frame` is closed immediately afterwards.
+ *
+ * A plain `(frame) => void` type is deliberately insufficient, because TypeScript permits an `async`
+ * function returning `Promise<void>` wherever a `void` return is expected. This type rejects every
+ * `PromiseLike` return while preserving ordinary block-bodied and expression-bodied synchronous
+ * callbacks: `R` is inferred from the callback's return type, and the intersection collapses to
+ * `never` — assignable from nothing — as soon as that type extends `PromiseLike<unknown>`.
+ */
+export type SyncReturn<R> =
+  R extends PromiseLike<unknown> ? never : unknown;
+
+export type FrameCallback<R> =
+  (frame: Frame) => R & SyncReturn<R>;
+
+/**
+ * The frame's own `GPUCommandEncoder`, lent to an `f.raw()` callback with `finish()` removed:
+ * submission stays the frame's job, so `finish()` is **unrepresentable**, not merely forbidden.
+ */
+export type BorrowedCommandEncoder = Omit<GPUCommandEncoder, "finish">;
+
+/** Per-call options of `f.compute()`. Additive: `f.compute(kernel, n)` needs none of them. */
+export interface FrameComputeOptions {
+  /**
+   * Call-site link of the `pendingPipelines` chain (call site → frame → gpu): wins over the frame's
+   * policy and over the gpu-wide `init({ pendingPipelines })` default for this dispatch only.
+   */
+  readonly pendingPipelines?: PendingPipelines;
+  // @internal Extension point for `slots` (uniformArray dynamic offsets): contract #13 requires
+  // `slots` to be accepted identically by `p.draw(inst, { slots })` and `f.compute(inst, n, { slots })`.
+  // `uniformArray` does not exist yet, so no field is declared here — it lands with that feature.
+}
+
+/** Anything with a `GPUBuffer` and a byte size: the `.gpu` accessor spelling every vgpu object ships. */
+export interface CopyableBuffer {
+  readonly gpu: GPUBuffer;
+  readonly size: number;
+}
+
+/**
+ * Mirrors `copyBufferToBuffer`: offsets default to `0`, and an omitted `size` defaults to
+ * **`source.size − sourceOffset`** (the source remainder), exactly as WebGPU defines it.
+ */
+export interface CopyBufferOptions {
+  readonly source: CopyableBuffer;
+  readonly destination: CopyableBuffer;
+  /** Bytes to copy. Omitted means the source remainder, `source.size - sourceOffset` — never a truncated copy. */
+  readonly size?: number;
+  readonly sourceOffset?: number;
+  readonly destinationOffset?: number;
 }
 
 /** Per-frame options. Additive: `frame(gpu, cb)` keeps behaving exactly as before. */
@@ -49,7 +104,7 @@ export interface FrameOptions {
  * The loop belongs to the gpu's `scheduler` phase, so `gpu.dispose()` stops it before anything it
  * could encode against is torn down; a loop that stops on its own drops that registration.
  */
-export function frameLoop(gpu: Gpu, cb: FrameLoopCallback, opts: FrameLoopOptions = {}): FrameLoopHandle {
+export function frameLoop<R>(gpu: Gpu, cb: FrameCallback<R>, opts: FrameLoopOptions = {}): FrameLoopHandle {
   return frameRunner(liveKernel(gpu, "frameLoop")).loop(cb, opts);
 }
 
@@ -132,6 +187,18 @@ export class Frame {
   #submitted = false;
   #canceled = false;
   #passActive = false;
+  /**
+   * An `f.raw()` callback is borrowing the encoder right now. Kept apart from `#passActive` so the
+   * `VGPU-FRAME-ENCODER-LOCKED` guard covers both shapes of borrow with one check.
+   */
+  #rawActive = false;
+  /**
+   * The frame was aborted because a callback returned a thenable (contract #24). Independent of
+   * `#canceled`/`#submitted` on purpose: those two are legitimate ends of a frame's life with their
+   * own errors (`VGPU-FRAME-CANCELED`, `VGPU-FRAME-SUBMITTED`), while this one means the reference
+   * escaped a frame that was closed under it — `VGPU-FRAME-CLOSED`.
+   */
+  #asyncAborted = false;
   constructor(
     private readonly device: Device,
     private readonly defaultTarget?: Target,
@@ -152,6 +219,9 @@ export class Frame {
     // re-take the telemetry retains cancel() just released), so reject the call instead. Checked
     // before the device: `gpu.dispose()` cancels outstanding frames and *then* drops the device, so
     // cancellation is the proximate cause there and names it better than a generic disposed device.
+    // Checked before everything else: a frame whose callback returned a thenable was closed under
+    // this reference, which is a different lifecycle bug than cancel()/submit() and names itself.
+    if (this.#asyncAborted) throw frameClosedError("Frame.pass");
     if (this.#canceled) throw frameCanceledError("Frame.pass");
     assertDeviceUsable(this.device, "Frame.pass");
     const targetOnly = isTarget(target);
@@ -245,7 +315,105 @@ export class Frame {
     endRenderPassWithClaimValidation(this.device, encoder, this.#validations);
   }
 
+  /**
+   * Records one compute dispatch into **this frame's** command encoder, so it lands in the frame's
+   * single `queue.submit()`, in program order relative to every `f.pass()` around it (contract #1).
+   * That is the whole point of the method: `compute.dispatch()` / `compute.dispatchOnce()` open their
+   * own encoder and submit on their own, which is exactly the extra submit `f.compute()` removes.
+   *
+   * Workgroup counts are validated as integers >= 0 with the same stable code `dispatchOnce()` uses
+   * (contract #17), and the writable-storage aliasing guard runs unchanged. Nothing is encoded when
+   * either rejects.
+   *
+   * `pendingPipelines` resolves call site → frame → gpu: under `"throw"` an uncompiled kernel raises
+   * `VGPU-PIPELINE-PENDING` and compiles nothing; under `"skip"` the dispatch is omitted this frame
+   * while compilation continues in the background; under `"sync"` (today's effective default) the
+   * pipeline is created inline.
+   */
+  compute(compute: Compute, x: number, y?: number, z?: number, opts: FrameComputeOptions = {}): void {
+    if (this.#asyncAborted) throw frameClosedError("Frame.compute");
+    if (this.#canceled) throw frameCanceledError("Frame.compute");
+    assertDeviceUsable(this.device, "Frame.compute");
+    // A compute pass cannot be opened on an encoder whose render pass is still open, and an f.raw()
+    // callback owns the encoder while it runs: reject up front with the same "the encoder is lent
+    // out" error f.raw() uses, instead of letting native validation fail the whole command buffer.
+    if (this.#passActive || this.#rawActive) throw frameEncoderLockedError("Frame.compute");
+    const protocol = frameComputable(compute);
+    // Two links of the pendingPipelines chain collapse here, exactly like FramePass.draw: the call
+    // site wins, the frame's policy fills in, and `undefined` still resolves to the gpu-wide default
+    // further down (in the compute instance itself, which owns its pipeline).
+    protocol.encodeForFrame(this.#encoder, x, y, z, opts.pendingPipelines ?? this.pendingPipelines);
+  }
+
+  /**
+   * Buffer-to-buffer copy in this frame's encoder, mirroring `copyBufferToBuffer`: offsets default to
+   * `0`, and an omitted `size` defaults to **`source.size − sourceOffset`** (the source remainder).
+   *
+   * WebGPU's validation is preserved verbatim, not softened: `size`, `sourceOffset` and
+   * `destinationOffset` must be multiples of 4, `sourceOffset + size <= source.size`,
+   * `destinationOffset + size <= destination.size`, and `source` and `destination` must be different
+   * buffers. A destination too small for the source remainder is an error, never a truncated copy
+   * (contract #18). Texture copies go through `f.raw()`.
+   */
+  copyBuffer(opts: CopyBufferOptions): void {
+    if (this.#asyncAborted) throw frameClosedError("Frame.copyBuffer");
+    if (this.#canceled) throw frameCanceledError("Frame.copyBuffer");
+    assertDeviceUsable(this.device, "Frame.copyBuffer");
+    // Same reason as f.compute(): copyBufferToBuffer is a top-level encoder command, illegal while a
+    // managed pass is open, and the encoder is not ours to touch inside an f.raw() callback.
+    if (this.#passActive || this.#rawActive) throw frameEncoderLockedError("Frame.copyBuffer");
+    const copy = validatedBufferCopy(opts);
+    // Validated in full above: no partial encode is possible past this point.
+    this.#encoder.copyBufferToBuffer(copy.source, copy.sourceOffset, copy.destination, copy.destinationOffset, copy.size);
+  }
+
+  /**
+   * Lends this frame's open `GPUCommandEncoder` to `cb` — the escape hatch for anything that must land
+   * in **this** command buffer and submission: texture copies, `clearBuffer()`, `resolveQuerySet()`,
+   * debug markers, external encoders, and future WebGPU commands vgpu does not wrap yet.
+   *
+   * Normative clause (design §2), encoder ownership, lifetime and legal boundary:
+   * - it encodes into the frame's existing `GPUCommandEncoder`, preserving program order and the
+   *   frame's single submit;
+   * - it is legal **only while the frame's command encoder is open and no managed render/compute pass
+   *   and no other `f.raw()` callback is active**. Calling it from inside `f.pass(…)` / `f.compute(…)`,
+   *   or reentrantly from another `f.raw()` callback, throws `VGPU-FRAME-ENCODER-LOCKED` before the
+   *   callback is invoked — no borrowed encoder is handed out and nothing is encoded;
+   * - the callback is **synchronous**: it must not return a promise, and it must not retain the encoder
+   *   past its own return — the borrow ends when it returns;
+   * - `finish()` is **unrepresentable**, not merely forbidden: the parameter type is
+   *   `Omit<GPUCommandEncoder, "finish">`, so submission stays the frame's job;
+   * - any native render or compute pass begun inside the callback must also be **ended** inside it,
+   *   before returning;
+   * - **no render-state cache invalidation or "state re-establishment" is implied.** Render state
+   *   belongs to a `GPURenderPassEncoder`, not to the top-level `GPUCommandEncoder`, so a `raw` block
+   *   cannot perturb the state of vgpu's managed passes.
+   *
+   * A `Surface`'s current texture is deliberately not reachable through the borrowed encoder: it is
+   * frame-scoped and never exposed, so surface readback stays `surface.read()` / `surface.readFloats()`.
+   * Persistent `Texture` / `Target` handles are copyable here through their own `.gpu`.
+   */
+  raw(cb: (encoder: BorrowedCommandEncoder) => void): void {
+    if (this.#asyncAborted) throw frameClosedError("Frame.raw");
+    if (this.#canceled) throw frameCanceledError("Frame.raw");
+    assertDeviceUsable(this.device, "Frame.raw");
+    // Before the callback: the contract is that no borrowed encoder is ever handed out here.
+    if (this.#passActive || this.#rawActive) throw frameEncoderLockedError("Frame.raw");
+    this.#rawActive = true;
+    let result: unknown;
+    try {
+      result = cb(this.#encoder);
+    } finally {
+      this.#rawActive = false;
+      // A thenable return means the callback kept encoding after its own return: same runtime contract
+      // as an async frame callback (contract 25 defers to contract 24), so the whole frame aborts.
+      if (isThenableValue(result)) this.abortAsync();
+    }
+    if (isThenableValue(result)) throw asyncFrameCallbackError("Frame.raw");
+  }
+
   submit(): void {
+    if (this.#asyncAborted) throw frameClosedError("Frame.submit");
     // Closed either way: a re-submit has nothing left to flush, and a canceled frame dropped its
     // encoder. Both are silent no-ops so `frame(gpu, cb)`'s submit-in-finally never masks a cancel()
     // (or an exception) from inside the callback. Checked before the device so that submitting an
@@ -316,6 +484,7 @@ export class Frame {
    * lifecycle bug.
    */
   cancel(): void {
+    if (this.#asyncAborted) throw frameClosedError("Frame.cancel");
     if (this.#canceled) return;
     if (this.#submitted) throw frameAlreadySubmittedError("Frame.cancel");
     // An active pass descriptor still references telemetry query sets. Releasing their retains here
@@ -332,6 +501,38 @@ export class Frame {
     // this frame ran, so any native error they carry is about work that was thrown away.
     discardClaimedGroupValidationResults(this.#validations);
     this.#validations.length = 0;
+  }
+
+  /**
+   * Aborts the frame because a callback returned a thenable (contract #24, the runtime contract for
+   * JavaScript / `any`): closes the borrowed frame and discards its command encoder **without**
+   * submitting it, so the "one frame, one ordered command list, exactly one `queue.submit()`"
+   * guarantee is kept by submitting nothing at all rather than a prefix of the intended work.
+   *
+   * Same body as `cancel()` minus its `#submitted`/`#passActive` rejections: this path always runs
+   * after the callback returned, never with a pass open, and its whole purpose is to close a frame the
+   * caller no longer controls — so it never throws.
+   *
+   * @internal Called by `FrameRunner.frame()` and by `Frame.raw()`; not part of the public API.
+   */
+  abortAsync(): void {
+    if (this.#asyncAborted) return;
+    // A callback that already ended the frame by hand settled its owners exactly once (cancel()
+    // abandoned them; submit() read them back). Re-abandoning here would deliver a second terminal
+    // event per owner, so only mark the escaped reference closed.
+    if (this.#canceled || this.#submitted) {
+      this.#asyncAborted = true;
+      return;
+    }
+    this.releaseLifecycle?.();
+    this.#abandonOwners(this.#frameOwners());
+    this.#owners.clear();
+    this.#discardedOwners.clear();
+    // The claimed-group validation promises of the dropped encoder are never delivered: no draw of
+    // this frame ran, so any native error they carry is about work that was thrown away.
+    discardClaimedGroupValidationResults(this.#validations);
+    this.#validations.length = 0;
+    this.#asyncAborted = true;
   }
 
   /**
@@ -479,6 +680,67 @@ function frameDrawable(drawable: Draw | Effect): FrameDrawableProtocol {
   return encodable;
 }
 
+/** Nominal computable protocol of a `Compute`; the frame never imports `compute.ts`. */
+function frameComputable(compute: Compute): FrameComputableProtocol {
+  const encodable = frameComputableOf(compute);
+  if (!encodable) throw new TypeError("Invalid Compute instance: f.compute() expects a Compute created by this library.");
+  return encodable;
+}
+
+/**
+ * Detects the one runtime shape contract #24 keys on: a thenable return. `typeof then === "function"`
+ * is the same test the Promise resolution algorithm uses, so a hand-rolled thenable counts exactly
+ * like a native promise — which is the point, since this path exists for JavaScript and `any`.
+ */
+function isThenableValue(value: unknown): value is PromiseLike<unknown> {
+  return typeof (value as { then?: unknown } | null | undefined)?.then === "function";
+}
+
+/**
+ * WebGPU's `copyBufferToBuffer` validation, preserved verbatim rather than softened (contract #18).
+ *
+ * An omitted `size` is the **source remainder** — `source.size - sourceOffset`, exactly as WebGPU
+ * defines the default — never `min(source remainder, destination remainder)`: a destination too small
+ * for it is an error, not a truncated copy. Every check runs before the caller encodes anything.
+ */
+function validatedBufferCopy(opts: CopyBufferOptions): { source: GPUBuffer; sourceOffset: number; destination: GPUBuffer; destinationOffset: number; size: number } {
+  if (typeof opts !== "object" || opts === null) throw invalidCopy(`received ${previewValue(opts)}; expected { source, destination, size?, sourceOffset?, destinationOffset? }.`);
+  const source = copyableBuffer(opts.source, "source");
+  const destination = copyableBuffer(opts.destination, "destination");
+  const sourceOffset = copyOffset(opts.sourceOffset, "sourceOffset");
+  const destinationOffset = copyOffset(opts.destinationOffset, "destinationOffset");
+  const size = opts.size ?? source.size - sourceOffset;
+  if (typeof size !== "number" || !Number.isInteger(size) || size < 0) throw invalidCopy(`size received ${previewValue(opts.size)}; expected a non-negative integer.`);
+  // The default is the source remainder, so an unaligned source.size (or an offset past the end)
+  // surfaces here as an error rather than silently rounding the copy down.
+  if (size % 4 !== 0) throw invalidCopy(`size ${size} is not a multiple of 4${opts.size === undefined ? ` (it defaulted to the source remainder, source.size ${source.size} - sourceOffset ${sourceOffset})` : ""}.`);
+  // Identity, not equality of contents: WebGPU requires distinct buffers, and two vgpu facades can
+  // wrap the same GPUBuffer, so the underlying handle is what has to differ.
+  if (source.gpu === destination.gpu) throw invalidCopy("source and destination are the same buffer.");
+  if (sourceOffset + size > source.size) throw invalidCopy(`sourceOffset ${sourceOffset} + size ${size} exceeds source.size ${source.size}.`);
+  if (destinationOffset + size > destination.size) throw invalidCopy(`destinationOffset ${destinationOffset} + size ${size} exceeds destination.size ${destination.size}.`);
+  return { source: source.gpu, sourceOffset, destination: destination.gpu, destinationOffset, size };
+}
+
+function invalidCopy(detail: string): VGPUError {
+  return copyBufferInvalidError("Frame.copyBuffer", detail);
+}
+
+function copyableBuffer(value: unknown, field: string): CopyableBuffer {
+  const candidate = value as Partial<CopyableBuffer> | null | undefined;
+  if (!candidate || typeof candidate !== "object" || typeof candidate.size !== "number" || !candidate.gpu) {
+    throw invalidCopy(`${field} received ${previewValue(value)}; expected a buffer with a .gpu handle and a .size in bytes.`);
+  }
+  return candidate as CopyableBuffer;
+}
+
+function copyOffset(value: number | undefined, field: string): number {
+  if (value === undefined) return 0;
+  if (typeof value !== "number" || !Number.isInteger(value) || value < 0) throw invalidCopy(`${field} received ${previewValue(value)}; expected a non-negative integer.`);
+  if (value % 4 !== 0) throw invalidCopy(`${field} ${value} is not a multiple of 4.`);
+  return value;
+}
+
 function invalidBundle(): never {
   throw new VGPUError({ code: "VGPU-R3-BUNDLE-INVALID", message: "p.bundles() expected bundles created by bundle(gpu, { target }, cb).", where: "FramePass.bundles" });
 }
@@ -551,6 +813,11 @@ function isDeviceGoneError(error: unknown): boolean {
   return code === "VGPU-DEVICE-DISPOSED" || code === "VGPU-DEVICE-LOST";
 }
 
+/** True when the frame was already closed by an inner thenable abort, so there is nothing left to flush. */
+function isFrameClosedError(error: unknown): boolean {
+  return (error as VGPUError | undefined)?.code === "VGPU-FRAME-CLOSED";
+}
+
 export class FrameRunner {
   #running = false;
   /**
@@ -559,7 +826,7 @@ export class FrameRunner {
    * stop the loops still running without holding on to the ones already stopped.
    */
   constructor(private readonly createFrame: (opts?: FrameOptions) => Frame, private readonly advance: () => void, private readonly trackLoop?: (handle: FrameLoopHandle) => () => void) {}
-  frame(cb?: (frame: Frame) => void, opts?: FrameOptions): Frame {
+  frame<R>(cb?: FrameCallback<R>, opts?: FrameOptions): Frame {
     if (this.#running || isSurfaceResizeCallbackActive()) throw frameReentrantError();
     this.#running = true;
     enterFrame();
@@ -567,16 +834,29 @@ export class FrameRunner {
       this.advance();
       const frame = this.createFrame(opts);
       if (cb) {
-        try { cb(frame); }
+        let result: unknown;
+        try { result = cb(frame); }
         finally {
-          // A callback is allowed to dispose the owning gpu (gpu.dispose() inside a loop tick does
-          // exactly that). The device is then gone and the frame has nothing left to flush, so this
-          // implicit submit swallows that one error instead of throwing over the callback's own
-          // intent — the same reason a canceled frame submits as a no-op. An explicit
-          // frame.submit() on a dead device still reports it.
-          try { frame.submit(); }
-          catch (error) { if (!isDeviceGoneError(error)) throw error; }
+          // Contract #24: a thenable return aborts the frame instead of submitting what it recorded —
+          // the one explicit exception to "a managed frame submits itself when its callback returns",
+          // and never a partial submit. A callback that *throws* synchronously never assigns `result`,
+          // so it still takes the submit branch: frame() is documented to submit on the way out of a
+          // throw, and only the thenable case discards the encoder.
+          if (isThenableValue(result)) frame.abortAsync();
+          else {
+            // A callback is allowed to dispose the owning gpu (gpu.dispose() inside a loop tick does
+            // exactly that). The device is then gone and the frame has nothing left to flush, so this
+            // implicit submit swallows that one error instead of throwing over the callback's own
+            // intent — the same reason a canceled frame submits as a no-op. An explicit
+            // frame.submit() on a dead device still reports it. A frame an inner f.raw() already
+            // aborted is closed for the same reason: it has nothing left to flush, and swallowing
+            // VGPU-FRAME-CLOSED here keeps the VGPU-ASYNC-FRAME-CALLBACK that caused it as the error
+            // the caller sees.
+            try { frame.submit(); }
+            catch (error) { if (!isDeviceGoneError(error) && !isFrameClosedError(error)) throw error; }
+          }
         }
+        if (isThenableValue(result)) throw asyncFrameCallbackError("frame");
       }
       return frame;
     } finally {
@@ -584,7 +864,7 @@ export class FrameRunner {
       this.#running = false;
     }
   }
-  loop(cb: FrameLoopCallback, opts: FrameLoopOptions = {}): FrameLoopHandle {
+  loop<R>(cb: FrameCallback<R>, opts: FrameLoopOptions = {}): FrameLoopHandle {
     let stopped = false;
     const request = globalThis.requestAnimationFrame ?? ((fn: FrameRequestCallback) => setTimeout(() => fn(performance.now()), 16) as unknown as number);
     const cancel = globalThis.cancelAnimationFrame ?? ((id: number) => clearTimeout(id));

--- a/packages/vgpu-api/src/index.ts
+++ b/packages/vgpu-api/src/index.ts
@@ -5,7 +5,7 @@ export type { Bundle, BundleOptions, BundleRecorder, Compute, ComputeOptions, Di
 export type { BlendComponentOptions, BlendOptions, BlendPreset, DepthOptions, Draw, DrawOptions, DrawCallOptions, DrawLayoutOptions, GeometryLike, StencilFaceOptions, StencilOptions } from "./draw.ts";
 export { Geometry } from "./scene/geometry-descriptor.ts";
 export type { GeometryAttributeOverride, GeometryAttributes, GeometryBuffer, GeometryBufferOptions, GeometryData, GeometryOptions, GeometrySlice, GeometrySliceOptions } from "./scene/geometry-descriptor.ts";
-export type { Frame, FrameOptions, FramePass, FramePassOptions, FrameLoopHandle, FrameLoopOptions, FrameRunner } from "./frame.ts";
+export type { BorrowedCommandEncoder, CopyableBuffer, CopyBufferOptions, Frame, FrameCallback, FrameComputeOptions, FrameOptions, FramePass, FramePassOptions, FrameLoopHandle, FrameLoopOptions, FrameRunner, SyncReturn } from "./frame.ts";
 export type { Effect, EffectOptions } from "./effect.ts";
 export type { CompileTarget, Target, TargetOptions, TargetSignature, TargetTextureOptions } from "./target.ts";
 export { VGPUError } from "./errors.ts";

--- a/packages/vgpu-api/src/mock.ts
+++ b/packages/vgpu-api/src/mock.ts
@@ -9,7 +9,7 @@ export type { Bundle, BundleOptions, BundleRecorder, Compute, ComputeOptions, Di
 export type { BlendComponentOptions, BlendOptions, BlendPreset, DepthOptions, Draw, DrawOptions, DrawCallOptions, DrawLayoutOptions, GeometryLike, StencilFaceOptions, StencilOptions } from "./draw.ts";
 export { Geometry } from "./scene/geometry-descriptor.ts";
 export type { GeometryAttributeOverride, GeometryAttributes, GeometryBuffer, GeometryBufferOptions, GeometryData, GeometryOptions, GeometrySlice, GeometrySliceOptions } from "./scene/geometry-descriptor.ts";
-export type { Frame, FrameOptions, FramePass, FramePassOptions, FrameLoopHandle, FrameLoopOptions, FrameRunner } from "./frame.ts";
+export type { BorrowedCommandEncoder, CopyableBuffer, CopyBufferOptions, Frame, FrameCallback, FrameComputeOptions, FrameOptions, FramePass, FramePassOptions, FrameLoopHandle, FrameLoopOptions, FrameRunner, SyncReturn } from "./frame.ts";
 export type { Effect, EffectOptions } from "./effect.ts";
 export type { CompileTarget, Target, TargetOptions, TargetSignature, TargetTextureOptions } from "./target.ts";
 export { VGPUError } from "./errors.ts";

--- a/packages/vgpu-api/src/node.ts
+++ b/packages/vgpu-api/src/node.ts
@@ -7,7 +7,7 @@ export type { Bundle, BundleOptions, BundleRecorder, Compute, ComputeOptions, Di
 export type { BlendComponentOptions, BlendOptions, BlendPreset, DepthOptions, Draw, DrawOptions, DrawCallOptions, DrawLayoutOptions, GeometryLike, StencilFaceOptions, StencilOptions } from "./draw.ts";
 export { Geometry } from "./scene/geometry-descriptor.ts";
 export type { GeometryAttributeOverride, GeometryAttributes, GeometryBuffer, GeometryBufferOptions, GeometryData, GeometryOptions, GeometrySlice, GeometrySliceOptions } from "./scene/geometry-descriptor.ts";
-export type { Frame, FrameOptions, FramePass, FramePassOptions, FrameLoopHandle, FrameLoopOptions, FrameRunner } from "./frame.ts";
+export type { BorrowedCommandEncoder, CopyableBuffer, CopyBufferOptions, Frame, FrameCallback, FrameComputeOptions, FrameOptions, FramePass, FramePassOptions, FrameLoopHandle, FrameLoopOptions, FrameRunner, SyncReturn } from "./frame.ts";
 export type { Effect, EffectOptions } from "./effect.ts";
 export type { CompileTarget, Target, TargetOptions, TargetSignature, TargetTextureOptions } from "./target.ts";
 export { VGPUError } from "./errors.ts";

--- a/packages/vgpu-api/tests/frame-unified.test.ts
+++ b/packages/vgpu-api/tests/frame-unified.test.ts
@@ -30,6 +30,16 @@ const COMPUTE_WGSL = `
 @compute @workgroup_size(1) fn main() {}
 `;
 
+/** Same shape compute/aliasing.test.ts uses: one read binding plus one writable binding to trip on. */
+const ALIASING_WGSL = `
+@group(0) @binding(0) var<storage, read> src: array<vec4f>;
+@group(0) @binding(1) var<storage, read_write> dst: array<vec4f>;
+@compute @workgroup_size(1)
+fn main(@builtin(global_invocation_id) id: vec3u) {
+  dst[id.x] = src[id.x];
+}
+`;
+
 let gpu: Awaited<ReturnType<typeof init>> | undefined;
 
 afterEach(() => {
@@ -264,6 +274,7 @@ test("a thenable-returning frame callback throws VGPU-ASYNC-FRAME-CALLBACK and s
   gpu = await init();
   const colorTarget = target(gpu, { size: [4, 4] });
   const drawable = draw(gpu, { shader: RENDER_WGSL, label: "dots" });
+  const sim = compute(gpu, COMPUTE_WGSL, { label: "sim" });
   const spy = spyFrameEncoder(gpu.device.gpu);
   let escaped: Frame | undefined;
 
@@ -284,6 +295,7 @@ test("a thenable-returning frame callback throws VGPU-ASYNC-FRAME-CALLBACK and s
   expect(caught(() => escaped!.cancel())?.code).toBe("VGPU-FRAME-CLOSED");
   expect(caught(() => escaped!.raw(() => undefined))?.code).toBe("VGPU-FRAME-CLOSED");
   expect(caught(() => escaped!.copyBuffer({ source: storage(gpu!, 4), destination: storage(gpu!, 4) }))?.code).toBe("VGPU-FRAME-CLOSED");
+  expect(caught(() => escaped!.compute(sim, 1))?.code).toBe("VGPU-FRAME-CLOSED");
   expect(spy.submits.count).toBe(0);
 });
 
@@ -523,4 +535,47 @@ test("f.compute() rejects a value that is not a Compute created by this library"
 
   expect(error).toBeInstanceOf(TypeError);
   expect(error?.message).toContain("f.compute()");
+});
+
+test("the gpu-wide default applies when neither the call site nor the frame names a policy (contract #3 chain)", async () => {
+  // Last link of the chain: with both overrides absent, f.compute() must read init()'s default
+  // rather than falling back to a hardcoded "sync".
+  gpu = await init({ pendingPipelines: "throw" });
+  const sim = compute(gpu, COMPUTE_WGSL, { label: "sim" });
+  const spy = spyFrameEncoder(gpu.device.gpu);
+
+  const error = caught(() => frame(gpu!, (f) => f.compute(sim, 1)));
+
+  expect(error?.code).toBe("VGPU-PIPELINE-PENDING");
+  expect(getMockGPUDeviceInstrumentation(gpu.device.gpu).calls.createComputePipeline).toBe(0);
+  expect(names(spy.ops)).toEqual([]);
+});
+
+test("f.compute() runs the writable-storage aliasing guard and encodes nothing when it trips", async () => {
+  // The guard is #preflightAliasing, reused verbatim from dispatch()/dispatchOnce(): the frame path
+  // must not be a hole through which an aliased bind group reaches the queue.
+  gpu = await init();
+  const sim = compute(gpu, ALIASING_WGSL, { label: "sim" });
+  const buffer = storage(gpu, 16);
+  sim.set({ src: buffer, dst: buffer });
+  const spy = spyFrameEncoder(gpu.device.gpu);
+
+  const error = caught(() => frame(gpu!, (f) => f.compute(sim, 1)));
+
+  expect(error?.code).toBe(caught(() => sim.dispatch(1))?.code);
+  expect(error?.message).toContain("alias");
+  expect(names(spy.ops)).toEqual([]);
+});
+
+test("an unexpected submit failure propagates instead of being swallowed", async () => {
+  // frame()'s implicit submit swallows exactly two codes (device gone, frame closed). Anything else
+  // must reach the caller: silently dropping a queue failure would hide a real bug.
+  gpu = await init();
+  const colorTarget = target(gpu, { size: [4, 4] });
+  const drawable = draw(gpu, { shader: RENDER_WGSL, label: "dots" });
+  vi.spyOn(gpu.device.gpu.queue, "submit").mockImplementation(() => {
+    throw new Error("submit exploded");
+  });
+
+  expect(() => frame(gpu!, (f) => f.pass(colorTarget, (p) => p.draw(drawable)))).toThrowError("submit exploded");
 });

--- a/packages/vgpu-api/tests/frame-unified.test.ts
+++ b/packages/vgpu-api/tests/frame-unified.test.ts
@@ -1,0 +1,526 @@
+/**
+ * Contracts of the unified frame (issue #320 §2 / §2a): one encoder and exactly one
+ * `queue.submit()` for `f.compute()` + `f.copyBuffer()` + `f.raw()` + `f.pass()`.
+ *
+ * - #1  — a compute dispatch and a render pass recorded in the same `frame()` produce exactly one
+ *         `queue.submit()`, in program order.
+ * - #17 — `f.compute()` validates integer workgroup counts >= 0 with the same stable code
+ *         `dispatchOnce()` already uses.
+ * - #18 — `f.copyBuffer()` defaults `size` to `source.size - sourceOffset`; a range/alignment
+ *         violation or `source === destination` fails with a stable code and encodes nothing.
+ * - #24 — a thenable return aborts the frame (`VGPU-ASYNC-FRAME-CALLBACK`, no submit at all) and an
+ *         escaped `Frame` then throws `VGPU-FRAME-CLOSED`.
+ * - #25 — `f.raw()` borrows the frame's open encoder; inside a managed pass or reentrantly it throws
+ *         `VGPU-FRAME-ENCODER-LOCKED` *before* invoking the callback.
+ */
+import { afterEach, expect, test, vi } from "vitest";
+import { getMockGPUDeviceInstrumentation } from "@vgpu/core";
+import { compute, draw, frame, init, storage, target } from "../src/mock.ts";
+import type { Frame } from "../src/frame.ts";
+
+const RENDER_WGSL = `
+@vertex fn vs_main(@builtin(vertex_index) vi: u32) -> @builtin(position) vec4f {
+  var pos = array<vec2f, 3>(vec2f(-1.0, -1.0), vec2f(3.0, -1.0), vec2f(-1.0, 3.0));
+  return vec4f(pos[vi], 0.0, 1.0);
+}
+@fragment fn fs_main() -> @location(0) vec4f { return vec4f(1.0); }
+`;
+
+const COMPUTE_WGSL = `
+@compute @workgroup_size(1) fn main() {}
+`;
+
+let gpu: Awaited<ReturnType<typeof init>> | undefined;
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  gpu?.dispose();
+  gpu = undefined;
+});
+
+type EncodeOp = readonly [name: string, ...args: unknown[]];
+
+/**
+ * Records, in encode order, every command the frame's own encoder receives plus every
+ * `queue.submit()`. `vgpu.frame` is the only label `Frame` uses, so a `dispatch()` that opened its
+ * own encoder would not be counted here — which is exactly the distinction contract #1 needs.
+ */
+function spyFrameEncoder(device: GPUDevice): { readonly ops: EncodeOp[]; readonly submits: { count: number }; readonly frameEncoders: GPUCommandEncoder[] } {
+  const ops: EncodeOp[] = [];
+  const submits = { count: 0 };
+  const frameEncoders: GPUCommandEncoder[] = [];
+  const createCommandEncoder = device.createCommandEncoder.bind(device);
+  vi.spyOn(device, "createCommandEncoder").mockImplementation((desc?: GPUCommandEncoderDescriptor) => {
+    const encoder = createCommandEncoder(desc);
+    if (desc?.label !== "vgpu.frame") return encoder;
+    frameEncoders.push(encoder);
+    const beginRenderPass = encoder.beginRenderPass.bind(encoder);
+    const beginComputePass = encoder.beginComputePass.bind(encoder);
+    const copyBufferToBuffer = encoder.copyBufferToBuffer.bind(encoder);
+    (encoder as { beginRenderPass: unknown }).beginRenderPass = (passDesc: GPURenderPassDescriptor) => {
+      ops.push(["beginRenderPass"]);
+      return beginRenderPass(passDesc);
+    };
+    (encoder as { beginComputePass: unknown }).beginComputePass = (passDesc?: GPUComputePassDescriptor) => {
+      ops.push(["beginComputePass"]);
+      return beginComputePass(passDesc);
+    };
+    (encoder as { copyBufferToBuffer: unknown }).copyBufferToBuffer = (source: GPUBuffer, sourceOffset: number, destination: GPUBuffer, destinationOffset: number, size?: number) => {
+      ops.push(["copyBufferToBuffer", source, sourceOffset, destination, destinationOffset, size]);
+      return copyBufferToBuffer(source, sourceOffset, destination, destinationOffset, size);
+    };
+    return encoder;
+  });
+  const submit = device.queue.submit.bind(device.queue);
+  vi.spyOn(device.queue, "submit").mockImplementation((buffers: Iterable<GPUCommandBuffer>) => {
+    submits.count += 1;
+    submit(buffers);
+  });
+  return { ops, submits, frameEncoders };
+}
+
+/** Returns the error a synchronous call threw, so assertions pin `code` instead of message text. */
+function caught(fn: () => unknown): { code?: string; message?: string } | undefined {
+  try { fn(); }
+  catch (error) { return error as { code?: string; message?: string }; }
+  return undefined;
+}
+
+/** GPUBufferUsage is a WebGPU global the mock environment does not install; the flags are spec constants. */
+const BUFFER_USAGE = { COPY_SRC: 0x0004, COPY_DST: 0x0008 } as const;
+
+function names(ops: readonly EncodeOp[]): string[] {
+  return ops.map((op) => op[0]);
+}
+
+// --- Contract #1 — one encoder, one submit, program order ---------------------------------------
+
+test("a compute dispatch and a render pass in the same frame() produce exactly one submit, in program order (contract #1)", async () => {
+  gpu = await init();
+  const colorTarget = target(gpu, { size: [4, 4] });
+  const sim = compute(gpu, COMPUTE_WGSL, { label: "sim" });
+  const drawable = draw(gpu, { shader: RENDER_WGSL, label: "dots" });
+  const spy = spyFrameEncoder(gpu.device.gpu);
+
+  frame(gpu, (f) => {
+    f.compute(sim, 2);
+    f.pass(colorTarget, (p) => p.draw(drawable));
+  });
+
+  expect(spy.submits.count).toBe(1);
+  expect(names(spy.ops)).toEqual(["beginComputePass", "beginRenderPass"]);
+});
+
+test("program order is the encode order, render first (contract #1)", async () => {
+  gpu = await init();
+  const colorTarget = target(gpu, { size: [4, 4] });
+  const sim = compute(gpu, COMPUTE_WGSL, { label: "sim" });
+  const drawable = draw(gpu, { shader: RENDER_WGSL, label: "dots" });
+  const spy = spyFrameEncoder(gpu.device.gpu);
+
+  frame(gpu, (f) => {
+    f.pass(colorTarget, (p) => p.draw(drawable));
+    f.compute(sim, 1, 2, 3);
+  });
+
+  expect(spy.submits.count).toBe(1);
+  expect(names(spy.ops)).toEqual(["beginRenderPass", "beginComputePass"]);
+});
+
+test("f.compute() dispatches the resolved workgroup counts and never finishes the borrowed encoder", async () => {
+  gpu = await init();
+  const sim = compute(gpu, COMPUTE_WGSL, { label: "sim" });
+  const dispatched: Array<readonly [number, number, number]> = [];
+  const createCommandEncoder = gpu.device.gpu.createCommandEncoder.bind(gpu.device.gpu);
+  let finishes = 0;
+  vi.spyOn(gpu.device.gpu, "createCommandEncoder").mockImplementation((desc?: GPUCommandEncoderDescriptor) => {
+    const encoder = createCommandEncoder(desc);
+    if (desc?.label !== "vgpu.frame") return encoder;
+    const beginComputePass = encoder.beginComputePass.bind(encoder);
+    const finish = encoder.finish.bind(encoder);
+    (encoder as { beginComputePass: unknown }).beginComputePass = (passDesc?: GPUComputePassDescriptor) => {
+      const pass = beginComputePass(passDesc);
+      const dispatchWorkgroups = pass.dispatchWorkgroups.bind(pass);
+      (pass as { dispatchWorkgroups: unknown }).dispatchWorkgroups = (x: number, y?: number, z?: number) => {
+        dispatched.push([x, y ?? 1, z ?? 1]);
+        dispatchWorkgroups(x, y, z);
+      };
+      return pass;
+    };
+    (encoder as { finish: unknown }).finish = (finishDesc?: GPUCommandBufferDescriptor) => {
+      finishes += 1;
+      return finish(finishDesc);
+    };
+    return encoder;
+  });
+
+  frame(gpu, (f) => {
+    f.compute(sim, 4);
+    f.compute(sim, 4, 5);
+    f.compute(sim, 4, 5, 6);
+  });
+
+  expect(dispatched).toEqual([[4, 1, 1], [4, 5, 1], [4, 5, 6]]);
+  // Exactly one finish() — the frame's, at submit time. `encodeForFrame` never finishes the borrow.
+  expect(finishes).toBe(1);
+});
+
+// --- Contract #17 — workgroup count validation is shared with dispatchOnce ----------------------
+
+test("f.compute() rejects non-integer and negative workgroup counts with the same code as dispatchOnce (contract #17)", async () => {
+  gpu = await init();
+  const sim = compute(gpu, COMPUTE_WGSL, { label: "sim" });
+  const spy = spyFrameEncoder(gpu.device.gpu);
+
+  const legacy = await dispatchOnceError(sim);
+  expect(legacy?.code).toBe("VGPU-R1-DISPATCH-COUNT");
+
+  for (const bad of [-1, 1.5, Number.NaN] as const) {
+    const error = caught(() => frame(gpu!, (f) => f.compute(sim, bad)));
+    expect(error?.code).toBe(legacy?.code);
+  }
+  const yError = caught(() => frame(gpu!, (f) => f.compute(sim, 1, -2)));
+  expect(yError?.code).toBe("VGPU-R1-DISPATCH-COUNT");
+  const zError = caught(() => frame(gpu!, (f) => f.compute(sim, 1, 1, 0.5)));
+  expect(zError?.code).toBe("VGPU-R1-DISPATCH-COUNT");
+
+  // Nothing was encoded: the validation runs before the compute pass opens.
+  expect(names(spy.ops)).toEqual([]);
+});
+
+async function dispatchOnceError(sim: ReturnType<typeof compute>): Promise<{ code?: string } | undefined> {
+  try { await sim.dispatchOnce(-1); }
+  catch (error) { return error as { code?: string }; }
+  return undefined;
+}
+
+// --- Contract #18 — f.copyBuffer() -------------------------------------------------------------
+
+test("f.copyBuffer() with size omitted copies source.size - sourceOffset bytes (contract #18)", async () => {
+  gpu = await init();
+  const source = storage(gpu, 64);
+  const destination = storage(gpu, 64);
+  const spy = spyFrameEncoder(gpu.device.gpu);
+
+  frame(gpu, (f) => {
+    f.copyBuffer({ source, destination });
+    f.copyBuffer({ source, destination, sourceOffset: 16 });
+    f.copyBuffer({ source, destination, sourceOffset: 16, destinationOffset: 8, size: 4 });
+  });
+
+  expect(spy.ops).toEqual([
+    ["copyBufferToBuffer", source.gpu, 0, destination.gpu, 0, 64],
+    ["copyBufferToBuffer", source.gpu, 16, destination.gpu, 0, 48],
+    ["copyBufferToBuffer", source.gpu, 16, destination.gpu, 8, 4],
+  ]);
+  expect(spy.submits.count).toBe(1);
+});
+
+test("f.copyBuffer() rejects range, alignment and self-copy violations with a stable code and encodes nothing (contract #18)", async () => {
+  gpu = await init();
+  const source = storage(gpu, 64);
+  const destination = storage(gpu, 32);
+  const spy = spyFrameEncoder(gpu.device.gpu);
+
+  const violations: Array<() => void> = [
+    // sourceOffset is not a multiple of 4
+    () => frame(gpu!, (f) => f.copyBuffer({ source, destination, sourceOffset: 2, size: 4 })),
+    // destinationOffset is not a multiple of 4
+    () => frame(gpu!, (f) => f.copyBuffer({ source, destination, destinationOffset: 3, size: 4 })),
+    // size is not a multiple of 4
+    () => frame(gpu!, (f) => f.copyBuffer({ source, destination, size: 6 })),
+    // sourceOffset + size > source.size
+    () => frame(gpu!, (f) => f.copyBuffer({ source, destination, sourceOffset: 60, size: 8 })),
+    // destinationOffset + size > destination.size — the implicit source remainder is too big
+    () => frame(gpu!, (f) => f.copyBuffer({ source, destination })),
+    // destinationOffset + size > destination.size, explicit size
+    () => frame(gpu!, (f) => f.copyBuffer({ source, destination, destinationOffset: 28, size: 8 })),
+    // source === destination
+    () => frame(gpu!, (f) => f.copyBuffer({ source, destination: source, size: 4 })),
+    // negative offset
+    () => frame(gpu!, (f) => f.copyBuffer({ source, destination, sourceOffset: -4, size: 4 })),
+  ];
+
+  for (const violation of violations) {
+    expect(caught(violation)?.code).toBe("VGPU-COPY-BUFFER-INVALID");
+  }
+  expect(names(spy.ops)).toEqual([]);
+});
+
+test("f.copyBuffer() accepts any { gpu, size } pair, not only a StorageBuffer (contract #18)", async () => {
+  gpu = await init();
+  const source = storage(gpu, 16);
+  const raw = gpu.gpu.createBuffer({ size: 16, usage: BUFFER_USAGE.COPY_DST | BUFFER_USAGE.COPY_SRC });
+  const spy = spyFrameEncoder(gpu.device.gpu);
+
+  frame(gpu, (f) => { f.copyBuffer({ source, destination: { gpu: raw, size: 16 } }); });
+
+  expect(spy.ops).toEqual([["copyBufferToBuffer", source.gpu, 0, raw, 0, 16]]);
+});
+
+// --- Contract #24 — synchronous callbacks ------------------------------------------------------
+
+test("a thenable-returning frame callback throws VGPU-ASYNC-FRAME-CALLBACK and submits nothing (contract #24)", async () => {
+  gpu = await init();
+  const colorTarget = target(gpu, { size: [4, 4] });
+  const drawable = draw(gpu, { shader: RENDER_WGSL, label: "dots" });
+  const spy = spyFrameEncoder(gpu.device.gpu);
+  let escaped: Frame | undefined;
+
+  const error = caught(() => frame(gpu!, ((f: Frame) => {
+    escaped = f;
+    f.pass(colorTarget, (p) => p.draw(drawable));
+    return Promise.resolve();
+  }) as never));
+
+  expect(error?.code).toBe("VGPU-ASYNC-FRAME-CALLBACK");
+  // Not a partial submit: the recorded render pass is discarded with the encoder.
+  expect(spy.submits.count).toBe(0);
+  expect(names(spy.ops)).toEqual(["beginRenderPass"]);
+
+  // Every entry point of the escaped frame is closed.
+  expect(caught(() => escaped!.pass(colorTarget, () => undefined))?.code).toBe("VGPU-FRAME-CLOSED");
+  expect(caught(() => escaped!.submit())?.code).toBe("VGPU-FRAME-CLOSED");
+  expect(caught(() => escaped!.cancel())?.code).toBe("VGPU-FRAME-CLOSED");
+  expect(caught(() => escaped!.raw(() => undefined))?.code).toBe("VGPU-FRAME-CLOSED");
+  expect(caught(() => escaped!.copyBuffer({ source: storage(gpu!, 4), destination: storage(gpu!, 4) }))?.code).toBe("VGPU-FRAME-CLOSED");
+  expect(spy.submits.count).toBe(0);
+});
+
+test("any thenable counts, not only a real promise (contract #24)", async () => {
+  gpu = await init();
+  const spy = spyFrameEncoder(gpu.device.gpu);
+
+  const error = caught(() => frame(gpu!, (() => ({ then() { /* thenable */ } })) as never));
+
+  expect(error?.code).toBe("VGPU-ASYNC-FRAME-CALLBACK");
+  expect(spy.submits.count).toBe(0);
+});
+
+test("frameLoop() rejects a thenable callback the same way (contract #24)", async () => {
+  gpu = await init();
+  const spy = spyFrameEncoder(gpu.device.gpu);
+  const requested: FrameRequestCallback[] = [];
+  vi.stubGlobal("requestAnimationFrame", (cb: FrameRequestCallback) => { requested.push(cb); return requested.length; });
+  vi.stubGlobal("cancelAnimationFrame", () => undefined);
+
+  const { frameLoop } = await import("../src/mock.ts");
+  const handle = frameLoop(gpu, (() => Promise.resolve()) as never);
+  const error = caught(() => requested[0]?.(0));
+  handle.stop();
+  vi.unstubAllGlobals();
+
+  expect(error?.code).toBe("VGPU-ASYNC-FRAME-CALLBACK");
+  expect(spy.submits.count).toBe(0);
+});
+
+test("a callback that throws synchronously still submits the prefix it recorded (preexisting behavior)", async () => {
+  gpu = await init();
+  const colorTarget = target(gpu, { size: [4, 4] });
+  const drawable = draw(gpu, { shader: RENDER_WGSL, label: "dots" });
+  const spy = spyFrameEncoder(gpu.device.gpu);
+
+  const error = caught(() => frame(gpu!, (f) => {
+    f.pass(colorTarget, (p) => p.draw(drawable));
+    throw new Error("boom");
+  }));
+
+  expect(error?.message).toBe("boom");
+  // Documented behavior of frame(): it submits on the way out of a throw. Only the thenable case discards.
+  expect(spy.submits.count).toBe(1);
+});
+
+// --- Contract #25 — f.raw() --------------------------------------------------------------------
+
+test("f.raw() lends the frame's own encoder between managed passes, keeping one submit (contract #25)", async () => {
+  gpu = await init();
+  const colorTarget = target(gpu, { size: [4, 4] });
+  const drawable = draw(gpu, { shader: RENDER_WGSL, label: "dots" });
+  const sim = compute(gpu, COMPUTE_WGSL, { label: "sim" });
+  const scratchSource = storage(gpu, 16);
+  const scratchDestination = storage(gpu, 16);
+  const spy = spyFrameEncoder(gpu.device.gpu);
+  const borrowed: unknown[] = [];
+
+  frame(gpu, (f) => {
+    // The mock command encoder implements only the copy/pass/finish subset, so the raw block uses
+    // copyBufferToBuffer: what matters here is the encoder identity and the program order, not which
+    // command is recorded.
+    f.raw((encoder) => {
+      borrowed.push(encoder);
+      encoder.copyBufferToBuffer(scratchSource.gpu, 0, scratchDestination.gpu, 0, 16);
+    });
+    f.compute(sim, 1);
+    f.pass(colorTarget, (p) => p.draw(drawable));
+  });
+
+  // Identity, not a wrapper: the callback receives the very encoder the frame will finish and submit,
+  // which is what makes program order and the single submit structural rather than best-effort.
+  expect(borrowed).toHaveLength(1);
+  expect(borrowed[0]).toBe(spy.frameEncoders[0]);
+  expect(spy.submits.count).toBe(1);
+  expect(names(spy.ops)).toEqual(["copyBufferToBuffer", "beginComputePass", "beginRenderPass"]);
+});
+
+test("f.raw() inside f.pass() throws VGPU-FRAME-ENCODER-LOCKED before invoking the callback (contract #25)", async () => {
+  gpu = await init();
+  const colorTarget = target(gpu, { size: [4, 4] });
+  const drawable = draw(gpu, { shader: RENDER_WGSL, label: "dots" });
+  let ran = false;
+
+  const error = caught(() => frame(gpu!, (f) => {
+    f.pass(colorTarget, (p) => {
+      p.draw(drawable);
+      f.raw(() => { ran = true; });
+    });
+  }));
+
+  expect(error?.code).toBe("VGPU-FRAME-ENCODER-LOCKED");
+  expect(ran).toBe(false);
+});
+
+test("f.raw() reentrantly from another f.raw() callback throws VGPU-FRAME-ENCODER-LOCKED before invoking the callback (contract #25)", async () => {
+  gpu = await init();
+  let ran = false;
+
+  const error = caught(() => frame(gpu!, (f) => {
+    f.raw(() => { f.raw(() => { ran = true; }); });
+  }));
+
+  expect(error?.code).toBe("VGPU-FRAME-ENCODER-LOCKED");
+  expect(ran).toBe(false);
+});
+
+test("f.compute() and f.copyBuffer() inside a managed pass are rejected the same way (contract #25 boundary)", async () => {
+  gpu = await init();
+  const colorTarget = target(gpu, { size: [4, 4] });
+  const sim = compute(gpu, COMPUTE_WGSL, { label: "sim" });
+  const source = storage(gpu, 16);
+  const destination = storage(gpu, 16);
+
+  const computeError = caught(() => frame(gpu!, (f) => {
+    f.pass(colorTarget, () => { f.compute(sim, 1); });
+  }));
+  const copyError = caught(() => frame(gpu!, (f) => {
+    f.pass(colorTarget, () => { f.copyBuffer({ source, destination }); });
+  }));
+
+  expect(computeError?.code).toBe("VGPU-FRAME-ENCODER-LOCKED");
+  expect(copyError?.code).toBe("VGPU-FRAME-ENCODER-LOCKED");
+});
+
+test("the borrow ends when the raw callback returns: a second f.raw() after it is legal (contract #25)", async () => {
+  gpu = await init();
+  const spy = spyFrameEncoder(gpu.device.gpu);
+  const seen: string[] = [];
+
+  frame(gpu, (f) => {
+    f.raw(() => { seen.push("first"); });
+    f.raw(() => { seen.push("second"); });
+  });
+
+  expect(seen).toEqual(["first", "second"]);
+  expect(spy.submits.count).toBe(1);
+});
+
+test("a raw callback returning a thenable aborts the whole frame, exactly like the top-level case (contract #25 -> #24)", async () => {
+  gpu = await init();
+  const colorTarget = target(gpu, { size: [4, 4] });
+  const drawable = draw(gpu, { shader: RENDER_WGSL, label: "dots" });
+  const spy = spyFrameEncoder(gpu.device.gpu);
+  let escaped: Frame | undefined;
+
+  const error = caught(() => frame(gpu!, (f) => {
+    escaped = f;
+    f.pass(colorTarget, (p) => p.draw(drawable));
+    f.raw((() => Promise.resolve()) as never);
+  }));
+
+  expect(error?.code).toBe("VGPU-ASYNC-FRAME-CALLBACK");
+  expect(spy.submits.count).toBe(0);
+  expect(caught(() => escaped!.raw(() => undefined))?.code).toBe("VGPU-FRAME-CLOSED");
+});
+
+// --- Regression: the frame that uses none of the new methods behaves exactly as before ---------
+
+test("a frame with only f.pass() still submits exactly once, unchanged", async () => {
+  gpu = await init();
+  const colorTarget = target(gpu, { size: [4, 4] });
+  const drawable = draw(gpu, { shader: RENDER_WGSL, label: "dots" });
+  const spy = spyFrameEncoder(gpu.device.gpu);
+
+  frame(gpu, (f) => f.pass(colorTarget, (p) => p.draw(drawable)));
+
+  expect(spy.submits.count).toBe(1);
+  expect(names(spy.ops)).toEqual(["beginRenderPass"]);
+  expect(getMockGPUDeviceInstrumentation(gpu.device.gpu).calls.createComputePipeline).toBe(0);
+});
+
+// --- pendingPipelines policy for f.compute() (contract #3/#4 through the frame) -----------------
+
+test("f.compute() compiles inline under the effective \"sync\" default (contract #3)", async () => {
+  gpu = await init();
+  const sim = compute(gpu, COMPUTE_WGSL, { label: "sim" });
+  const spy = spyFrameEncoder(gpu.device.gpu);
+
+  frame(gpu, (f) => f.compute(sim, 1));
+
+  const calls = getMockGPUDeviceInstrumentation(gpu.device.gpu).calls;
+  expect(calls.createComputePipeline).toBe(1);
+  expect(calls.createComputePipelineAsync).toBe(0);
+  expect(names(spy.ops)).toEqual(["beginComputePass"]);
+});
+
+test("f.compute() under \"throw\" reports VGPU-PIPELINE-PENDING and starts no compilation (contract #3)", async () => {
+  gpu = await init();
+  const sim = compute(gpu, COMPUTE_WGSL, { label: "sim" });
+  const spy = spyFrameEncoder(gpu.device.gpu);
+
+  const error = caught(() => frame(gpu!, (f) => f.compute(sim, 1), { pendingPipelines: "throw" }));
+
+  expect(error?.code).toBe("VGPU-PIPELINE-PENDING");
+  const calls = getMockGPUDeviceInstrumentation(gpu.device.gpu).calls;
+  expect(calls.createComputePipeline).toBe(0);
+  expect(calls.createComputePipelineAsync).toBe(0);
+  expect(names(spy.ops)).toEqual([]);
+});
+
+test("f.compute() under \"skip\" starts async compilation, encodes nothing and never throws (contract #3)", async () => {
+  gpu = await init();
+  const sim = compute(gpu, COMPUTE_WGSL, { label: "sim" });
+  const spy = spyFrameEncoder(gpu.device.gpu);
+
+  expect(() => frame(gpu!, (f) => f.compute(sim, 1), { pendingPipelines: "skip" })).not.toThrow();
+
+  const calls = getMockGPUDeviceInstrumentation(gpu.device.gpu).calls;
+  expect(calls.createComputePipeline).toBe(0);
+  expect(calls.createComputePipelineAsync).toBe(1);
+  expect(names(spy.ops)).toEqual([]);
+  expect(spy.submits.count).toBe(1);
+
+  // Once the background compile lands, the next frame encodes the dispatch without compiling again.
+  await sim.dispatchOnce(1);
+  frame(gpu, (f) => f.compute(sim, 1), { pendingPipelines: "skip" });
+  expect(getMockGPUDeviceInstrumentation(gpu.device.gpu).calls.createComputePipelineAsync).toBe(1);
+  expect(names(spy.ops)).toEqual(["beginComputePass"]);
+});
+
+test("the call-site policy wins over the frame policy for f.compute() (contract #3 chain)", async () => {
+  gpu = await init();
+  const sim = compute(gpu, COMPUTE_WGSL, { label: "sim" });
+
+  frame(gpu, (f) => f.compute(sim, 1, undefined, undefined, { pendingPipelines: "skip" }), { pendingPipelines: "throw" });
+
+  const calls = getMockGPUDeviceInstrumentation(gpu.device.gpu).calls;
+  expect(calls.createComputePipeline).toBe(0);
+  expect(calls.createComputePipelineAsync).toBe(1);
+});
+
+test("f.compute() rejects a value that is not a Compute created by this library", async () => {
+  gpu = await init();
+
+  const error = caught(() => frame(gpu!, (f) => f.compute({ dispatch() {} } as never, 1)));
+
+  expect(error).toBeInstanceOf(TypeError);
+  expect(error?.message).toContain("f.compute()");
+});

--- a/packages/vgpu-api/tests/frame/frame-callback-types.ts
+++ b/packages/vgpu-api/tests/frame/frame-callback-types.ts
@@ -1,0 +1,78 @@
+/**
+ * Type-level fixture for contract #24 / #25: `frame()` and `frameLoop()` accept synchronous
+ * callbacks only, and the encoder `f.raw()` lends out cannot be finished.
+ *
+ * Compiled by `pnpm typecheck:fixtures` (tsconfig.types.json next to this file): every
+ * `@ts-expect-error` below must be a real error, and every other line must compile clean.
+ */
+import type { BorrowedCommandEncoder, Frame, Gpu, Target } from "../../src/index.ts";
+import { frame, frameLoop } from "../../src/index.ts";
+
+declare const gpu: Gpu;
+declare const screen: Target;
+declare const loadAssets: () => Promise<void>;
+
+// --- Accepted: every synchronous shape the corpus uses today ------------------------------------
+
+// Block-bodied arrow.
+frame(gpu, (f) => { f.pass(screen, () => undefined); });
+// Expression-bodied arrow returning void.
+frame(gpu, (f) => f.pass(screen, () => undefined));
+// Expression-bodied arrow returning a value (not a thenable).
+frame(gpu, (f) => (f.pass(screen, () => undefined), 42));
+// Function expression form.
+frame(gpu, function record(f: Frame) { f.pass(screen, () => undefined); });
+// Early return inside a block body.
+frame(gpu, (f) => { if (Math.random() > 0.5) return; f.pass(screen, () => undefined); });
+// No callback at all: the manual frame form.
+frame(gpu);
+// Options bag still accepted alongside the callback.
+frame(gpu, (f) => { f.pass(screen, () => undefined); }, { pendingPipelines: "sync" });
+
+frameLoop(gpu, (f) => { f.pass(screen, () => undefined); });
+frameLoop(gpu, (f) => f.pass(screen, () => undefined));
+frameLoop(gpu, (f) => { f.pass(screen, () => undefined); }, { fps: 30 });
+
+// --- Rejected: any callback whose inferred return extends PromiseLike ---------------------------
+
+// @ts-expect-error an async callback returns Promise<void>, which FrameCallback rejects (contract #24)
+frame(gpu, async (f) => { await loadAssets(); f.pass(screen, () => undefined); });
+// @ts-expect-error an expression-bodied callback returning a promise is rejected too
+frame(gpu, () => loadAssets());
+// @ts-expect-error frameLoop() uses the same constraint
+frameLoop(gpu, async (f) => { await loadAssets(); f.pass(screen, () => undefined); });
+// @ts-expect-error frameLoop() rejects an expression-bodied promise return as well
+frameLoop(gpu, () => loadAssets());
+
+// --- f.raw(): finish() is unrepresentable, not merely forbidden (contract #25) ------------------
+
+declare const stats: GPUQuerySet;
+declare const resolved: GPUBuffer;
+
+frame(gpu, (f) => {
+  f.raw((encoder: BorrowedCommandEncoder) => {
+    encoder.pushDebugGroup("simulation");
+    encoder.clearBuffer(resolved, 0, 16);
+    encoder.resolveQuerySet(stats, 0, 2, resolved, 0);
+    encoder.popDebugGroup();
+    // @ts-expect-error finish() is omitted from the borrowed encoder: submission stays the frame's job
+    encoder.finish();
+  });
+});
+
+// The callback parameter is inferred, so an annotation is never required.
+frame(gpu, (f) => {
+  f.raw((encoder) => { encoder.pushDebugGroup("x"); encoder.popDebugGroup(); });
+});
+
+// --- f.copyBuffer(): structural, so any { gpu, size } pair is accepted (contract #18) ----------
+
+declare const source: { readonly gpu: GPUBuffer; readonly size: number };
+declare const destination: { readonly gpu: GPUBuffer; readonly size: number };
+
+frame(gpu, (f) => {
+  f.copyBuffer({ source, destination });
+  f.copyBuffer({ source, destination, size: 4, sourceOffset: 4, destinationOffset: 8 });
+  // @ts-expect-error a buffer-less object is not a copyable buffer
+  f.copyBuffer({ source: { size: 4 }, destination });
+});

--- a/packages/vgpu-api/tests/frame/tsconfig.types.json
+++ b/packages/vgpu-api/tests/frame/tsconfig.types.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "composite": false,
+    "declaration": false,
+    "declarationMap": false,
+    "noEmit": true,
+    "allowImportingTsExtensions": true
+  },
+  "include": ["../../src/**/*.ts", "frame-callback-types.ts"]
+}


### PR DESCRIPTION
Implements the **unified frame** (issue #320 §2/§2a, rev 6.1): `f.compute()`, `f.copyBuffer()` and
`f.raw()` record into the *same* `GPUCommandEncoder` as `f.pass()`, so one frame is still exactly one
`queue.submit()`, in program order. Contracts **#1 / #17 / #18 / #24 / #25**.

Base: `next/0.4` @ `b4d39016` (re-fetched explicitly; `origin/next/0.4` is unchanged, so no merge
commit was needed — the branch already contains the tip). 6 signed commits.

## What landed

- **`f.compute(compute, x, y?, z?, opts?)`** — encodes one compute pass into the frame's encoder via
  the new nominal `FRAME_COMPUTABLE` protocol, so **`frame.ts` never imports `compute.ts`**
  (pay-for-what-you-import). Reuses `#validateCounts` / `#preflightAliasing` verbatim (contract #17)
  — no reimplementation. `pendingPipelines` resolves call site → frame → gpu.
- **`f.copyBuffer(opts)`** — WebGPU's `copyBufferToBuffer` validation preserved **verbatim**. An
  omitted `size` is the **source remainder** `source.size − sourceOffset`, *never*
  `min(sourceRemaining, destRemaining)`: a destination too small is an error, not a silent truncation.
- **`f.raw(cb)`** — lends the open encoder as `BorrowedCommandEncoder = Omit<GPUCommandEncoder,"finish">`,
  so `finish()` is *unrepresentable*, not merely forbidden. `VGPU-FRAME-ENCODER-LOCKED` is thrown
  **before** the callback is invoked.
- **Synchronous-callback contract** — `FrameCallback<R>`/`SyncReturn<R>` reject `async` callbacks at
  compile time; at runtime a thenable return raises `VGPU-ASYNC-FRAME-CALLBACK`, discards the encoder
  **without submitting anything**, and any later use of the escaped `Frame` raises `VGPU-FRAME-CLOSED`.
- **`StorageBuffer.gpu`** exposed (additive) — `f.copyBuffer()` is not expressible without it.
- New codes: `VGPU-FRAME-ENCODER-LOCKED`, `VGPU-ASYNC-FRAME-CALLBACK`, `VGPU-FRAME-CLOSED`,
  `VGPU-COPY-BUFFER-INVALID`.

## The three builder decisions

**1. `f.compute()` / `f.copyBuffer()` inside an open `f.pass()` also throw `VGPU-FRAME-ENCODER-LOCKED`.**
This is an **addition** — contract #25's text only forbids nesting `f.raw()`; rev 6.1 is silent about
the other two. It is nonetheless the right call, and the WebGPU spec is the reason: a
`GPUCommandEncoder` whose pass encoder is active is in the **`"locked"` encoder state**, and
*"Any command issued in this state **invalidates the encoder**"* (WebGPU §13.1 `GPUCommandsMixin`,
"Validate the encoder state"). So without the guard, one stray `f.copyBuffer()` mid-pass would
silently invalidate the **whole frame's command buffer** and surface later as an opaque
`finish()` validation error. The guard converts that into a precise, actionable error, and it reuses
the platform's own vocabulary ("locked"). This is a **deviation-by-addition**: strictly more
restrictive than rev 6.1, never more permissive, and it rejects only programs the platform would
have invalidated anyway. **Recommend amending contract #25 to state this explicitly** (queued with
the contract owner), since a reader of the contract list alone would not expect it.

**2. `isFrameClosedError` is swallowed by the implicit submit** — so an inner `f.raw()` thenable abort
surfaces as the original `VGPU-ASYNC-FRAME-CALLBACK` instead of being masked by a redundant
`VGPU-FRAME-CLOSED` echo. Audited: `#asyncAborted` is set **only** by `abortAsync()`, which is called
only from (a) `FrameRunner.frame()`'s thenable branch — which never calls `submit()` — and (b)
`Frame.raw()`. So the only `VGPU-FRAME-CLOSED` reachable at that call site is the frame's own abort.
Verified adversarially: a legitimate native submit failure still propagates, and a `VGPU-FRAME-CLOSED`
originating from a *different* (previously escaped) frame propagates too, with the healthy frame still
submitting normally. Latent (not live) fragility: the guard matches on the error **code** rather than a
scoped sentinel, so a future second throw-site for that code would be swallowed here silently.

**3. `f.compute()` under `"skip"` is not tracked in `gpu.settled()`** — scoped out, and the
"pre-existing" classification is **confirmed**: `compute.ts` contains no `trackDelivery` at
`b4d39016` *or* on this branch, i.e. compute-pipeline compiles were never covered by `settled()`.
`f.compute()` inherits that gap rather than introducing it. Filed as **#332** (contract #21).

## Falsifications / corrections worth recording

- **Correction (author, post-QA): the commit message of `06bda418` claims the runtime error strings
  were "trimmed first (~205 B gzip recovered)", and that claim is not supported by this branch's
  diff.** QA is right: `errors.ts` is `+62 / −0` and **no** string literal is modified versus base
  (the 28 deletions are all structural: imports, signatures, the old `FrameRunner` block, budget
  numbers). What actually happened: the trim was applied to *uncommitted* work in progress, before
  the first commit existed — `.` measured 42608 B pre-trim and 42403 B post-trim, hence the 205 B —
  so it is real history but **invisible in the branch diff, and therefore unverifiable by a
  reviewer**. Treat the sentence as unsubstantiated. **The measured numbers in the table are exact
  and were reproduced byte-for-byte by QA independently**; only the narrative about *how they were
  reached* is at fault. The commit message is left as-is rather than force-pushed (rewriting shared
  history to improve a claim about myself is the wrong trade); this note is the correction of record.
- ~~**The escaped-`Frame` test covers 5 of the 6 guarded entry points**~~ — **RESOLVED in `efffce74`**:
  `Frame.compute` is now asserted too, so all six guarded entry points are covered. That commit also
  closes the other three QA-reported test gaps (gpu-wide `pendingPipelines` default, the aliasing
  guard through the frame path, and an unexpected submit failure propagating instead of being
  swallowed). All four were missing *tests*, not missing product: they passed against the
  implementation unchanged.

## Verification (adversarial pre-push QA, mutation testing)

- `pnpm typecheck` (incl. the new `tests/frame/tsconfig.types.json` fixture) ✓ · full monorepo
  `vitest run` **2023 passed / 254 files** ✓ · `pnpm bundle-check` **zero WARN, zero FAIL** ✓
- **31 mutants, 27 killed.** The load-bearing ones all die:
  - the round-2 `min(sourceRemaining, destRemaining)` truncation bug → **killed**;
  - a hidden second `queue.submit()`, and encoding into a second encoder → **killed**;
  - deferring the compute encode (program order lost) → **killed by exactly the compute-first test**,
    leaving the render-first test green, which proves both order directions are pinned independently;
  - the **regression mutant** (a *synchronously throwing* callback stops submitting its prefix, i.e.
    losing 0.2.0 semantics) → **killed**;
  - `VGPU-FRAME-ENCODER-LOCKED` moved to *after* the callback → **killed** by the body-never-ran flag;
  - encode-before-validate in `copyBuffer` → killed **solely** by the "zero `copyBufferToBuffer` calls"
    assertion, which is exactly what contract #18 asks for.
- **4 survivors, all test-coverage gaps — product verified correct by probe in every case**:
  `Frame.compute` on a closed frame (→ `VGPU-FRAME-CLOSED`), the storage-aliasing guard through
  `f.compute()` (→ `VGPU-R1-STORAGE-ALIASING`), the gpu-wide `pendingPipelines` default reaching
  `f.compute()` (→ `VGPU-PIPELINE-PENDING` / 0 dispatches under `"skip"`), and "a real submit error
  must still propagate" (it does).
- **`FRAME_COMPUTABLE` proven load-bearing by metafile**: the `effect-only` fixture retains 29 modules
  and **zero** `compute*`. Mutating `frame.ts` to `import { ComputePipeline } from "./compute.ts"`
  makes CI fail loudly: `retained prohibited compute input packages/vgpu-api/dist/compute.js`
  (+926 B over budget). The gate works.
- **Budgets re-measured by rebuilding *both* sides** (source-only reverts silently re-report branch
  numbers, since the checker measures `dist/`). All **7 rows of the commit's table reproduce exactly**
  — base `41085 / 41256 / 41177 / 27173 / 30262 / 31500 / 41194`, branch
  `42403 / 42568 / 42490 / 28292 / 31366 / 32628 / 42499`, every delta matching the claim. Each new
  budget is the next 512 B multiple strictly above measured; base headroom was 216–475 B as stated.
  No foreign ceiling moved (only `packages/vgpu-api/package.json` + the root `typecheck:fixtures` line).

## Notes for reviewers

- **The mock device does not implement `clearBuffer`, `pushDebugGroup`, `popDebugGroup`,
  `insertDebugMarker`, `copyBufferToTexture` or `writeTimestamp`.** The type fixture exercises those
  `f.raw()` use cases at the *type* level only; they cannot be smoke-tested against `./mock` at
  runtime yet. Worth filling in when `f.raw()` gets broader coverage.
- `Frame.abortAsync()` is documented `@internal` but is a genuinely public, typed, callable method on
  the exported `Frame`. A user holding an escaped reference can call it and silently abort a frame
  (no error, nothing submitted) — mildly at odds with the "escaped reference" story contract #24 is
  built on. Cosmetic, but a `#`-private + module-local accessor would close it.
- Nuance on "no submit at all": if a callback explicitly calls `f.submit()` **and then** returns a
  thenable, the explicit submit stands and `VGPU-ASYNC-FRAME-CALLBACK` is still thrown. That is not a
  *partial* submit, but it is worth one sentence of documentation.
- Pre-existing, unrelated: any `pnpm build` regenerates `skills/vgpu/SKILL.md` (stale `gitSha`),
  dirtying the tree. Also report-only: the bundle gate's exclusion is a **basename-exact** regex, so a
  rename to `compute-*.ts` or a `compute/index.ts` directory refactor would defeat it, and the
  `compute` / `bundle` / `uniforms` patterns have no unit-test coverage in `scripts/bundle-budgets.test.ts`.

Refs #320. Follow-up: #332.

