### PR TITLE
feat(bundle): the contract #15 bundle state machine (status, error, rebuild, dispose)

### DIFF
--- a/apps/docs/scripts/example-chunk-budgets.json
+++ b/apps/docs/scripts/example-chunk-budgets.json
@@ -1,26 +1,27 @@
 {
   "description": "Production Turbopack gzip baselines refreshed for the 0.2.0 GPU-first free-function migration. The check allows the larger of 2% or 5 KiB growth for an example and 5 KiB for the shared preview host. The three ML routes were re-measured under this same per-experience methodology; the mtime staleness gate in check-example-bundles.mjs refuses to grade a stale build at all. The ML routes' baselines cover the route-owned chunks only: onnxruntime-web is imported dynamically inside the example, so its runtime chunk and the ~24 MiB same-origin WASM are fetched on demand and are not attributed to a route chunk by this checker. depth-estimation ships two shaders, the model contract, preprocessing and the scheduler; its three models are same-origin public assets staged outside git, and its 230 KB thumbnail fixture is behind a Node-only entry so it never reaches the browser. air-painting ships four shaders plus the pose contract, camera, preprocess, scheduler and fixture modules; its 9 MB same-origin model is likewise a public asset. The checker also rejects a chunk shared by two preview routes. Its scan for `apps/docs(-next)/examples/<slug>/` markers is supplementary rather than a complete source-isolation proof: Turbopack retains those paths for inlined WGSL but strips them from ordinary TypeScript modules, so the current ML route chunks have no markers to inspect. A future manifest-backed module-to-chunk check is needed for a complete cross-contamination guarantee.",
+  "$comment:next-04": "RE-BASELINED for legitimate cumulative growth of the 0.4 train: the unified frame (#333) and the bundle state machine (#335) together added ~3.7 KB gzip to every /preview route, because each example chunk carries the vgpu library code they both grew. Only fluid actually failed (63077 B vs a 62992 B budget, +85 B), but ALL FIFTEEN routes had crossed 90% of their allowance on that build -- headroom ranged from 448 B (triangle-led-front) to 1482 B (mnist-classifier) -- so the next kilobyte landing anywhere in the library would have failed fourteen more routes one PR at a time. Refreshed once, together, rather than in a queue of single-route commits. Every number here is the value THIS script measured on a production build of this app; nothing is padded and no allowance was relaxed (still the larger of 2% or 5 KiB per route, 5 KiB for the shared host), so each route keeps a full 5 KiB of real growth room from where it actually stands. The shared host was re-measured in the same pass (1952 -> 1995 B) even though it sits at 28% of its budget, so the file stays one coherent measurement instead of a mix of two builds. previousAppsDocsBaseline is untouched: it is provenance for the geistdocs migration, not a live budget.",
   "$comment:tgeist-08": "RE-BASELINED during the geistdocs migration (Grupo D, Decision 1'; this file is the single permitted deviation from byte-identical transplant in F2/F3), while the incoming app was still named apps/docs-next -- it has since been renamed to apps/docs at cutover (TGEIST-15). Every number below is the value measured by this same script against a production build of that app (Next 16.2.6 + React 19 + Tailwind v4 + geistdocs 1.15.2), reproduced identically on two consecutive clean builds. The previous numbers -- captured on the pre-migration apps/docs app, since retired -- are kept in the `previousAppsDocsBaseline` block below so the re-baseline stays auditable instead of being a black box (Risk #8). Nothing here relaxes a check: every route also passed the OLD baselines on this build (the +0.2%..+0.7% deltas all fit inside the existing 2%/5 KiB growth allowance), so the re-baseline TIGHTENS the budgets back onto the real numbers rather than papering over a failure. The deltas are uniform across all 14 routes and the shared host (+76 B), which is the signature of framework/runtime overhead, not of any single example's code regressing; the isolation assertion was not touched and needed no re-baseline. Growth allowances (2% / 5 KiB / 5 KiB host) are unchanged from the old app.",
   "sharedHost": {
-    "gzipBytes": 1952,
+    "gzipBytes": 1995,
     "maxGrowthBytes": 5120
   },
   "examples": {
-    "gradient": 49625,
-    "triangle-led-front": 89822,
-    "anti-aliasing": 53081,
-    "post-processing": 53581,
-    "black-hole": 55332,
-    "fluid": 57872,
-    "instanced-rendering": 60234,
-    "batch-rendering": 60084,
-    "fft-ocean": 58540,
-    "raymarched-fractal": 52811,
-    "radiance-cascades": 61842,
-    "agent-radiance-cascades": 60742,
-    "depth-estimation": 58868,
-    "mnist-classifier": 56298,
-    "air-painting": 70900
+    "gradient": 53346,
+    "triangle-led-front": 94494,
+    "anti-aliasing": 56805,
+    "post-processing": 57307,
+    "black-hole": 59057,
+    "fluid": 63077,
+    "instanced-rendering": 64905,
+    "batch-rendering": 64744,
+    "fft-ocean": 62260,
+    "raymarched-fractal": 56535,
+    "radiance-cascades": 65558,
+    "agent-radiance-cascades": 65231,
+    "depth-estimation": 63096,
+    "mnist-classifier": 59936,
+    "air-painting": 75118
   },
   "exampleGrowth": {
     "percent": 2,

--- a/packages/vgpu-api/package.json
+++ b/packages/vgpu-api/package.json
@@ -91,9 +91,9 @@
     "./core": "client"
   },
   "vgpuExportBundleBudgetsGzipBytes": {
-    ".": 41472,
-    "./node": 41472,
-    "./mock": 41472,
+    ".": 41984,
+    "./node": 42496,
+    "./mock": 41984,
     "./scene": 12800,
     "./client": 512,
     "./core": 3584
@@ -106,7 +106,7 @@
     "effect-only": 27648,
     "triangle-low-level": 30720,
     "draw-recipe-box": 31744,
-    "full-root": 41472
+    "full-root": 42496
   },
   "vgpuSceneBundleBudgetNote": "The scene barrel retains all recipe builders after the geometry redesign; direct primitive imports retain only their selected mesh, as the experience fixtures assert."
 }

--- a/packages/vgpu-api/package.json
+++ b/packages/vgpu-api/package.json
@@ -93,7 +93,7 @@
   "vgpuExportBundleBudgetsGzipBytes": {
     ".": 41984,
     "./node": 42496,
-    "./mock": 41984,
+    "./mock": 42496,
     "./scene": 12800,
     "./client": 512,
     "./core": 3584

--- a/packages/vgpu-api/src/bundle.ts
+++ b/packages/vgpu-api/src/bundle.ts
@@ -3,23 +3,37 @@ import { InternalDraw, drawUsesBlendConstant, drawUsesStencilReference, encodeDr
 import { InternalEffect, effectDraw, type Effect } from "./effect.ts";
 import type { CompileTarget, Target, TargetSignature } from "./target.ts";
 import { normalizeSignature, signatureKeyOf, validateTargetSignature } from "./pipeline-store.ts";
-import { bundleBlendConstantError, bundleStencilReferenceError, surfaceNotInFrameError, VGPUError } from "./errors.ts";
+import { bundleBlendConstantError, bundleDisposedError, bundleStencilReferenceError, compileFailedError, pipelinePendingError, surfaceNotInFrameError, VGPUError } from "./errors.ts";
 import { isFrameActive, isSurface } from "./surface.ts";
 import { FRAME_BUNDLE, type FrameBundleProtocol } from "./frame-protocols.ts";
 import { liveKernel } from "./live-kernel.ts";
+import type { PendingPipelines } from "./pending-pipelines.ts";
 import type { Gpu } from "./kernel.ts";
 
 /**
  * Records an explicit WebGPU render bundle: the draws in `record` are encoded once and replayed
  * with `pass.bundles(bundle)`.
  *
+ * Recording needs only formats — never `getCurrentTexture()` — so `bundle(gpu, { target: surface },
+ * …)` is legal outside `frame()`, exactly like `prepare()`. Construction captures the **logical**
+ * command list and compiles nothing: the bundle is born `"pending-pipelines"` and
+ * `prepare(gpu, [{ bundle }])` materializes it. Construction never throws for pending pipelines.
+ *
  * A bundle freezes its commands, its bind groups and the target signature it was recorded for; the
- * recorded state is re-checked at replay and a mismatch throws `VGPU-R3-BUNDLE-STALE` instead of
- * drawing something stale. Recording against a `Surface` is only legal inside a frame, because the
- * surface's current texture — and therefore its format — is only defined there.
+ * recorded state is re-checked at replay and a target-signature mismatch throws
+ * `VGPU-R3-BUNDLE-STALE` instead of drawing something stale.
  */
 export function bundle(gpu: Gpu, opts: BundleOptions, record: (recorder: BundleRecorder) => void): Bundle {
-  return createBundle(liveKernel(gpu, "bundle").device, opts, record);
+  const kernel = liveKernel(gpu, "bundle");
+  // Same wiring pattern the other kernel-backed features use (`render-service.ts:31-34`): the
+  // feature never reaches for the `Gpu`, it takes exactly the three kernel capabilities it needs —
+  // the device, the last link of the pendingPipelines chain, and the error channel.
+  return createBundle({
+    device: kernel.device,
+    pendingPipelinesDefault: () => kernel.pendingPipelinesDefault(),
+    reportError: (error) => { void kernel.reportError(error); },
+    trackSettled: (promise) => { void kernel.trackDelivery(promise); },
+  }, opts, record);
 }
 
 export interface BundleOptions {
@@ -31,26 +45,105 @@ export interface BundleRecorder {
   draw(drawable: Draw | Effect, opts?: DrawCallOptions): void;
 }
 
+/**
+ * Observable state of a recorded bundle — a **frozen** union (contract #15).
+ *
+ * Semantics: `pending-pipelines` = pipelines still to compile (and the native bundle to encode);
+ * `stale` = pipelines compiled, the native bundle must be re-encoded **from the retained logical
+ * recording** — that re-encode is `prepare(gpu, [{ bundle }])` (or an explicit `"sync"` replay);
+ * `rebuild()` is never required to leave `stale`. Every public transition:
+ *
+ * | From | Event | To |
+ * |---|---|---|
+ * | — | `bundle(gpu, { target }, rec)` | `pending-pipelines` (always: the native bundle is not materialized at construction) |
+ * | `pending-pipelines` \| `stale` \| `failed` | `prepare(gpu, [{ bundle }])` succeeds | `ready` (compiles missing pipelines, then encodes the native bundle) |
+ * | any non-`disposed` | `prepare()` fails | `failed`, retaining the error in `bundle.error` |
+ * | `ready` | `.set()` byte update on a captured resource | `ready` (no transition) |
+ * | `ready` | `.bind()` identity update, or a captured `Target` recreating its texture (resize) | `stale` |
+ * | `pending-pipelines` \| `stale` \| `failed` | identity update | unchanged |
+ * | any non-`disposed` | `rebuild(cb)` (synchronous) | Clear `bundle.error`, then move to `stale`, or `pending-pipelines` if the new recording introduces an uncompiled combination. `rebuild()` replaces the logical command list; it never compiles and never throws for readiness reasons |
+ * | any | `dispose()` | `disposed` (terminal; releases the native bundle and the retained recording; a second `dispose()` is a no-op) |
+ *
+ * `prepare()` on a `ready` bundle is a no-op. **`prepare()` always retries a `failed` bundle** —
+ * there is no "retryable failure" classification; during that retry `bundle.error` remains
+ * available and the status stays `failed`, then success clears the error and moves to `ready`.
+ * `rebuild()` clears the retained error immediately because it replaces the logical recording to
+ * which that failure belonged. `bundle.error?: VGPUError` is defined only while status is `failed`.
+ *
+ * **Replay of a non-`ready` bundle** follows the one `pendingPipelines` chain (frame → gpu for
+ * bundles; `p.bundles()` takes no per-call options):
+ * - `"throw"`: `pending-pipelines` → `VGPU-PIPELINE-PENDING`; `stale` → `VGPU-R3-BUNDLE-STALE`
+ *   (message names `prepare(gpu, { bundle })`; no `rebuild()` is required); `failed` → the retained
+ *   error is rethrown (`cause` preserved).
+ * - `"skip"`: the bundle is skipped this frame; `pending-pipelines` starts/continues async
+ *   compilation; `failed` is reported once via `gpu.onError` and keeps being skipped; `stale` is
+ *   skipped — never silently re-encoded.
+ * - `"sync"`: do the pending work inline — `pending-pipelines`: compile + encode (the stall this
+ *   feature exists to avoid); `stale`: re-encode from the retained recording (bounded: no
+ *   compilation — this is the opt-in auto-heal); `failed`: does **not** retry, the retained error is
+ *   thrown (retry is only through `prepare()`).
+ * - `disposed` **always** throws `VGPU-BUNDLE-DISPOSED`, under every policy.
+ */
+export type BundleStatus = "pending-pipelines" | "ready" | "stale" | "failed" | "disposed";
+
 export interface Bundle {
   readonly id: string;
-  readonly gpu: GPURenderBundle;
+  /**
+   * The native bundle, once it exists. `undefined` until the first successful `prepare()` (or
+   * `"sync"` replay) encodes it — same semantics as `Draw.gpu`, which is only defined once that
+   * combination compiled. A `disposed` bundle drops it back to `undefined`.
+   */
+  readonly gpu: GPURenderBundle | undefined;
+  /** See {@link BundleStatus} for the full transition table. */
+  readonly status: BundleStatus;
+  /** The retained failure of the last `prepare()`; defined **only** while `status === "failed"`. */
+  readonly error: VGPUError | undefined;
+  /**
+   * Replaces the logical command list, synchronously. It clears `error` immediately (the failure
+   * belonged to the recording being replaced), never compiles and never throws for readiness
+   * reasons: the bundle lands on `stale`, or on `pending-pipelines` when the new recording
+   * introduces a combination that is not compiled yet. `rebuild()` is **not** how a `stale` bundle
+   * becomes `ready` — that is `prepare(gpu, [{ bundle }])`.
+   */
+  rebuild(record: (recorder: BundleRecorder) => void): void;
+  /** Terminal: releases the native bundle and the retained recording. A second call is a no-op. */
+  dispose(): void;
+}
+
+/**
+ * The kernel capabilities a bundle needs. Given explicitly (instead of the `Gpu`) so `bundle.ts`
+ * stays testable and never reaches back into the kernel module's public surface.
+ *
+ * @internal
+ */
+export interface BundleHost {
+  readonly device: { readonly gpu: GPUDevice };
+  /** Last link of the `pendingPipelines` chain, for a replay whose frame named no policy. */
+  pendingPipelinesDefault?(): PendingPipelines;
+  /** `gpu.onError` channel: where a `"skip"` replay reports a `failed` bundle, once. */
+  reportError?(error: VGPUError): void;
+  /** Joins `gpu.settled()`: background preparation started by a `"skip"` replay is observable. */
+  trackSettled?(promise: Promise<unknown>): void;
 }
 
 let nextBundleId = 1;
 let recordingDepth = 0;
 
 /** Records explicit WebGPU render bundles and keeps the R3 stale signature checked at replay time. */
-export function createBundle(device: { readonly gpu: GPUDevice }, opts: BundleOptions, record: (recorder: BundleRecorder) => void): Bundle {
+export function createBundle(host: BundleHost, opts: BundleOptions, record: (recorder: BundleRecorder) => void): Bundle {
   const id = opts.label ?? `bundle${nextBundleId++}`;
   if (isSurface(opts.target) && !isFrameActive()) throw surfaceNotInFrameError("bundle");
   const signature = normalizeBundleSignature(opts.target);
-  const bundle = new RecordedBundle(device, id, signature);
-  bundle.record(record);
+  const bundle = new RecordedBundle(host, id, signature);
+  bundle.track(record);
   return bundle;
 }
 
 class RecordedBundle implements Bundle, BundleBackReference {
-  gpu!: GPURenderBundle;
+  #gpu?: GPURenderBundle;
+  #status: BundleStatus = "pending-pipelines";
+  #error?: VGPUError;
+  #reportedFailure = false;
   #staleEvent?: BundleStaleEvent;
   /**
    * The logical recording, retained. `record()` used to take the closure and forget it, which made
@@ -58,75 +151,232 @@ class RecordedBundle implements Bundle, BundleBackReference {
    * rebuild the native bundle from the same commands with the current resources.
    */
   #record?: (recorder: BundleRecorder) => void;
+  /**
+   * Bumped by every `rebuild()`. A `prepare()` in flight compares it after its `await`: if the
+   * logical recording was replaced while pipelines were compiling, the prepare re-runs the warm-up
+   * for the NEW recording instead of encoding a command list nobody asked for any more.
+   */
+  #generation = 0;
+  /** The in-flight `prepare()`, so the same bundle requested twice in one batch does the work once. */
+  #preparing?: Promise<GPURenderBundle>;
   readonly #signatureKey: string;
-  readonly #draws = new Set<InternalDraw>();
+  #draws = new Set<InternalDraw>();
 
-  constructor(private readonly device: { readonly gpu: GPUDevice }, readonly id: string, readonly signature: TargetSignature) {
+  constructor(private readonly host: BundleHost, readonly id: string, readonly signature: TargetSignature) {
     this.#signatureKey = signatureKeyOf(signature);
   }
 
-  record(record: (recorder: BundleRecorder) => void): void {
-    this.#record = record;
-    this.#staleEvent = undefined;
-    this.gpu = createRenderBundle(this.device, {
-      label: this.id,
-      colorFormats: this.signature.colors,
-      depthStencilFormat: this.signature.depth,
-      sampleCount: this.signature.sampleCount ?? 1,
-      record: (recorder) => this.#recordCommands(record, recorder.gpu as unknown as GPURenderPassEncoder),
-    });
-    for (const draw of this.#draws) registerDrawBundle(draw, this);
-  }
+  get gpu(): GPURenderBundle | undefined { return this.#gpu; }
+  get status(): BundleStatus { return this.#status; }
+  get error(): VGPUError | undefined { return this.#status === "failed" ? this.#error : undefined; }
 
   /**
    * Frame bundle protocol: `pass.bundles()` replays through this, so `frame.ts` never imports
-   * bundle.ts. The recorded bundle is its own protocol object — `gpu` and the staleness check.
+   * bundle.ts nor learns what a `BundleStatus` is.
    */
   get [FRAME_BUNDLE](): FrameBundleProtocol { return this; }
 
   /**
-   * Async readiness for `prepare(gpu, [{ bundle }])`, in the trimmed scope of T04-05: a bundle made
-   * stale by an identity change is re-encoded here from the retained recording, and a bundle that is
-   * not stale is left exactly as it is (no work, same native bundle).
-   *
-   * The pipelines its draws need are compiled by the recording itself, through the ordinary encode
-   * path. What this does NOT do is the rest of contract #15 — there is no public `status`, `error`,
-   * `rebuild()` or `dispose()` yet, and a signature mismatch still throws `VGPU-R3-BUNDLE-STALE` at
-   * replay instead of auto-healing: re-recording against a different target is a different target's
-   * recording, which belongs to the bundle state machine of wave 2+.
+   * Construction (and `rebuild()`): run the closure against a tracking-only recorder to learn which
+   * draws the recording names, without opening a native encoder and without compiling anything.
    *
    * @internal
    */
-  prepareCombination(): void {
-    if (!this.#staleEvent || !this.#record) return;
-    this.record(this.#record);
+  track(record: (recorder: BundleRecorder) => void): void {
+    this.#record = record;
+    // A brand new recording starts from an empty draw set: a draw the previous recording named and
+    // this one does not must be dropped, or its identity changes would keep staling this bundle.
+    this.#draws = new Set();
+    this.#recordCommands(record);
+    for (const draw of this.#draws) registerDrawBundle(draw, this);
+  }
+
+  /**
+   * Async readiness for `prepare(gpu, [{ bundle }])`: pre-warms the pipelines of every recorded draw
+   * through the draw's own `pipelineForAsync` — one async compile per missing combination, never a
+   * synchronous `createRenderPipeline` — and only then encodes the native bundle.
+   *
+   * @internal
+   */
+  prepareCombination(): Promise<GPURenderBundle> {
+    if (this.#status === "disposed") return Promise.reject(bundleDisposedError(this.id, "prepare"));
+    // prepare() on a ready bundle is a no-op: no new pipeline, no re-encode (contract #7, bundle half).
+    if (this.#status === "ready" && this.#gpu) return Promise.resolve(this.#gpu);
+    if (this.#preparing) return this.#preparing;
+    const preparing = this.#prepareNow();
+    this.#preparing = preparing;
+    // Clearing the in-flight slot must not turn a handled rejection into an unhandled one, so both
+    // outcomes are observed here while the original promise is what callers await.
+    preparing.then(() => { if (this.#preparing === preparing) this.#preparing = undefined; }, () => { if (this.#preparing === preparing) this.#preparing = undefined; });
+    return preparing;
+  }
+
+  async #prepareNow(): Promise<GPURenderBundle> {
+    for (;;) {
+      const generation = this.#generation;
+      const settled = await Promise.allSettled([...this.#draws].map((draw) => draw.pipelineForAsync(this.signature)));
+      // dispose() is terminal, including for work that was already in flight when it landed.
+      if (this.#status === "disposed") throw bundleDisposedError(this.id, "prepare");
+      // rebuild() replaced the recording mid-flight: prepare() prepares whatever recording is
+      // current when it finishes, so warm the new one instead of encoding the old command list.
+      if (this.#generation !== generation) continue;
+      const failure = settled.find((result): result is PromiseRejectedResult => result.status === "rejected");
+      if (failure) throw this.#fail(failure.reason);
+      // Every pipeline is warm now, so this encode hits the store's ready fast path: zero new
+      // createRenderPipeline calls, which is what makes re-preparing a ready bundle free.
+      try { return this.#materialize("sync"); }
+      catch (cause) { throw this.#fail(cause); }
+    }
+  }
+
+  /**
+   * Replay resolution for `FramePass.bundles()`: the whole `BundleStatus` × `pendingPipelines`
+   * table lives here, so the frame only ever sees "this is the native bundle to execute" or
+   * "nothing to execute this frame".
+   *
+   * @internal
+   */
+  resolveForReplay(target: Target, policy?: PendingPipelines): GPURenderBundle | undefined {
+    // Terminal beats policy: a disposed bundle has no native bundle to replay under any of them.
+    if (this.#status === "disposed") throw bundleDisposedError(this.id, "replay");
+    // A different target signature is a usage error, not a readiness state: it is checked before the
+    // policy and no policy can turn it into a skip or an inline re-encode.
+    this.#assertSignature(target);
+    if (this.#status === "ready" && this.#gpu) return this.#gpu;
+    const resolved = policy ?? this.host.pendingPipelinesDefault?.() ?? "sync";
+    if (this.#status === "failed") {
+      // "skip" reports it once and keeps skipping; "throw"/"sync" rethrow. Retry is only prepare().
+      if (resolved === "skip") { this.#reportFailureOnce(); return undefined; }
+      throw this.#error;
+    }
+    if (resolved === "sync") return this.#materialize("sync");
+    if (resolved === "skip") {
+      // A stale bundle is never silently re-encoded; a pending one continues compiling in background.
+      if (this.#status === "pending-pipelines") this.#startBackgroundPrepare();
+      return undefined;
+    }
+    if (this.#status === "stale") throw bundleStaleError(this.id, staleEventMessage(this.id, this.#staleEvent));
+    throw pipelinePendingError(`bundle '${this.id}' replay`, this.id, this.#signatureKey);
+  }
+
+  rebuild(record: (recorder: BundleRecorder) => void): void {
+    if (this.#status === "disposed") throw bundleDisposedError(this.id, "rebuild");
+    this.#generation += 1;
+    // The retained error belonged to the recording being replaced, so it goes away with it.
+    this.#error = undefined;
+    this.#reportedFailure = false;
+    this.#staleEvent = undefined;
+    this.track(record);
+    // Never compiles, never encodes: the last native bundle stays the last valid one until a
+    // prepare() (or a "sync" replay) re-encodes the new command list.
+    this.#status = [...this.#draws].every((draw) => draw.readyForSignature(this.signature)) ? "stale" : "pending-pipelines";
+  }
+
+  dispose(): void {
+    if (this.#status === "disposed") return;
+    this.#status = "disposed";
+    // WebGPU has no GPURenderBundle.destroy(): releasing the native bundle IS dropping the last
+    // reference to it, together with the retained recording and the tracked draws.
+    this.#gpu = undefined;
+    this.#record = undefined;
+    this.#error = undefined;
+    this.#staleEvent = undefined;
+    // The draws keep their back-reference to this bundle (dropping it needs a draw.ts registry API
+    // this branch may not add); markStale() below is a no-op on a disposed bundle, so a disposed
+    // bundle can never come back to life through one.
+    this.#draws = new Set();
   }
 
   markStale(event: BundleStaleEvent): void {
     if (recordingDepth > 0) return;
-    this.#staleEvent ??= event;
+    // Only a ready bundle can go stale: on pending-pipelines/stale/failed the status is unchanged,
+    // because the encode that is still owed will read the current resources anyway.
+    if (this.#status !== "ready") return;
+    this.#staleEvent = event;
+    this.#status = "stale";
   }
 
-  assertReplayable(target: Target): void {
-    const actual = normalizeBundleSignature(target);
-    const actualKey = signatureKeyOf(actual);
-    if (this.#signatureKey !== actualKey) throw bundleStaleError(this.id, targetSignatureStaleMessage(this.id, this.#signatureKey, actualKey));
-    if (this.#staleEvent) throw bundleStaleError(this.id, staleEventMessage(this.id, this.#staleEvent));
-  }
-
+  /** @internal Populated by the recorders: the draws the current logical recording names. */
   remember(draw: InternalDraw): void {
     this.#draws.add(draw);
   }
 
-  #recordCommands(record: (recorder: BundleRecorder) => void, encoder: GPURenderPassEncoder): void {
+  #assertSignature(target: Target): void {
+    const actual = normalizeBundleSignature(target);
+    const actualKey = signatureKeyOf(actual);
+    if (this.#signatureKey !== actualKey) throw bundleStaleError(this.id, targetSignatureStaleMessage(this.id, this.#signatureKey, actualKey));
+  }
+
+  /**
+   * Runs the retained recording against a real `GPURenderBundleEncoder`. `policy` fills in for the
+   * recorded draws that named none, so a `"sync"` replay may compile inline while the prepare path
+   * (whose pipelines are already warm) never does.
+   *
+   * Encoding is synchronous from end to end, so no identity change can interleave with it: an event
+   * that arrived while a `prepare()` was awaiting its pipelines is already reflected by the bind
+   * groups this encode reads, which is why clearing `#staleEvent` here cannot lose an update.
+   */
+  #materialize(policy?: PendingPipelines): GPURenderBundle {
+    const record = this.#record;
+    if (!record) throw bundleDisposedError(this.id, "replay");
+    const gpu = createRenderBundle(this.host.device, {
+      label: this.id,
+      colorFormats: this.signature.colors,
+      depthStencilFormat: this.signature.depth,
+      sampleCount: this.signature.sampleCount ?? 1,
+      record: (recorder) => this.#recordCommands(record, recorder.gpu as unknown as GPURenderPassEncoder, policy),
+    });
+    this.#gpu = gpu;
+    this.#staleEvent = undefined;
+    this.#error = undefined;
+    this.#reportedFailure = false;
+    this.#status = "ready";
+    return gpu;
+  }
+
+  #recordCommands(record: (recorder: BundleRecorder) => void, encoder?: GPURenderPassEncoder, policy?: PendingPipelines): void {
     recordingDepth += 1;
-    try { record(new ExplicitBundleRecorder(this, encoder)); }
+    try { record(new BundleRecording(this, encoder, policy)); }
     finally { recordingDepth -= 1; }
+  }
+
+  #fail(cause: unknown): VGPUError {
+    const error = compileFailedError(`bundle '${this.id}' prepare`, cause, this.#signatureKey);
+    this.#status = "failed";
+    this.#error = error;
+    this.#reportedFailure = false;
+    return error;
+  }
+
+  /**
+   * Background preparation for a `"skip"` replay. Local to this module on purpose: the skip path
+   * needs nothing new from the pipeline store, only the same async warm-up `prepare()` runs.
+   */
+  #startBackgroundPrepare(): void {
+    if (this.#preparing) return;
+    const promise = this.prepareCombination().then(() => undefined, () => { this.#reportFailureOnce(); });
+    this.host.trackSettled?.(promise);
+  }
+
+  #reportFailureOnce(): void {
+    if (this.#reportedFailure) return;
+    const error = this.#error;
+    if (!error) return;
+    this.#reportedFailure = true;
+    this.host.reportError?.(error);
   }
 }
 
-class ExplicitBundleRecorder implements BundleRecorder {
-  constructor(private readonly bundle: RecordedBundle, private readonly encoder: GPURenderPassEncoder) {}
+/**
+ * The one recorder, in its two modes. Without an `encoder` it is the **tracking** pass construction
+ * and `rebuild()` run: it resolves which `InternalDraw`s the closure names and nothing else — no
+ * native encoder is opened, no command is encoded, no pipeline is compiled, which is what
+ * "construction records the logical command list without compiling" means. With an encoder it is the
+ * real recording the materialization performs. Both modes reject the two commands a render bundle
+ * encoder cannot express, so a user's mistake is still reported where the user wrote it.
+ */
+class BundleRecording implements BundleRecorder {
+  constructor(private readonly bundle: RecordedBundle, private readonly encoder?: GPURenderPassEncoder, private readonly policy?: PendingPipelines) {}
 
   draw(drawable: Draw | Effect, opts: DrawCallOptions = {}): void {
     // Blend/writeMask are constructor-only draw pipeline state. If they ever become mutable or per-call,
@@ -137,24 +387,29 @@ class ExplicitBundleRecorder implements BundleRecorder {
     // Likewise the stencil reference: GPURenderBundleEncoder has no setStencilReference. Stencil pipeline state without ref records fine.
     if (drawUsesStencilReference(draw)) throw bundleStencilReferenceError(this.bundle.id, draw.label);
     this.bundle.remember(draw);
-    encodeDraw(draw, this.encoder, this.bundle.signature, opts);
+    if (!this.encoder) return;
+    // The replay's resolved policy fills in for a recorded draw that named none — the same collapse
+    // of the chain `FramePass.draw()` does, one link later.
+    const resolved = opts.pendingPipelines === undefined && this.policy !== undefined ? { ...opts, pendingPipelines: this.policy } : opts;
+    encodeDraw(draw, this.encoder, this.bundle.signature, resolved);
   }
 }
 
 /**
- * Re-encodes `bundle` if it is stale and reports the handle `prepare()` hands back.
+ * Compiles the pipelines of the recorded draws, encodes the native bundle and reports the handle
+ * `prepare()` hands back. Genuinely async: this is the one spelling for bundle readiness.
  *
  * @internal
  */
-export function prepareBundle(bundle: Bundle): { readonly signature: TargetSignature; readonly gpu: GPURenderBundle } {
+export async function prepareBundle(bundle: Bundle): Promise<{ readonly signature: TargetSignature; readonly gpu: GPURenderBundle }> {
   if (!(bundle instanceof RecordedBundle)) throw new VGPUError({
     code: "VGPU-BUNDLE-FOREIGN",
     message: "prepare({ bundle }) received an object this library did not record.",
     fix: "Pass the bundle returned by bundle(gpu, { target }, record).",
     where: "prepare",
   });
-  bundle.prepareCombination();
-  return { signature: bundle.signature, gpu: bundle.gpu };
+  const gpu = await bundle.prepareCombination();
+  return { signature: bundle.signature, gpu };
 }
 
 function normalizeBundleSignature(target: CompileTarget): TargetSignature {
@@ -167,15 +422,19 @@ function targetSignatureStaleMessage(id: string, recordedKey: string, actualKey:
   return `bundle '${id}' is stale: the replay target signature does not match the recorded signature. Bundles freeze format/depth/sampleCount and bind groups.\n  Recorded signature: ${recordedKey}\n  Actual signature: ${actualKey}\n  Fix: re-record the bundle for this target → ${id} = bundle(gpu, { target: scene }, ...)\n  (re-recording is always your responsibility; the library only detects this).`;
 }
 
-function staleEventMessage(id: string, event: BundleStaleEvent): string {
+/**
+ * An identity change only made the native bundle stale: the logical recording is still valid, so the
+ * fix names `prepare()` (the re-encode), never `rebuild()` (which replaces the commands).
+ */
+function staleEventMessage(id: string, event: BundleStaleEvent | undefined): string {
+  const fix = `  Fix: re-encode the retained recording → await prepare(gpu, { bundle: ${id} })\n  (or pendingPipelines: "sync" to re-encode inline; rebuild() only replaces the recorded commands).`;
+  if (!event) return `bundle '${id}' is stale: its native bundle must be re-encoded from the retained recording.\n${fix}`;
   if (event.kind === "group-claim") {
-    return `bundle '${id}' is stale: group ${event.group} of draw\n  '${event.drawLabel}' changed bind group after recording. Bundles freeze commands and bind groups.\n  Fix: re-record it → ${id} = bundle(gpu, { target: scene }, ...)\n  (re-recording is always your responsibility; the library only detects this).`;
+    return `bundle '${id}' is stale: group ${event.group} of draw\n  '${event.drawLabel}' changed bind group after recording. Bundles freeze commands and bind groups.\n${fix}`;
   }
-  return `bundle '${id}' is stale: binding \`${event.bindingName}\` (@group(${event.group}) @binding(${event.binding})) of draw\n  '${event.drawLabel}' changed resource after recording. Bundles freeze commands and bind groups.\n  Fix: re-record it → ${id} = bundle(gpu, { target: scene }, ...)\n  (re-recording is always your responsibility; the library only detects this).`;
+  return `bundle '${id}' is stale: binding \`${event.bindingName}\` (@group(${event.group}) @binding(${event.binding})) of draw\n  '${event.drawLabel}' changed resource after recording. Bundles freeze commands and bind groups.\n${fix}`;
 }
 
 function bundleStaleError(id: string, message: string): VGPUError {
   return new VGPUError({ code: "VGPU-R3-BUNDLE-STALE", message, where: `bundle '${id}' replay` });
 }
-
-

--- a/packages/vgpu-api/src/bundle.ts
+++ b/packages/vgpu-api/src/bundle.ts
@@ -1,5 +1,5 @@
 import { createRenderBundle } from "./core/render-bundle.ts";
-import { InternalDraw, drawUsesBlendConstant, drawUsesStencilReference, encodeDraw, registerDrawBundle, type BundleBackReference, type BundleStaleEvent, type Draw, type DrawCallOptions } from "./draw.ts";
+import { InternalDraw, drawUsesBlendConstant, drawUsesStencilReference, encodeDraw, registerDrawBundle, unregisterDrawBundle, type BundleBackReference, type BundleStaleEvent, type Draw, type DrawCallOptions } from "./draw.ts";
 import { InternalEffect, effectDraw, type Effect } from "./effect.ts";
 import type { CompileTarget, Target, TargetSignature } from "./target.ts";
 import { normalizeSignature, signatureKeyOf, validateTargetSignature } from "./pipeline-store.ts";
@@ -184,11 +184,16 @@ class RecordedBundle implements Bundle, BundleBackReference {
    */
   track(record: (recorder: BundleRecorder) => void): void {
     this.#record = record;
-    // A brand new recording starts from an empty draw set: a draw the previous recording named and
-    // this one does not must be dropped, or its identity changes would keep staling this bundle.
+    // A brand new recording starts from an empty draw set, and a draw the previous recording named
+    // and this one does not is unregistered from its back-reference registry: forgetting it here is
+    // not enough, because the registration is what makes the draw call markStale() on this bundle.
+    // Leaving it in place stales this bundle forever from a draw it no longer encodes (and keeps a
+    // dropped draw holding the bundle alive).
+    const previous = this.#draws;
     this.#draws = new Set();
     this.#recordCommands(record);
     for (const draw of this.#draws) registerDrawBundle(draw, this);
+    for (const draw of previous) if (!this.#draws.has(draw)) unregisterDrawBundle(draw, this);
   }
 
   /**
@@ -281,9 +286,9 @@ class RecordedBundle implements Bundle, BundleBackReference {
     this.#record = undefined;
     this.#error = undefined;
     this.#staleEvent = undefined;
-    // The draws keep their back-reference to this bundle (dropping it needs a draw.ts registry API
-    // this branch may not add); markStale() below is a no-op on a disposed bundle, so a disposed
-    // bundle can never come back to life through one.
+    // Every draw drops its back-reference to this bundle: a disposed bundle must not be reachable
+    // from a live draw (that was a leak, and markStale() traffic for nothing).
+    for (const draw of this.#draws) unregisterDrawBundle(draw, this);
     this.#draws = new Set();
   }
 

--- a/packages/vgpu-api/src/draw.ts
+++ b/packages/vgpu-api/src/draw.ts
@@ -570,6 +570,20 @@ export class InternalDraw implements Draw {
     return this.#pipelineForEncode(target, "sync");
   }
 
+  /**
+   * Is the pipeline of THIS combination already compiled? Asks the store for the very key
+   * `pipelineForAsync`/`#compileKey` would use and never starts a compilation, so a caller can
+   * classify readiness without paying for it.
+   *
+   * `gpu` cannot answer this: it reports the first resolved key of any signature, while a bundle
+   * needs the answer for the one signature it recorded.
+   *
+   * @internal
+   */
+  readyForSignature(signature: TargetSignature): boolean {
+    return !!drawState(this).pipelineStore.getReady(this.#pipelineKey(signature));
+  }
+
   pipelineForAsync(target: Target | TargetSignature): Promise<GPURenderPipeline> {
     assertDeviceUsable(drawState(this).device, `${this.label}.pipelineForAsync`);
     const { key, signature, signatureKey } = this.#compileKey(target, `${this.label}.pipelineForAsync`);

--- a/packages/vgpu-api/src/draw.ts
+++ b/packages/vgpu-api/src/draw.ts
@@ -1149,6 +1149,13 @@ export function drawReflection(draw: Draw): Reflection { return drawState(draw).
 export function drawBindingState(draw: Draw, name: string): BindingState | undefined { return drawState(draw).setCore.bindingState(name); }
 
 export function registerDrawBundle(draw: Draw, bundle: BundleBackReference): void { drawState(draw).recordedIn.add(bundle); }
+/**
+ * The other half of `registerDrawBundle`: a bundle that stops replaying a draw (because `rebuild()`
+ * dropped it, or because the bundle was disposed) must leave that draw's back-reference registry.
+ * Without this the registration is one-way, so an identity change on a draw the bundle no longer
+ * encodes keeps staling it forever, and the registry keeps a disposed bundle alive.
+ */
+export function unregisterDrawBundle(draw: Draw, bundle: BundleBackReference): void { drawState(draw).recordedIn.delete(bundle); }
 
 /** Render bundle encoders cannot set the pass blend constant; bundle uses this to reject such draws at recording. */
 export function drawUsesBlendConstant(draw: Draw): boolean { return drawState(draw).blendConstant !== undefined; }

--- a/packages/vgpu-api/src/errors.ts
+++ b/packages/vgpu-api/src/errors.ts
@@ -194,6 +194,19 @@ export function bundleStencilReferenceError(bundleId: string, drawLabel: string)
   });
 }
 
+/**
+ * `dispose()` is terminal for a bundle: it released the native bundle and the retained recording, so
+ * there is nothing left to replay, prepare or rebuild — under **every** `pendingPipelines` policy.
+ */
+export function bundleDisposedError(bundleId: string, where: "replay" | "prepare" | "rebuild"): VGPUError {
+  return new VGPUError({
+    code: "VGPU-BUNDLE-DISPOSED",
+    message: `bundle '${bundleId}' was disposed: dispose() is terminal and released its native bundle and recording.`,
+    fix: `Record a new bundle with bundle(gpu, { target }, record); this throws under every pendingPipelines policy.`,
+    where: `bundle '${bundleId}' ${where}`,
+  });
+}
+
 export function multisampleInvalidError(label: string, reason: string, where = "draw"): VGPUError {
   return new VGPUError({
     code: "VGPU-MULTISAMPLE-INVALID",

--- a/packages/vgpu-api/src/frame-protocols.ts
+++ b/packages/vgpu-api/src/frame-protocols.ts
@@ -18,6 +18,7 @@
 import type { Device } from "@vgpu/core";
 import type { ClaimedGroupValidationResult } from "./claim-validation.ts";
 import type { DrawCallOptions } from "./draw.ts";
+import type { PendingPipelines } from "./pending-pipelines.ts";
 import type { Target } from "./target.ts";
 
 /**
@@ -57,9 +58,17 @@ export function frameDrawableOf(value: unknown): FrameDrawableProtocol | undefin
 export const FRAME_BUNDLE: unique symbol = Symbol("vgpu.frame.bundle");
 
 export interface FrameBundleProtocol {
-  readonly gpu: GPURenderBundle;
-  /** Throws `VGPU-R3-BUNDLE-STALE` when the recorded signature no longer matches `target`. */
-  assertReplayable(target: Target): void;
+  /**
+   * The native bundle to execute this frame, or `undefined` when the resolved `pendingPipelines`
+   * policy skipped it. The whole `BundleStatus` × policy table lives behind this call, so the frame
+   * never learns what a bundle status is: it either gets something to execute or nothing.
+   *
+   * Throws for the cases the policy does not absorb — `VGPU-BUNDLE-DISPOSED` (always),
+   * `VGPU-R3-BUNDLE-STALE` (recorded signature no longer matches `target`, or `"throw"` on a stale
+   * bundle), `VGPU-PIPELINE-PENDING` (`"throw"` on an unprepared bundle) and the retained failure of
+   * a `failed` bundle.
+   */
+  resolveForReplay(target: Target, policy?: PendingPipelines): GPURenderBundle | undefined;
 }
 
 export interface FrameBundleLike {

--- a/packages/vgpu-api/src/frame.ts
+++ b/packages/vgpu-api/src/frame.ts
@@ -445,10 +445,14 @@ export class FramePass {
     // reject up front instead of leaving it to native validation.
     if (this.depthReadOnly) throw passDepthReadOnlyError("pass cannot replay bundles: bundle records bundles with writable depth/stencil, and WebGPU only executes read-only-recorded bundles in a read-only pass.", "Encode the draws directly with pass.draw(...) inside the depthReadOnly pass.", "FramePass.bundles");
     const recorded = bundles.map((entry) => frameBundleOf(entry) ?? invalidBundle());
-    // Staleness is checked for every bundle before the first one replays: a pass either replays the
-    // whole list or none of it.
-    for (const entry of recorded) entry.assertReplayable(this.target);
-    this.encoder.executeBundles(recorded.map((entry) => entry.gpu));
+    // Readiness and staleness are resolved for every bundle before the first one replays: a pass
+    // either replays the whole list or none of it. The bundle owns the `BundleStatus` ×
+    // `pendingPipelines` table (frame → gpu; `p.bundles()` takes no per-call policy), so this hands
+    // it the frame's policy and gets back either a native bundle or nothing — `undefined` is the
+    // bundle the resolved policy skipped this frame.
+    const replayable = recorded.map((entry) => entry.resolveForReplay(this.target, this.pendingPipelines)).filter((native): native is GPURenderBundle => native !== undefined);
+    if (!replayable.length) return;
+    this.encoder.executeBundles(replayable);
   }
 }
 

--- a/packages/vgpu-api/src/index.ts
+++ b/packages/vgpu-api/src/index.ts
@@ -1,7 +1,7 @@
 import { createGpu, type InitOptions } from "./init.ts";
 export { initFromDevice } from "./init-from-device.ts";
 
-export type { Bundle, BundleOptions, BundleRecorder, Compute, ComputeOptions, DispatchOptions, ClearColor, GpuErrorListener, InitOptions, PingPongStorage, PingPongTargets, SharedUniforms, StorageAccess, StorageBuffer, StorageOptions, Surface, SurfaceOptions, SurfaceResizeEvent, Timer, TimerSpan, Visibility, VisibilityOptions, VisibilityQuery } from "./init.ts";
+export type { Bundle, BundleOptions, BundleRecorder, BundleStatus, Compute, ComputeOptions, DispatchOptions, ClearColor, GpuErrorListener, InitOptions, PingPongStorage, PingPongTargets, SharedUniforms, StorageAccess, StorageBuffer, StorageOptions, Surface, SurfaceOptions, SurfaceResizeEvent, Timer, TimerSpan, Visibility, VisibilityOptions, VisibilityQuery } from "./init.ts";
 export type { BlendComponentOptions, BlendOptions, BlendPreset, DepthOptions, Draw, DrawOptions, DrawCallOptions, DrawLayoutOptions, GeometryLike, StencilFaceOptions, StencilOptions } from "./draw.ts";
 export { Geometry } from "./scene/geometry-descriptor.ts";
 export type { GeometryAttributeOverride, GeometryAttributes, GeometryBuffer, GeometryBufferOptions, GeometryData, GeometryOptions, GeometrySlice, GeometrySliceOptions } from "./scene/geometry-descriptor.ts";

--- a/packages/vgpu-api/src/init.ts
+++ b/packages/vgpu-api/src/init.ts
@@ -5,7 +5,7 @@ export type { Compute, ComputeOptions, DispatchOptions, GpuErrorListener, PingPo
 export type { ClearColor } from "./target-utils.ts";
 export type { Timer, TimerSpan } from "./timer.ts";
 export type { Visibility, VisibilityOptions, VisibilityQuery } from "./visibility.ts";
-export type { Bundle, BundleOptions, BundleRecorder } from "./bundle.ts";
+export type { Bundle, BundleOptions, BundleRecorder, BundleStatus } from "./bundle.ts";
 export type { Surface, SurfaceOptions, SurfaceResizeEvent } from "./surface.ts";
 
 import { createCoreGpu } from "./kernel.ts";

--- a/packages/vgpu-api/src/mock.ts
+++ b/packages/vgpu-api/src/mock.ts
@@ -5,7 +5,7 @@ export { initFromDevice } from "./init-from-device.ts";
 export { createMockAdapter } from "@vgpu/adapter-mock";
 export type { CreateMockAdapterOptions } from "@vgpu/adapter-mock";
 export { getMockGPUDeviceInstrumentation } from "@vgpu/core";
-export type { Bundle, BundleOptions, BundleRecorder, Compute, ComputeOptions, DispatchOptions, ClearColor, GpuErrorListener, InitOptions, PingPongStorage, PingPongTargets, SharedUniforms, StorageAccess, StorageBuffer, StorageOptions, Surface, SurfaceOptions, SurfaceResizeEvent, Timer, TimerSpan, Visibility, VisibilityOptions, VisibilityQuery } from "./init.ts";
+export type { Bundle, BundleOptions, BundleRecorder, BundleStatus, Compute, ComputeOptions, DispatchOptions, ClearColor, GpuErrorListener, InitOptions, PingPongStorage, PingPongTargets, SharedUniforms, StorageAccess, StorageBuffer, StorageOptions, Surface, SurfaceOptions, SurfaceResizeEvent, Timer, TimerSpan, Visibility, VisibilityOptions, VisibilityQuery } from "./init.ts";
 export type { BlendComponentOptions, BlendOptions, BlendPreset, DepthOptions, Draw, DrawOptions, DrawCallOptions, DrawLayoutOptions, GeometryLike, StencilFaceOptions, StencilOptions } from "./draw.ts";
 export { Geometry } from "./scene/geometry-descriptor.ts";
 export type { GeometryAttributeOverride, GeometryAttributes, GeometryBuffer, GeometryBufferOptions, GeometryData, GeometryOptions, GeometrySlice, GeometrySliceOptions } from "./scene/geometry-descriptor.ts";

--- a/packages/vgpu-api/src/node.ts
+++ b/packages/vgpu-api/src/node.ts
@@ -3,7 +3,7 @@ import type { VGPUAdapter } from "@vgpu/core";
 import { createGpu, type Gpu, type InitOptions } from "./init.ts";
 
 export { createNodeAdapter } from "@vgpu/adapter-node";
-export type { Bundle, BundleOptions, BundleRecorder, Compute, ComputeOptions, DispatchOptions, ClearColor, GpuErrorListener, PingPongStorage, PingPongTargets, SharedUniforms, StorageAccess, StorageBuffer, StorageOptions, Surface, SurfaceOptions, SurfaceResizeEvent, Timer, TimerSpan, Visibility, VisibilityOptions, VisibilityQuery } from "./init.ts";
+export type { Bundle, BundleOptions, BundleRecorder, BundleStatus, Compute, ComputeOptions, DispatchOptions, ClearColor, GpuErrorListener, InitOptions, PingPongStorage, PingPongTargets, SharedUniforms, StorageAccess, StorageBuffer, StorageOptions, Surface, SurfaceOptions, SurfaceResizeEvent, Timer, TimerSpan, Visibility, VisibilityOptions, VisibilityQuery } from "./init.ts";
 export type { BlendComponentOptions, BlendOptions, BlendPreset, DepthOptions, Draw, DrawOptions, DrawCallOptions, DrawLayoutOptions, GeometryLike, StencilFaceOptions, StencilOptions } from "./draw.ts";
 export { Geometry } from "./scene/geometry-descriptor.ts";
 export type { GeometryAttributeOverride, GeometryAttributes, GeometryBuffer, GeometryBufferOptions, GeometryData, GeometryOptions, GeometrySlice, GeometrySliceOptions } from "./scene/geometry-descriptor.ts";

--- a/packages/vgpu-api/src/prepare.ts
+++ b/packages/vgpu-api/src/prepare.ts
@@ -107,7 +107,9 @@ async function prepareOne(request: PrepareRequest): Promise<PreparedDraw | Prepa
     return { compute: request.compute, gpu: await asComputePipeline(request.compute).prepareCombination() };
   }
   if ("bundle" in request) {
-    const { signature, gpu } = prepareBundle(request.bundle);
+    // Genuinely awaited: preparing a bundle pre-warms the pipelines of every draw it recorded
+    // through the async path, and only then encodes the native bundle.
+    const { signature, gpu } = await prepareBundle(request.bundle);
     return { bundle: request.bundle, signature, gpu };
   }
   throw unsupportedError("prepare", "a prepare() request must be { draw, target }, { compute } or { bundle }.");

--- a/packages/vgpu-api/tests/bundle-signature.test.ts
+++ b/packages/vgpu-api/tests/bundle-signature.test.ts
@@ -79,23 +79,38 @@ test("precompiled draws record into signature bundles without sync pipeline crea
   gpu.dispose();
 });
 
-test("signature bundle recording still requires draw resources to be set", async () => {
+test("a bundle recording still requires draw resources to be set, at the moment it is encoded", async () => {
   const gpu = await init();
+  const scene = target(gpu, { size: [4, 4], format: "rgba8unorm" });
   const post = effect(gpu, TEXTURE, { label: "post" });
 
-  expect(() => bundle(gpu, { target: { colors: ["rgba8unorm"] }, label: "unsetTextureBundle" }, (b) => b.draw(post))).toThrowError(/VGPU-R1-BINDING-NEVER-SET|Unset/);
+  // Contract #15, row 1: construction records the logical command list and encodes nothing, so an
+  // unset binding is no longer discovered by bundle() itself — the encode the first replay performs
+  // (or prepare()) is what resolves the bind groups, and that is where it fails.
+  const recorded = bundle(gpu, { target: { colors: ["rgba8unorm"] }, label: "unsetTextureBundle" }, (b) => b.draw(post));
+  expect(recorded.status).toBe("pending-pipelines");
+
+  expect(() => frame(gpu, (currentFrame) => currentFrame.pass({ target: scene }, (p) => p.bundles(recorded)))).toThrowError(/VGPU-R1-BINDING-NEVER-SET|Unset/);
   gpu.dispose();
 });
 
-test("cold signature bundle recording uses the sync pipeline path and reports failures through gpu.onError", async () => {
+test("the first sync replay of a cold bundle uses the sync pipeline path and reports failures through gpu.onError", async () => {
   const gpu = await init();
+  const scene = target(gpu, { size: [4, 4], format: "rgba8unorm" });
   const shader = effect(gpu, SOLID, { label: "coldFailure" });
   const nativeError = new Error("sync pipeline failed during bundle recording");
   const errors: unknown[] = [];
   gpu.onError((error) => errors.push(error));
   vi.spyOn(gpu.device.gpu, "createRenderPipeline").mockImplementation(() => { throw nativeError; });
 
-  expect(() => bundle(gpu, { target: { colors: ["rgba8unorm"] }, label: "coldFailureBundle" }, (b) => b.draw(shader))).not.toThrow();
+  // Contract #15: "construction never throws for pending pipelines" — and it never compiles either,
+  // so nothing can fail here. The inline compile moved to the first replay, which under the train's
+  // "sync" default reproduces exactly the eager behavior (and its error report) of before.
+  const recorded = bundle(gpu, { target: { colors: ["rgba8unorm"] }, label: "coldFailureBundle" }, (b) => b.draw(shader));
+  await gpu.settled();
+  expect(errors).toEqual([]);
+
+  expect(() => frame(gpu, (currentFrame) => currentFrame.pass({ target: scene }, (p) => p.bundles(recorded)))).not.toThrow();
   await gpu.settled();
 
   expect(errors).toEqual([

--- a/packages/vgpu-api/tests/bundle/bundle-retention.test.ts
+++ b/packages/vgpu-api/tests/bundle/bundle-retention.test.ts
@@ -1,0 +1,68 @@
+import { expect, test } from "vitest";
+
+import { bundle, effect, init, prepare, target } from "../../src/mock.ts";
+
+/**
+ * The retention half of contract #15's `dispose()` row, imported from the adversarial QA probe that
+ * found the leak this file now guards.
+ *
+ * Why a GC test at all: `dispose()`'s own unit test can only assert what `dispose()` sets (status
+ * `disposed`, every replay throwing) — it is tautological about the reference graph, and it passed
+ * happily while a disposed bundle stayed reachable forever from every draw it had recorded. The
+ * draw→bundle back-reference registry is add-only by construction, so the ONLY thing that observes
+ * `unregisterDrawBundle()` being wired into `dispose()` is a collectability measurement. If someone
+ * touches `dispose()` or that registry, this is the net.
+ *
+ * Read the shape of the test carefully before editing it: the bundle MUST be created inside its own
+ * function, with only the `WeakRef` escaping. Creating it in a block scope of the test body and
+ * awaiting there instead reports a false positive — V8 keeps block-scoped bindings alive in the
+ * enclosing async context, so the bundle looks retained even when the registry is clean. That false
+ * positive is exactly what the first version of the QA probe measured.
+ */
+const gc = () => (globalThis as { gc?: () => void }).gc;
+
+test.skipIf(typeof gc() !== "function")("a disposed bundle is collectable while the draws it recorded stay alive; skipped without --expose-gc", async () => {
+  const gpu = await init();
+  try {
+    const scene = target(gpu, { size: [4, 4] });
+    // The draw outlives every bundle here: that is the whole point. It is what holds the registry.
+    const fx = effect(gpu, SOLID, { label: "retentionFx" });
+
+    const makeDisposedBundle = async (): Promise<WeakRef<object>> => {
+      const recorded = bundle(gpu, { target: scene, label: "retentionDisposed" }, (b) => b.draw(fx));
+      await prepare(gpu, { bundle: recorded });
+      recorded.dispose();
+      return new WeakRef(recorded as object);
+    };
+
+    const disposed = await makeDisposedBundle();
+    await forceCollection();
+    expect(disposed.deref()).toBeUndefined();
+
+    // And the cost of an identity change must not grow with the number of bundles that ever recorded
+    // the draw: a registry that never drops entries makes every .set() walk the graveyard.
+    const samples: WeakRef<object>[] = [];
+    for (let i = 0; i < 500; i++) {
+      const churn = bundle(gpu, { target: scene, label: `retentionChurn${i}` }, (b) => b.draw(fx));
+      churn.dispose();
+      if (i % 125 === 0) samples.push(new WeakRef(churn as object));
+    }
+    await forceCollection();
+    expect(samples.filter((sample) => sample.deref() !== undefined)).toEqual([]);
+  } finally {
+    gpu.dispose();
+  }
+});
+
+async function forceCollection(): Promise<void> {
+  const runGc = gc();
+  if (!runGc) return;
+  for (let i = 0; i < 8; i++) {
+    runGc();
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+}
+
+const SOLID = `
+@fragment fn main(@location(0) uv: vec2f) -> @location(0) vec4f { return vec4f(uv, 0.0, 1.0); }
+`;

--- a/packages/vgpu-api/tests/bundle/bundle-state.test.ts
+++ b/packages/vgpu-api/tests/bundle/bundle-state.test.ts
@@ -472,9 +472,56 @@ test("a skipped bundle does not stop the rest of the pass from replaying", async
   await prepare(gpu, { bundle: ready });
   const pending = bundle(gpu, { target: scene, label: "mixedPending" }, (b) => b.draw(pendingFx));
 
+  const executed: unknown[][] = [];
+  const passes: GPURenderPassEncoder[] = [];
+  const originalPass = gpu.device.gpu.createCommandEncoder.bind(gpu.device.gpu);
+  vi.spyOn(gpu.device.gpu, "createCommandEncoder").mockImplementation((desc?: GPUCommandEncoderDescriptor) => {
+    const encoder = originalPass(desc);
+    const beginRenderPass = encoder.beginRenderPass.bind(encoder);
+    encoder.beginRenderPass = (descriptor: GPURenderPassDescriptor) => {
+      const pass = beginRenderPass(descriptor);
+      passes.push(pass);
+      const executeBundles = pass.executeBundles.bind(pass);
+      pass.executeBundles = (list: Iterable<GPURenderBundle>) => { executed.push([...list]); return executeBundles(list); };
+      return pass;
+    };
+    return encoder;
+  });
+
   expect(() => frame(gpu, (f) => f.pass(scene, (p) => p.bundles(ready, pending)), { pendingPipelines: "skip" })).not.toThrow();
 
   expect(ready.status).toBe("ready");
+  // The skipped entry must be FILTERED OUT, not passed to WebGPU as a hole: executeBundles(undefined)
+  // is a native validation error waiting to happen, and the mock's no-op stub would never notice.
+  expect(executed.length).toBe(1);
+  expect(executed[0]).toEqual([ready.gpu]);
+  expect(executed[0]?.every((entry) => entry !== undefined)).toBe(true);
+
+  // ...and when EVERY bundle of the call is skipped there must be no executeBundles call at all:
+  // executeBundles([]) is a native call for nothing, repeated every frame of a loop that is waiting
+  // for its pipelines. The early return is the thing being asserted here.
+  executed.length = 0;
+  expect(() => frame(gpu, (f) => f.pass(scene, (p) => p.bundles(pending)), { pendingPipelines: "skip" })).not.toThrow();
+  expect(executed).toEqual([]);
+  vi.restoreAllMocks();
+  gpu.dispose();
+});
+
+test('a "sync" replay hands the policy down to the recorded draws, not just to the bundle', async () => {
+  // The gpu default is "throw" here, so a draw that is asked to encode without an explicit policy
+  // refuses to compile. The frame says "sync", and that has to reach the recorded draws through the
+  // encode — otherwise the bundle materializes its native encoder and the draw inside it throws.
+  const gpu = await init({ pendingPipelines: "throw" });
+  const scene = target(gpu, { size: [4, 4] });
+  const fx = effect(gpu, SOLID, { label: "policyDownFx" });
+  const recorded = bundle(gpu, { target: scene, label: "policyDownBundle" }, (b) => b.draw(fx));
+  const mock = getMockGPUDeviceInstrumentation(gpu.device.gpu);
+  const syncCompiles = mock.calls.createRenderPipeline;
+
+  expect(() => frame(gpu, (f) => f.pass(scene, (p) => p.bundles(recorded)), { pendingPipelines: "sync" })).not.toThrow();
+
+  expect(recorded.status).toBe("ready");
+  expect(mock.calls.createRenderPipeline).toBe(syncCompiles + 1);
   gpu.dispose();
 });
 

--- a/packages/vgpu-api/tests/bundle/bundle-state.test.ts
+++ b/packages/vgpu-api/tests/bundle/bundle-state.test.ts
@@ -1,0 +1,587 @@
+/**
+ * Contract #15 — the bundle state machine (`BundleStatus`, `bundle.error`, `rebuild()`,
+ * `dispose()`) plus the `pendingPipelines` chain for replaying a non-`ready` bundle.
+ *
+ * One test per row of the transition table in the frozen design (issue #320, contract #15):
+ * construction is always `pending-pipelines` (nothing is compiled and no native bundle is
+ * encoded), `prepare()` is the one spelling that materializes it, an identity update only stales a
+ * `ready` bundle, `rebuild()` replaces the logical recording without ever compiling, and
+ * `dispose()` is terminal under every policy.
+ */
+import { expect, test, vi } from "vitest";
+import { getMockGPUDeviceInstrumentation } from "@vgpu/core";
+import { init, bundle, effect, frame, prepare, target } from "../../src/mock.ts";
+import type { VGPUError } from "../../src/errors.ts";
+
+const SOLID = `
+@fragment fn main(@location(0) uv: vec2f) -> @location(0) vec4f {
+  return vec4f(uv, 0.0, 1.0);
+}
+`;
+
+const OTHER_SOLID = `
+@fragment fn main(@location(0) uv: vec2f) -> @location(0) vec4f {
+  return vec4f(1.0 - uv.x, uv.y, 0.5, 1.0);
+}
+`;
+
+const TEXTURED = `
+@group(0) @binding(0) var src: texture_2d<f32>;
+@fragment fn main(@location(0) uv: vec2f) -> @location(0) vec4f {
+  return textureLoad(src, vec2u(0, 0), 0) + vec4f(uv, 0.0, 0.0);
+}
+`;
+
+function caught(run: () => unknown): VGPUError | undefined {
+  try { run(); return undefined; }
+  catch (error) { return error as VGPUError; }
+}
+
+async function rejection(run: () => Promise<unknown>): Promise<VGPUError> {
+  try { await run(); throw new Error("expected a rejection"); }
+  catch (error) { return error as VGPUError; }
+}
+
+// ---------------------------------------------------------------------------
+// Row 1: construction → pending-pipelines, always.
+// ---------------------------------------------------------------------------
+
+test("bundle() records the logical command list without compiling or encoding anything", async () => {
+  const gpu = await init();
+  const scene = target(gpu, { size: [4, 4] });
+  const fx = effect(gpu, SOLID, { label: "constructionFx" });
+  const mock = getMockGPUDeviceInstrumentation(gpu.device.gpu);
+
+  const recorded = bundle(gpu, { target: scene, label: "construction" }, (b) => b.draw(fx));
+
+  expect(recorded.status).toBe("pending-pipelines");
+  expect(recorded.gpu).toBeUndefined();
+  expect(recorded.error).toBeUndefined();
+  expect(mock.calls.createRenderPipeline).toBe(0);
+  expect(mock.calls.createRenderPipelineAsync).toBe(0);
+  expect(mock.calls.createRenderBundleEncoder).toBe(0);
+  gpu.dispose();
+});
+
+test("a bundle whose draws already have their pipeline is still born pending-pipelines", async () => {
+  const gpu = await init();
+  const scene = target(gpu, { size: [4, 4] });
+  const fx = effect(gpu, SOLID, { label: "warmFx" });
+  await prepare(gpu, { draw: fx, target: scene });
+
+  // "always: the native bundle is not materialized at construction" — readiness of the pipelines is
+  // not the same fact as readiness of the native bundle.
+  const recorded = bundle(gpu, { target: scene, label: "warmConstruction" }, (b) => b.draw(fx));
+
+  expect(recorded.status).toBe("pending-pipelines");
+  expect(recorded.gpu).toBeUndefined();
+  gpu.dispose();
+});
+
+// ---------------------------------------------------------------------------
+// Row 2: prepare() succeeds → ready. Plus contract #7 (bundle half): re-preparing is free.
+// ---------------------------------------------------------------------------
+
+test("prepare({ bundle }) compiles the recorded draws asynchronously and then encodes the native bundle", async () => {
+  const gpu = await init();
+  const scene = target(gpu, { size: [4, 4] });
+  const fx = effect(gpu, SOLID, { label: "prepareFx" });
+  const recorded = bundle(gpu, { target: scene, label: "preparedBundle" }, (b) => b.draw(fx));
+  const mock = getMockGPUDeviceInstrumentation(gpu.device.gpu);
+
+  const prepared = await prepare(gpu, { bundle: recorded });
+
+  expect(mock.calls.createRenderPipelineAsync).toBe(1);
+  expect(mock.calls.createRenderPipeline).toBe(0);
+  expect(mock.calls.createRenderBundleEncoder).toBe(1);
+  expect(recorded.status).toBe("ready");
+  expect(recorded.gpu).toBeDefined();
+  expect(prepared.gpu).toBe(recorded.gpu);
+  expect(prepared.bundle).toBe(recorded);
+
+  const again = await prepare(gpu, { bundle: recorded });
+
+  // prepare() on a ready bundle is a no-op: no new pipeline, no re-encode.
+  expect(mock.calls.createRenderPipelineAsync).toBe(1);
+  expect(mock.calls.createRenderPipeline).toBe(0);
+  expect(mock.calls.createRenderBundleEncoder).toBe(1);
+  expect(again.gpu).toBe(recorded.gpu);
+  expect(recorded.status).toBe("ready");
+  gpu.dispose();
+});
+
+test("prepare() of the same bundle twice in one batch does not duplicate the work", async () => {
+  const gpu = await init();
+  const scene = target(gpu, { size: [4, 4] });
+  const fx = effect(gpu, SOLID, { label: "batchFx" });
+  const recorded = bundle(gpu, { target: scene, label: "batchBundle" }, (b) => b.draw(fx));
+  const mock = getMockGPUDeviceInstrumentation(gpu.device.gpu);
+
+  const [first, second] = await prepare(gpu, [{ bundle: recorded }, { bundle: recorded }]);
+
+  expect(mock.calls.createRenderBundleEncoder).toBe(1);
+  expect(mock.calls.createRenderPipelineAsync).toBe(1);
+  expect(first.gpu).toBe(second.gpu);
+  expect(recorded.status).toBe("ready");
+  gpu.dispose();
+});
+
+// ---------------------------------------------------------------------------
+// Row 3: prepare() fails → failed, retaining the error. And prepare() always retries.
+// ---------------------------------------------------------------------------
+
+test("a failed prepare({ bundle }) leaves the bundle failed with the error retained, and a later prepare retries it", async () => {
+  const gpu = await init();
+  const scene = target(gpu, { size: [4, 4] });
+  const fx = effect(gpu, SOLID, { label: "failingFx" });
+  const recorded = bundle(gpu, { target: scene, label: "failingBundle" }, (b) => b.draw(fx));
+  const nativeError = new Error("async pipeline creation failed");
+  const original = gpu.device.gpu.createRenderPipelineAsync.bind(gpu.device.gpu);
+  const spy = vi.spyOn(gpu.device.gpu, "createRenderPipelineAsync").mockRejectedValue(nativeError);
+
+  const failure = await rejection(() => prepare(gpu, { bundle: recorded }));
+
+  expect(failure.code).toBe("VGPU-PREPARE-FAILED");
+  expect(failure.message).toContain("failingBundle");
+  expect(recorded.status).toBe("failed");
+  expect(recorded.error?.code).toBe("VGPU-COMPILE-FAILED");
+  expect(recorded.error?.where).toBe("bundle 'failingBundle' prepare");
+  expect(recorded.gpu).toBeUndefined();
+
+  spy.mockImplementation((desc: GPURenderPipelineDescriptor) => original(desc));
+  const prepared = await prepare(gpu, { bundle: recorded });
+
+  expect(recorded.status).toBe("ready");
+  expect(recorded.error).toBeUndefined();
+  expect(prepared.gpu).toBe(recorded.gpu);
+  gpu.dispose();
+});
+
+// ---------------------------------------------------------------------------
+// Rows 4-6: .set() does not transition, .bind() stales a ready bundle, an identity update on a
+// non-ready bundle changes nothing.
+// ---------------------------------------------------------------------------
+
+test(".set() byte updates keep a ready bundle ready, .bind() identity updates make it stale", async () => {
+  const gpu = await init();
+  const scene = target(gpu, { size: [4, 4], format: "rgba8unorm" });
+  const first = target(gpu, { size: [4, 4] });
+  const second = target(gpu, { size: [4, 4] });
+  const fx = effect(gpu, { shader: TEXTURED, label: "identityFx", bindings: { src: first } });
+  const recorded = bundle(gpu, { target: scene, label: "identityBundle" }, (b) => b.draw(fx));
+  await prepare(gpu, { bundle: recorded });
+  const native = recorded.gpu;
+
+  fx.bind("src", first);
+  expect(recorded.status).toBe("ready");
+
+  fx.bind("src", second);
+  expect(recorded.status).toBe("stale");
+  // The last valid native bundle is retained until something re-encodes it.
+  expect(recorded.gpu).toBe(native);
+  gpu.dispose();
+});
+
+test("an identity update on a bundle that is not ready leaves its status unchanged", async () => {
+  const gpu = await init();
+  const scene = target(gpu, { size: [4, 4], format: "rgba8unorm" });
+  const first = target(gpu, { size: [4, 4] });
+  const second = target(gpu, { size: [4, 4] });
+  const fx = effect(gpu, { shader: TEXTURED, label: "pendingIdentityFx", bindings: { src: first } });
+  const recorded = bundle(gpu, { target: scene, label: "pendingIdentityBundle" }, (b) => b.draw(fx));
+
+  fx.bind("src", second);
+
+  expect(recorded.status).toBe("pending-pipelines");
+  gpu.dispose();
+});
+
+// ---------------------------------------------------------------------------
+// Row 7: rebuild() replaces the logical recording, synchronously, without compiling.
+// ---------------------------------------------------------------------------
+
+test("rebuild() replaces the recording without compiling or encoding and lands on stale when every draw is ready", async () => {
+  const gpu = await init();
+  const scene = target(gpu, { size: [4, 4] });
+  const fx = effect(gpu, SOLID, { label: "rebuildFx" });
+  const recorded = bundle(gpu, { target: scene, label: "rebuildBundle" }, (b) => b.draw(fx));
+  await prepare(gpu, { bundle: recorded });
+  const mock = getMockGPUDeviceInstrumentation(gpu.device.gpu);
+  const baseline = { ...mock.calls };
+  const native = recorded.gpu;
+
+  recorded.rebuild((b) => b.draw(fx));
+
+  expect(recorded.status).toBe("stale");
+  expect(mock.calls.createRenderPipeline).toBe(baseline.createRenderPipeline);
+  expect(mock.calls.createRenderPipelineAsync).toBe(baseline.createRenderPipelineAsync);
+  expect(mock.calls.createRenderBundleEncoder).toBe(baseline.createRenderBundleEncoder);
+  // The old native bundle stays the last valid one until a prepare()/"sync" replay re-encodes.
+  expect(recorded.gpu).toBe(native);
+
+  await prepare(gpu, { bundle: recorded });
+
+  expect(recorded.status).toBe("ready");
+  expect(mock.calls.createRenderBundleEncoder).toBe(baseline.createRenderBundleEncoder + 1);
+  expect(recorded.gpu).not.toBe(native);
+  gpu.dispose();
+});
+
+test("rebuild() goes to pending-pipelines when the new recording introduces an uncompiled combination", async () => {
+  const gpu = await init();
+  const scene = target(gpu, { size: [4, 4] });
+  const known = effect(gpu, SOLID, { label: "knownFx" });
+  // A distinct shader source: two effects over the SAME source share a cached module and therefore
+  // the same pipeline key, which would make the new draw ready for free.
+  const introduced = effect(gpu, OTHER_SOLID, { label: "introducedFx" });
+  const recorded = bundle(gpu, { target: scene, label: "growingBundle" }, (b) => b.draw(known));
+  await prepare(gpu, { bundle: recorded });
+  const mock = getMockGPUDeviceInstrumentation(gpu.device.gpu);
+  const baseline = { ...mock.calls };
+
+  recorded.rebuild((b) => { b.draw(known); b.draw(introduced); });
+
+  expect(recorded.status).toBe("pending-pipelines");
+  expect(mock.calls.createRenderPipeline).toBe(baseline.createRenderPipeline);
+  expect(mock.calls.createRenderPipelineAsync).toBe(baseline.createRenderPipelineAsync);
+  expect(mock.calls.createRenderBundleEncoder).toBe(baseline.createRenderBundleEncoder);
+  gpu.dispose();
+});
+
+test("rebuild() clears the retained error immediately because it replaces the recording that failed", async () => {
+  const gpu = await init();
+  const scene = target(gpu, { size: [4, 4] });
+  const fx = effect(gpu, SOLID, { label: "clearedFx" });
+  const recorded = bundle(gpu, { target: scene, label: "clearedBundle" }, (b) => b.draw(fx));
+  const original = gpu.device.gpu.createRenderPipelineAsync.bind(gpu.device.gpu);
+  const spy = vi.spyOn(gpu.device.gpu, "createRenderPipelineAsync").mockRejectedValue(new Error("nope"));
+  await rejection(() => prepare(gpu, { bundle: recorded }));
+  expect(recorded.error).toBeDefined();
+
+  spy.mockImplementation((desc: GPURenderPipelineDescriptor) => original(desc));
+  recorded.rebuild((b) => b.draw(fx));
+
+  expect(recorded.error).toBeUndefined();
+  expect(recorded.status).toBe("pending-pipelines");
+  gpu.dispose();
+});
+
+// ---------------------------------------------------------------------------
+// Replay of a non-ready bundle: the one pendingPipelines chain (frame → gpu for bundles).
+// ---------------------------------------------------------------------------
+
+test('replaying a pending-pipelines bundle under "throw" throws VGPU-PIPELINE-PENDING and compiles nothing', async () => {
+  const gpu = await init();
+  const scene = target(gpu, { size: [4, 4] });
+  const fx = effect(gpu, SOLID, { label: "throwPendingFx" });
+  const recorded = bundle(gpu, { target: scene, label: "throwPendingBundle" }, (b) => b.draw(fx));
+  const mock = getMockGPUDeviceInstrumentation(gpu.device.gpu);
+
+  const error = caught(() => frame(gpu, (f) => f.pass(scene, (p) => p.bundles(recorded)), { pendingPipelines: "throw" }));
+
+  expect(error?.code).toBe("VGPU-PIPELINE-PENDING");
+  expect(mock.calls.createRenderPipeline).toBe(0);
+  expect(mock.calls.createRenderBundleEncoder).toBe(0);
+  expect(recorded.status).toBe("pending-pipelines");
+  gpu.dispose();
+});
+
+test('replaying a stale bundle under "throw" throws VGPU-R3-BUNDLE-STALE naming prepare()', async () => {
+  const gpu = await init();
+  const scene = target(gpu, { size: [4, 4], format: "rgba8unorm" });
+  const first = target(gpu, { size: [4, 4] });
+  const second = target(gpu, { size: [4, 4] });
+  const fx = effect(gpu, { shader: TEXTURED, label: "throwStaleFx", bindings: { src: first } });
+  const recorded = bundle(gpu, { target: scene, label: "throwStaleBundle" }, (b) => b.draw(fx));
+  await prepare(gpu, { bundle: recorded });
+  fx.bind("src", second);
+  const mock = getMockGPUDeviceInstrumentation(gpu.device.gpu);
+  const encoders = mock.calls.createRenderBundleEncoder;
+
+  const error = caught(() => frame(gpu, (f) => f.pass(scene, (p) => p.bundles(recorded)), { pendingPipelines: "throw" }));
+
+  expect(error?.code).toBe("VGPU-R3-BUNDLE-STALE");
+  expect(error?.message).toContain("prepare(gpu, { bundle: throwStaleBundle })");
+  expect(mock.calls.createRenderBundleEncoder).toBe(encoders);
+  expect(recorded.status).toBe("stale");
+  gpu.dispose();
+});
+
+test('replaying a failed bundle under "throw" rethrows the retained error with its cause', async () => {
+  const gpu = await init();
+  const scene = target(gpu, { size: [4, 4] });
+  const fx = effect(gpu, SOLID, { label: "throwFailedFx" });
+  const recorded = bundle(gpu, { target: scene, label: "throwFailedBundle" }, (b) => b.draw(fx));
+  vi.spyOn(gpu.device.gpu, "createRenderPipelineAsync").mockRejectedValue(new Error("compile said no"));
+  await rejection(() => prepare(gpu, { bundle: recorded }));
+
+  const error = caught(() => frame(gpu, (f) => f.pass(scene, (p) => p.bundles(recorded)), { pendingPipelines: "throw" }));
+
+  expect(error).toBe(recorded.error);
+  expect((error?.cause as VGPUError)?.code).toBe("VGPU-COMPILE-FAILED");
+  gpu.dispose();
+});
+
+test('a pending-pipelines bundle under "skip" is omitted and its compilation continues in the background', async () => {
+  const gpu = await init();
+  const scene = target(gpu, { size: [4, 4] });
+  const fx = effect(gpu, SOLID, { label: "skipPendingFx" });
+  const recorded = bundle(gpu, { target: scene, label: "skipPendingBundle" }, (b) => b.draw(fx));
+  const mock = getMockGPUDeviceInstrumentation(gpu.device.gpu);
+
+  expect(() => frame(gpu, (f) => f.pass(scene, (p) => p.bundles(recorded)), { pendingPipelines: "skip" })).not.toThrow();
+
+  // Skipped this frame: nothing was compiled synchronously and nothing was encoded inline.
+  expect(mock.calls.createRenderPipeline).toBe(0);
+  expect(mock.calls.createRenderBundleEncoder).toBe(0);
+  expect(mock.calls.createRenderPipelineAsync).toBe(1);
+
+  await gpu.settled();
+
+  expect(recorded.status).toBe("ready");
+  expect(mock.calls.createRenderBundleEncoder).toBe(1);
+  gpu.dispose();
+});
+
+test('a stale bundle under "skip" is skipped and never silently re-encoded', async () => {
+  const gpu = await init();
+  const scene = target(gpu, { size: [4, 4], format: "rgba8unorm" });
+  const first = target(gpu, { size: [4, 4] });
+  const second = target(gpu, { size: [4, 4] });
+  const fx = effect(gpu, { shader: TEXTURED, label: "skipStaleFx", bindings: { src: first } });
+  const recorded = bundle(gpu, { target: scene, label: "skipStaleBundle" }, (b) => b.draw(fx));
+  await prepare(gpu, { bundle: recorded });
+  fx.bind("src", second);
+  const mock = getMockGPUDeviceInstrumentation(gpu.device.gpu);
+  const encoders = mock.calls.createRenderBundleEncoder;
+
+  expect(() => frame(gpu, (f) => f.pass(scene, (p) => p.bundles(recorded)), { pendingPipelines: "skip" })).not.toThrow();
+  await gpu.settled();
+
+  expect(recorded.status).toBe("stale");
+  expect(mock.calls.createRenderBundleEncoder).toBe(encoders);
+  gpu.dispose();
+});
+
+test('a failed bundle under "skip" is reported once through gpu.onError and keeps being skipped', async () => {
+  const gpu = await init();
+  const scene = target(gpu, { size: [4, 4] });
+  const fx = effect(gpu, SOLID, { label: "skipFailedFx" });
+  const recorded = bundle(gpu, { target: scene, label: "skipFailedBundle" }, (b) => b.draw(fx));
+  vi.spyOn(gpu.device.gpu, "createRenderPipelineAsync").mockRejectedValue(new Error("still no"));
+  await rejection(() => prepare(gpu, { bundle: recorded }));
+  const errors: VGPUError[] = [];
+  gpu.onError((error) => errors.push(error as VGPUError));
+
+  expect(() => frame(gpu, (f) => f.pass(scene, (p) => p.bundles(recorded)), { pendingPipelines: "skip" })).not.toThrow();
+  await gpu.settled();
+  expect(() => frame(gpu, (f) => f.pass(scene, (p) => p.bundles(recorded)), { pendingPipelines: "skip" })).not.toThrow();
+  await gpu.settled();
+
+  expect(errors).toHaveLength(1);
+  expect(errors[0]).toBe(recorded.error);
+  expect(recorded.status).toBe("failed");
+  gpu.dispose();
+});
+
+test('a pending-pipelines bundle under "sync" is compiled and encoded inline, which is the legacy eager behavior', async () => {
+  const gpu = await init();
+  const scene = target(gpu, { size: [4, 4] });
+  const fx = effect(gpu, SOLID, { label: "syncPendingFx" });
+  const recorded = bundle(gpu, { target: scene, label: "syncPendingBundle" }, (b) => b.draw(fx));
+  const mock = getMockGPUDeviceInstrumentation(gpu.device.gpu);
+
+  // No prepare() anywhere: the default policy of the train is "sync", so this is what every
+  // existing program does today.
+  expect(() => frame(gpu, (f) => f.pass(scene, (p) => p.bundles(recorded)))).not.toThrow();
+
+  expect(recorded.status).toBe("ready");
+  expect(recorded.gpu).toBeDefined();
+  expect(mock.calls.createRenderPipeline).toBe(1);
+  expect(mock.calls.createRenderBundleEncoder).toBe(1);
+
+  // A second replay of a ready bundle re-encodes nothing.
+  expect(() => frame(gpu, (f) => f.pass(scene, (p) => p.bundles(recorded)))).not.toThrow();
+  expect(mock.calls.createRenderBundleEncoder).toBe(1);
+  gpu.dispose();
+});
+
+test('a stale bundle under "sync" is re-encoded inline without compiling', async () => {
+  const gpu = await init();
+  const scene = target(gpu, { size: [4, 4], format: "rgba8unorm" });
+  const first = target(gpu, { size: [4, 4] });
+  const second = target(gpu, { size: [4, 4] });
+  const fx = effect(gpu, { shader: TEXTURED, label: "syncStaleFx", bindings: { src: first } });
+  const recorded = bundle(gpu, { target: scene, label: "syncStaleBundle" }, (b) => b.draw(fx));
+  await prepare(gpu, { bundle: recorded });
+  const native = recorded.gpu;
+  fx.bind("src", second);
+  const mock = getMockGPUDeviceInstrumentation(gpu.device.gpu);
+  const encoders = mock.calls.createRenderBundleEncoder;
+
+  expect(() => frame(gpu, (f) => f.pass(scene, (p) => p.bundles(recorded)), { pendingPipelines: "sync" })).not.toThrow();
+
+  expect(recorded.status).toBe("ready");
+  expect(recorded.gpu).not.toBe(native);
+  expect(mock.calls.createRenderBundleEncoder).toBe(encoders + 1);
+  expect(mock.calls.createRenderPipeline).toBe(0);
+  gpu.dispose();
+});
+
+test('a failed bundle under "sync" rethrows the retained error and does not retry', async () => {
+  const gpu = await init();
+  const scene = target(gpu, { size: [4, 4] });
+  const fx = effect(gpu, SOLID, { label: "syncFailedFx" });
+  const recorded = bundle(gpu, { target: scene, label: "syncFailedBundle" }, (b) => b.draw(fx));
+  vi.spyOn(gpu.device.gpu, "createRenderPipelineAsync").mockRejectedValue(new Error("no pipeline"));
+  await rejection(() => prepare(gpu, { bundle: recorded }));
+  const mock = getMockGPUDeviceInstrumentation(gpu.device.gpu);
+  const asyncCalls = mock.calls.createRenderPipelineAsync;
+
+  const error = caught(() => frame(gpu, (f) => f.pass(scene, (p) => p.bundles(recorded)), { pendingPipelines: "sync" }));
+
+  expect(error).toBe(recorded.error);
+  expect(mock.calls.createRenderPipelineAsync).toBe(asyncCalls);
+  expect(mock.calls.createRenderPipeline).toBe(0);
+  gpu.dispose();
+});
+
+test("a skipped bundle does not stop the rest of the pass from replaying", async () => {
+  const gpu = await init();
+  const scene = target(gpu, { size: [4, 4] });
+  const readyFx = effect(gpu, SOLID, { label: "mixedReadyFx" });
+  const pendingFx = effect(gpu, SOLID, { label: "mixedPendingFx" });
+  const ready = bundle(gpu, { target: scene, label: "mixedReady" }, (b) => b.draw(readyFx));
+  await prepare(gpu, { bundle: ready });
+  const pending = bundle(gpu, { target: scene, label: "mixedPending" }, (b) => b.draw(pendingFx));
+
+  expect(() => frame(gpu, (f) => f.pass(scene, (p) => p.bundles(ready, pending)), { pendingPipelines: "skip" })).not.toThrow();
+
+  expect(ready.status).toBe("ready");
+  gpu.dispose();
+});
+
+// ---------------------------------------------------------------------------
+// Row 8: dispose() is terminal under every policy.
+// ---------------------------------------------------------------------------
+
+test("dispose() is terminal and idempotent, and every replay policy throws VGPU-BUNDLE-DISPOSED", async () => {
+  const gpu = await init();
+  const scene = target(gpu, { size: [4, 4] });
+  const fx = effect(gpu, SOLID, { label: "disposedFx" });
+  const recorded = bundle(gpu, { target: scene, label: "disposedBundle" }, (b) => b.draw(fx));
+  await prepare(gpu, { bundle: recorded });
+
+  recorded.dispose();
+  expect(recorded.status).toBe("disposed");
+  expect(recorded.gpu).toBeUndefined();
+  expect(() => recorded.dispose()).not.toThrow();
+  expect(recorded.status).toBe("disposed");
+
+  for (const pendingPipelines of ["throw", "skip", "sync"] as const) {
+    const error = caught(() => frame(gpu, (f) => f.pass(scene, (p) => p.bundles(recorded)), { pendingPipelines }));
+    expect(error?.code).toBe("VGPU-BUNDLE-DISPOSED");
+  }
+
+  // prepare() on a disposed bundle fails loudly too — never a silent no-op.
+  const failure = await rejection(() => prepare(gpu, { bundle: recorded }));
+  expect(failure.code).toBe("VGPU-PREPARE-FAILED");
+  expect((failure.cause as VGPUError).code).toBe("VGPU-BUNDLE-DISPOSED");
+
+  expect(caught(() => recorded.rebuild((b) => b.draw(fx)))?.code).toBe("VGPU-BUNDLE-DISPOSED");
+  gpu.dispose();
+});
+
+// ---------------------------------------------------------------------------
+// Adversarial: events that arrive while a prepare() is in flight.
+// ---------------------------------------------------------------------------
+
+test("an identity update during an in-flight prepare() is not lost: the encode that follows it captures the new resource", async () => {
+  const gpu = await init();
+  const scene = target(gpu, { size: [4, 4], format: "rgba8unorm" });
+  const first = target(gpu, { size: [4, 4] });
+  const second = target(gpu, { size: [4, 4] });
+  const fx = effect(gpu, { shader: TEXTURED, label: "raceFx", bindings: { src: first } });
+  const recorded = bundle(gpu, { target: scene, label: "raceBundle" }, (b) => b.draw(fx));
+  const original = gpu.device.gpu.createRenderPipelineAsync.bind(gpu.device.gpu);
+  let release!: () => void;
+  const gate = new Promise<void>((resolve) => { release = resolve; });
+  vi.spyOn(gpu.device.gpu, "createRenderPipelineAsync").mockImplementation(async (desc: GPURenderPipelineDescriptor) => {
+    await gate;
+    return original(desc);
+  });
+
+  const preparing = prepare(gpu, { bundle: recorded });
+  fx.bind("src", second);
+  release();
+  await preparing;
+
+  // The recording is replayed AFTER the identity change, so the native bundle it produced is the
+  // up-to-date one: the bundle is ready, not stale.
+  expect(recorded.status).toBe("ready");
+  expect(() => frame(gpu, (f) => f.pass(scene, (p) => p.bundles(recorded)), { pendingPipelines: "throw" })).not.toThrow();
+  gpu.dispose();
+});
+
+test("rebuild() during an in-flight prepare() makes that prepare finish on the new recording", async () => {
+  const gpu = await init();
+  const scene = target(gpu, { size: [4, 4] });
+  const before = effect(gpu, SOLID, { label: "beforeRebuildFx" });
+  const after = effect(gpu, SOLID, { label: "afterRebuildFx" });
+  const recorded = bundle(gpu, { target: scene, label: "rebuildRaceBundle" }, (b) => b.draw(before));
+  const original = gpu.device.gpu.createRenderPipelineAsync.bind(gpu.device.gpu);
+  let release!: () => void;
+  const gate = new Promise<void>((resolve) => { release = resolve; });
+  vi.spyOn(gpu.device.gpu, "createRenderPipelineAsync").mockImplementation(async (desc: GPURenderPipelineDescriptor) => {
+    await gate;
+    return original(desc);
+  });
+
+  const preparing = prepare(gpu, { bundle: recorded });
+  recorded.rebuild((b) => b.draw(after));
+  release();
+  await preparing;
+
+  expect(recorded.status).toBe("ready");
+  // The pipeline of the draw the NEW recording names is the one that had to be compiled.
+  expect(after.gpu).toBeDefined();
+  expect(() => frame(gpu, (f) => f.pass(scene, (p) => p.bundles(recorded)), { pendingPipelines: "throw" })).not.toThrow();
+  gpu.dispose();
+});
+
+test("dispose() during an in-flight prepare() makes that prepare fail with VGPU-BUNDLE-DISPOSED", async () => {
+  const gpu = await init();
+  const scene = target(gpu, { size: [4, 4] });
+  const fx = effect(gpu, SOLID, { label: "disposeRaceFx" });
+  const recorded = bundle(gpu, { target: scene, label: "disposeRaceBundle" }, (b) => b.draw(fx));
+  const original = gpu.device.gpu.createRenderPipelineAsync.bind(gpu.device.gpu);
+  let release!: () => void;
+  const gate = new Promise<void>((resolve) => { release = resolve; });
+  vi.spyOn(gpu.device.gpu, "createRenderPipelineAsync").mockImplementation(async (desc: GPURenderPipelineDescriptor) => {
+    await gate;
+    return original(desc);
+  });
+  const mock = getMockGPUDeviceInstrumentation(gpu.device.gpu);
+
+  const preparing = prepare(gpu, { bundle: recorded });
+  recorded.dispose();
+  release();
+  const failure = await rejection(() => preparing);
+
+  expect(failure.code).toBe("VGPU-PREPARE-FAILED");
+  expect((failure.cause as VGPUError).code).toBe("VGPU-BUNDLE-DISPOSED");
+  expect(recorded.status).toBe("disposed");
+  expect(mock.calls.createRenderBundleEncoder).toBe(0);
+  gpu.dispose();
+});
+
+// ---------------------------------------------------------------------------
+// Contract #16 — deferred on purpose: `uniformArray`/`slots` do not exist on this branch.
+// ---------------------------------------------------------------------------
+
+test.skip("contract #16: a bundle recorded with slots: at(0) replays with slot 0's offset (T04-07)", () => {
+  // WebGPU freezes the dynamic offsets of setBindGroup when the GPURenderBundleEncoder records it,
+  // so this contract holds for free once `uniformArray`/`slots` land. There is no slot mechanism on
+  // this branch to exercise, and building one here would duplicate T04-07: the explicit
+  // verification lives with the feature that introduces it.
+});

--- a/packages/vgpu-api/tests/bundle/bundle-state.test.ts
+++ b/packages/vgpu-api/tests/bundle/bundle-state.test.ts
@@ -32,6 +32,15 @@ const TEXTURED = `
 }
 `;
 
+const TEXTURED_FOG = `
+struct Fog { fogDensity: f32 }
+@group(0) @binding(0) var src: texture_2d<f32>;
+@group(0) @binding(1) var<uniform> fog: Fog;
+@fragment fn main(@location(0) uv: vec2f) -> @location(0) vec4f {
+  return textureLoad(src, vec2u(0, 0), 0) * fog.fogDensity + vec4f(uv, 0.0, 0.0);
+}
+`;
+
 function caught(run: () => unknown): VGPUError | undefined {
   try { run(); return undefined; }
   catch (error) { return error as VGPUError; }
@@ -167,11 +176,19 @@ test(".set() byte updates keep a ready bundle ready, .bind() identity updates ma
   const scene = target(gpu, { size: [4, 4], format: "rgba8unorm" });
   const first = target(gpu, { size: [4, 4] });
   const second = target(gpu, { size: [4, 4] });
-  const fx = effect(gpu, { shader: TEXTURED, label: "identityFx", bindings: { src: first } });
+  const fx = effect(gpu, { shader: TEXTURED_FOG, label: "identityFx", bindings: { src: first }, set: { fogDensity: 0.1 } });
   const recorded = bundle(gpu, { target: scene, label: "identityBundle" }, (b) => b.draw(fx));
   await prepare(gpu, { bundle: recorded });
   const native = recorded.gpu;
 
+  // Row 4, the real thing: .set() writes bytes into the buffer the bundle already captured, so every
+  // recorded command and bind group stays valid — the bundle must NOT move, and must keep the very
+  // same native bundle (that is the whole point of R3: value updates are free for bundles).
+  fx.set({ fogDensity: 0.9 });
+  expect(recorded.status).toBe("ready");
+  expect(recorded.gpu).toBe(native);
+
+  // Re-binding the SAME identity is not an identity change either.
   fx.bind("src", first);
   expect(recorded.status).toBe("ready");
 
@@ -527,8 +544,12 @@ test("rebuild() during an in-flight prepare() makes that prepare finish on the n
   const gpu = await init();
   const scene = target(gpu, { size: [4, 4] });
   const before = effect(gpu, SOLID, { label: "beforeRebuildFx" });
-  const after = effect(gpu, SOLID, { label: "afterRebuildFx" });
+  // A DIFFERENT shader on purpose: the new recording needs a pipeline the in-flight prepare never
+  // warmed, which is exactly what the #generation re-check has to notice.
+  const after = effect(gpu, OTHER_SOLID, { label: "afterRebuildFx" });
   const recorded = bundle(gpu, { target: scene, label: "rebuildRaceBundle" }, (b) => b.draw(before));
+  const mock = getMockGPUDeviceInstrumentation(gpu.device.gpu);
+  const syncCompiles = mock.calls.createRenderPipeline;
   const original = gpu.device.gpu.createRenderPipelineAsync.bind(gpu.device.gpu);
   let release!: () => void;
   const gate = new Promise<void>((resolve) => { release = resolve; });
@@ -545,7 +566,58 @@ test("rebuild() during an in-flight prepare() makes that prepare finish on the n
   expect(recorded.status).toBe("ready");
   // The pipeline of the draw the NEW recording names is the one that had to be compiled.
   expect(after.gpu).toBeDefined();
+  // Load-bearing assert for the re-check: without it, prepare() encodes the new command list with
+  // only the old recording warmed, so `after`'s pipeline is created SYNCHRONOUSLY inside the encode —
+  // the stall prepare() exists to avoid. Zero synchronous creations is the proof it re-warmed.
+  expect(mock.calls.createRenderPipeline).toBe(syncCompiles);
   expect(() => frame(gpu, (f) => f.pass(scene, (p) => p.bundles(recorded)), { pendingPipelines: "throw" })).not.toThrow();
+  gpu.dispose();
+});
+
+test("rebuild() unregisters the draws it dropped, so their later identity changes no longer stale the bundle", async () => {
+  const gpu = await init();
+  const scene = target(gpu, { size: [4, 4], format: "rgba8unorm" });
+  const first = target(gpu, { size: [4, 4] });
+  const second = target(gpu, { size: [4, 4] });
+  const dropped = effect(gpu, { shader: TEXTURED, label: "droppedFx", bindings: { src: first } });
+  const kept = effect(gpu, { shader: TEXTURED, label: "keptFx", bindings: { src: first } });
+  const recorded = bundle(gpu, { target: scene, label: "dropBundle" }, (b) => b.draw(dropped));
+  await prepare(gpu, { bundle: recorded });
+
+  recorded.rebuild((b) => b.draw(kept));
+  await prepare(gpu, { bundle: recorded });
+  expect(recorded.status).toBe("ready");
+
+  // The dropped draw is not part of the recording any more, so its identity changes are none of this
+  // bundle's business. Registration is one-way in draw.ts, so getting this wrong is not a cosmetic
+  // detail: the bundle would be stale FOREVER from a draw it no longer encodes, and no prepare()
+  // could fix it because the re-encode does not name that draw.
+  dropped.bind("src", second);
+  expect(recorded.status).toBe("ready");
+  expect(() => frame(gpu, (f) => f.pass(scene, (p) => p.bundles(recorded)), { pendingPipelines: "throw" })).not.toThrow();
+
+  // ...while the draw the new recording DOES name still stales it.
+  kept.bind("src", second);
+  expect(recorded.status).toBe("stale");
+  gpu.dispose();
+});
+
+test("dispose() unregisters the bundle from its draws: a later identity change reaches nothing", async () => {
+  const gpu = await init();
+  const scene = target(gpu, { size: [4, 4], format: "rgba8unorm" });
+  const first = target(gpu, { size: [4, 4] });
+  const second = target(gpu, { size: [4, 4] });
+  const fx = effect(gpu, { shader: TEXTURED, label: "disposedFx", bindings: { src: first } });
+  const recorded = bundle(gpu, { target: scene, label: "disposedDropBundle" }, (b) => b.draw(fx));
+  await prepare(gpu, { bundle: recorded });
+
+  recorded.dispose();
+  // A live draw must not keep a disposed bundle reachable (that is a leak, and markStale() traffic
+  // for a bundle that can never replay again). The observable half: the update lands without
+  // throwing and the bundle stays terminal.
+  expect(() => fx.bind("src", second)).not.toThrow();
+  expect(recorded.status).toBe("disposed");
+  expect(recorded.gpu).toBeUndefined();
   gpu.dispose();
 });
 

--- a/packages/vgpu-api/tests/bundle/r3-r4-mock.test.ts
+++ b/packages/vgpu-api/tests/bundle/r3-r4-mock.test.ts
@@ -1,7 +1,7 @@
 import { expect, test, vi } from "vitest";
 import { bind, createBindGroup, createBindGroupLayout } from "@vgpu/core";
 import { UniformPool } from "../../src/core.ts";
-import { init, bundle, draw, effect, frame, target } from "../../src/mock.ts";
+import { init, bundle, draw, effect, frame, prepare, target } from "../../src/mock.ts";
 
 const FLOOR = `
 struct Fog { fogDensity: f32 }
@@ -42,15 +42,21 @@ test("R3 bundle replay stays valid after JS value writes and stales on bind-grou
     b.draw(walls);
   });
 
+  // Contract #15: the native bundle is materialized by prepare(), never by construction — and only a
+  // `ready` bundle can be made stale by an identity change.
+  await prepare(gpu, { bundle: staticScene });
+
   floor.set({ fogDensity: 0.2 });
   expect(() => frame(gpu, (f) => f.pass({ target: scene }, (p) => p.bundles(staticScene)))).not.toThrow();
 
   walls.set({ detail: tex2 });
-  expect(() => frame(gpu, (f) => f.pass({ target: scene }, (p) => p.bundles(staticScene)))).toThrowError(
+  // Loud failure lives on the "throw" policy: for a stale bundle "sync" (the train's default) is the
+  // opt-in inline re-encode of the retained recording, which draws current resources, never stale ones.
+  expect(() => frame(gpu, (f) => f.pass({ target: scene }, (p) => p.bundles(staticScene)), { pendingPipelines: "throw" })).toThrowError(
     "bundle 'staticScene' is stale: binding `detail` (@group(0) @binding(0)) of draw\n" +
       "  'walls' changed resource after recording. Bundles freeze commands and bind groups.\n" +
-      "  Fix: re-record it → staticScene = bundle(gpu, { target: scene }, ...)\n" +
-      "  (re-recording is always your responsibility; the library only detects this).",
+      "  Fix: re-encode the retained recording → await prepare(gpu, { bundle: staticScene })\n" +
+      '  (or pendingPipelines: "sync" to re-encode inline; rebuild() only replaces the recorded commands).',
   );
   gpu.dispose();
 });
@@ -65,23 +71,25 @@ test("R3 bundle sampling a repeatedly resized target stales through binding iden
   });
 
   const firstBundle = recordBundle("postBundleA");
+  await prepare(gpu, { bundle: firstBundle });
   source.resize([8, 8]);
 
-  expect(() => frame(gpu, (f) => f.pass({ target: scene }, (p) => p.bundles(firstBundle)))).toThrowError(
+  expect(() => frame(gpu, (f) => f.pass({ target: scene }, (p) => p.bundles(firstBundle)), { pendingPipelines: "throw" })).toThrowError(
     "bundle 'postBundleA' is stale: binding `detail` (@group(0) @binding(0)) of draw\n" +
       "  'post' changed resource after recording. Bundles freeze commands and bind groups.\n" +
-      "  Fix: re-record it → postBundleA = bundle(gpu, { target: scene }, ...)\n" +
-      "  (re-recording is always your responsibility; the library only detects this).",
+      "  Fix: re-encode the retained recording → await prepare(gpu, { bundle: postBundleA })\n" +
+      '  (or pendingPipelines: "sync" to re-encode inline; rebuild() only replaces the recorded commands).',
   );
 
   const secondBundle = recordBundle("postBundleB");
+  await prepare(gpu, { bundle: secondBundle });
   source.resize([16, 16]);
 
-  expect(() => frame(gpu, (f) => f.pass({ target: scene }, (p) => p.bundles(secondBundle)))).toThrowError(
+  expect(() => frame(gpu, (f) => f.pass({ target: scene }, (p) => p.bundles(secondBundle)), { pendingPipelines: "throw" })).toThrowError(
     "bundle 'postBundleB' is stale: binding `detail` (@group(0) @binding(0)) of draw\n" +
       "  'post' changed resource after recording. Bundles freeze commands and bind groups.\n" +
-      "  Fix: re-record it → postBundleB = bundle(gpu, { target: scene }, ...)\n" +
-      "  (re-recording is always your responsibility; the library only detects this).",
+      "  Fix: re-encode the retained recording → await prepare(gpu, { bundle: postBundleB })\n" +
+      '  (or pendingPipelines: "sync" to re-encode inline; rebuild() only replaces the recorded commands).',
   );
   gpu.dispose();
 });

--- a/packages/vgpu-api/tests/entrypoint-parity.test.ts
+++ b/packages/vgpu-api/tests/entrypoint-parity.test.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from "node:fs";
 import { expect, test } from "vitest";
 import * as index from "../src/index.ts";
 import * as mock from "../src/mock.ts";
@@ -13,6 +14,28 @@ import * as node from "../src/node.ts";
 for (const [name, entrypoint] of [["mock", mock] as const, ["node", node] as const]) {
   test(`./${name} re-exports every value export of the root entrypoint`, () => {
     const missing = Object.keys(index).filter((exported) => !(exported in entrypoint));
+    expect(missing, `missing from ./${name}: ${missing.join(", ")}`).toEqual([]);
+  });
+}
+
+// The runtime half above cannot see a TYPE export: types are erased, so `import * as node` has no
+// key for one. A type that only leaves the root entrypoint is just as broken for a `vgpu/node` user
+// (`BundleStatus` shipped exactly like that, and `InitOptions` had been missing from ./node for
+// longer), and nothing in the build fails. Reading the export lists as text is crude but it is the
+// only check that runs without a second typecheck project, and it is the one that would have caught
+// both. The same one-directional rule applies: an entrypoint may add types, never miss one.
+function typeExportsOf(entrypoint: string): string[] {
+  const source = readFileSync(new URL(`../src/${entrypoint}`, import.meta.url), "utf8");
+  return [...source.matchAll(/export\s+type\s*\{([^}]*)\}/g)]
+    .flatMap(([, group]) => group.split(","))
+    .map((entry) => entry.trim().split(/\s+as\s+/).pop()?.trim() ?? "")
+    .filter((name) => name.length > 0);
+}
+
+for (const name of ["mock", "node"]) {
+  test(`./${name} re-exports every type export of the root entrypoint`, () => {
+    const exported = new Set(typeExportsOf(`${name}.ts`));
+    const missing = typeExportsOf("index.ts").filter((type) => !exported.has(type));
     expect(missing, `missing from ./${name}: ${missing.join(", ")}`).toEqual([]);
   });
 }

--- a/packages/vgpu-api/tests/indirect.test.ts
+++ b/packages/vgpu-api/tests/indirect.test.ts
@@ -122,11 +122,14 @@ test("bundles record and replay indirect draws end-to-end", async () => {
     b.draw(indexed, { indirect: { buffer: indexedArgs, offset: 0 } });
   });
 
+  // Contract #15, row 1: construction records the LOGICAL command list, so no native bundle encoder
+  // is opened yet. The first replay is what encodes it — inline, under the train's "sync" default.
+  expect(bundleOps).toEqual([]);
+  expect(() => frame(gpu, (f) => f.pass(colorTarget, (p) => p.bundles(recorded)))).not.toThrow();
   expect(bundleOps).toEqual([
     ["setPipeline"], ["drawIndirect", gpuBufferOf(drawArgs), 0],
     ["setPipeline"], ["setVertexBuffer", 0], ["setIndexBuffer", geo.indexBuffer, "uint16"], ["drawIndexedIndirect", gpuBufferOf(indexedArgs), 0],
   ]);
-  expect(() => frame(gpu, (f) => f.pass(colorTarget, (p) => p.bundles(recorded)))).not.toThrow();
   gpu.dispose();
   vi.restoreAllMocks();
 });

--- a/packages/vgpu-api/tests/ownership.test.ts
+++ b/packages/vgpu-api/tests/ownership.test.ts
@@ -4,6 +4,7 @@ import { bundle } from "../src/bundle.ts";
 import { compute } from "../src/compute.ts";
 import { draw } from "../src/draw.ts";
 import { effect } from "../src/effect.ts";
+import { prepare } from "../src/prepare.ts";
 import { frame } from "../src/frame.ts";
 import { init } from "../src/mock.ts";
 import { storage } from "../src/storage.ts";
@@ -539,11 +540,16 @@ test(".bind() to a different resource marks a recorded bundle stale", async () =
   const second = target(gpu, { size: [4, 4] });
   const fx = effect(gpu, { shader: TEXTURE_SHADER, label: "fx", bindings: { src: first } });
   const recorded = bundle(gpu, { target: { colors: ["rgba8unorm"] }, label: "bnd" }, (r) => r.draw(fx));
+  // Contract #15: only a `ready` bundle can go stale, and construction no longer materializes one —
+  // prepare() is what encodes the native bundle whose bind groups the identity change invalidates.
+  await prepare(gpu, { bundle: recorded });
 
   fx.bind("src", second);
 
   // Replaying a bundle whose binding identity moved must fail loudly instead of drawing `first`.
-  expect(codeOf(() => frame(gpu, (f) => f.pass({ target: screen }, (p) => p.bundles(recorded))))).toBe("VGPU-R3-BUNDLE-STALE");
+  // Asserted under the explicit "throw" policy: for a stale bundle the train's "sync" default is
+  // the sanctioned opt-in inline re-encode (contract #15, replay sub-table), not a silent stale draw.
+  expect(codeOf(() => frame(gpu, (f) => f.pass({ target: screen }, (p) => p.bundles(recorded)), { pendingPipelines: "throw" }))).toBe("VGPU-R3-BUNDLE-STALE");
   gpu.dispose();
 });
 

--- a/packages/vgpu-api/tests/prepare.test.ts
+++ b/packages/vgpu-api/tests/prepare.test.ts
@@ -408,15 +408,20 @@ test("prepare({ bundle }) re-encodes a bundle made stale by a binding identity c
   drawable.set({ data: storage(gpu, 16) });
   const recorded = bundle(gpu, { target: colorTarget, label: "forest" }, (r) => r.draw(drawable));
   const mock = getMockGPUDeviceInstrumentation(gpu.device.gpu);
-  const encodersAfterRecord = mock.calls.createRenderBundleEncoder;
+  // Contract #15, row 1: construction materializes nothing, so the first prepare() is what encodes
+  // the native bundle an identity change can then make stale.
+  expect(recorded.gpu).toBeUndefined();
+  await prepare(gpu, { bundle: recorded });
+  const encodersAfterPrepare = mock.calls.createRenderBundleEncoder;
   const nativeBefore = recorded.gpu;
 
   drawable.set({ data: storage(gpu, 16) });
-  expect(caught(() => frame(gpu, (f) => f.pass(colorTarget, (p) => p.bundles(recorded))))?.code).toBe("VGPU-R3-BUNDLE-STALE");
+  expect(recorded.status).toBe("stale");
+  expect(caught(() => frame(gpu, (f) => f.pass(colorTarget, (p) => p.bundles(recorded)), { pendingPipelines: "throw" }))?.code).toBe("VGPU-R3-BUNDLE-STALE");
 
   const prepared = await prepare(gpu, { bundle: recorded });
 
-  expect(mock.calls.createRenderBundleEncoder).toBe(encodersAfterRecord + 1);
+  expect(mock.calls.createRenderBundleEncoder).toBe(encodersAfterPrepare + 1);
   expect(prepared.bundle).toBe(recorded);
   expect(prepared.gpu).toBe(recorded.gpu);
   expect(recorded.gpu).not.toBe(nativeBefore);
@@ -424,7 +429,7 @@ test("prepare({ bundle }) re-encodes a bundle made stale by a binding identity c
   gpu.dispose();
 });
 
-test("prepare({ bundle }) on a fresh bundle is a no-op that returns the recorded native bundle", async () => {
+test("prepare({ bundle }) materializes a fresh bundle, and preparing it again is free", async () => {
   const gpu = await init();
   const colorTarget = target(gpu, { size: [4, 4] });
   const drawable = draw(gpu, { shader: WGSL, label: "fresh" });
@@ -434,9 +439,18 @@ test("prepare({ bundle }) on a fresh bundle is a no-op that returns the recorded
 
   const prepared = await prepare(gpu, { bundle: recorded });
 
+  // prepare() is the spelling that materializes the native bundle (contract #15, row 2) — it is no
+  // longer a no-op on a fresh bundle, because construction no longer encoded one.
   expect(prepared.gpu).toBe(recorded.gpu);
   expect(prepared.signature).toEqual(normalizeSignature(colorTarget));
-  expect(mock.calls.createRenderBundleEncoder).toBe(encoders);
+  expect(mock.calls.createRenderBundleEncoder).toBe(encoders + 1);
+  expect(recorded.status).toBe("ready");
+
+  // Contract #7 (bundle half): re-preparing a ready bundle creates no pipeline and re-encodes nothing.
+  const again = await prepare(gpu, { bundle: recorded });
+
+  expect(again.gpu).toBe(prepared.gpu);
+  expect(mock.calls.createRenderBundleEncoder).toBe(encoders + 1);
   gpu.dispose();
 });
 


### PR DESCRIPTION
Closes the bundle half of #320: contract **#15**, the `Bundle` state machine.

`bundle()` used to compile pipelines and encode the native `GPURenderBundle` inline, in the hot path, at construction. It does not any more: **construction only records the logical command list and is always born `pending-pipelines`** (even when every pipeline it names happens to be hot — the contract says "always", and a test pins the textual always). `prepare(gpu, [{ bundle }])` is the one spelling that materializes it: genuinely async now, it warms every recorded draw through `pipelineForAsync` and only then encodes, so it hits the store's ready path and creates zero pipelines of its own (contract #7's bundle half). Recording needs only formats, never `getCurrentTexture()`, so `bundle()` outside `frame()` stays legal and construction never throws for readiness.

The rest of the surface: `bundle.status` (frozen 5-state union), `bundle.error` (retained failure — and `prepare()` always retries a failed bundle, there is no "retryable failure" classification), `rebuild(cb)` (replaces the recording synchronously, never compiles, never throws for readiness, lands on `stale` or on `pending-pipelines` if the new recording introduces an uncompiled combination), `dispose()` (terminal, idempotent), and `Bundle.gpu: GPURenderBundle | undefined` — the `Draw.gpu` pattern, defined only once the native resource exists.

Replaying a non-`ready` bundle follows the one `pendingPipelines` chain (call site → frame → gpu) through `FrameBundleProtocol.resolveForReplay`, so `frame.ts` still knows nothing about `BundleStatus`. There is **one test per row** of the transition table, plus 4 adversarial races (`.bind()`, `rebuild()`, `dispose()` landing during an in-flight `prepare()`, and an identity update that must not be lost by the encode that follows it).

One row is worth reading twice, because it changes observable behavior: under **`"sync"`** a `stale` bundle is **re-encoded inline** instead of throwing. That is the literal contract, and it trades a loud failure for a silent heal — so the load-bearing invariant is not the status but that **stale content is never drawn**. The QA verified that by content rather than by status (comparing the `GPUBindGroup` the bundle encoder receives against the one a plain `p.draw()` of the same drawable gets in the same state): the re-encode binds the *current* resource, and no policy ever executes the stale native bundle. The old R3 tests that expected a throw now ask for `"throw"` explicitly.

`contract #16` (slot offsets frozen at record time) is a documented skip: WebGPU freezes `setBindGroup` offsets when the encoder records them, so it holds for free once `uniformArray`/slots land in T04-07 — there is no slot mechanism on this branch to exercise.

## What the adversarial QA found, and what I did

**1. `BundleStatus` never left the root entrypoint.** `./node` re-exported `Bundle`, `BundleOptions` and `BundleRecorder` but not the status type a `vgpu/node` user needs to write `(s: BundleStatus) => …`. Same defect class `uniform()` shipped with. The parity test that already existed could not catch it: it compares `Object.keys(import * as …)`, and a type has no runtime key. It now compares the **type-export lists** too — and that retroactively caught a second, **pre-existing** gap: **`InitOptions` had been missing from `./node` since before this branch**. It goes out in the same line.

**2. The draw→bundle back-reference registry was one-way.** `registerDrawBundle` had no counterpart: `createBundleRegistry().delete()` existed with **zero call sites**. So `rebuild()` dropping a draw only forgot it on the bundle's side — the draw kept its back-reference and kept calling `markStale()` on a bundle that no longer encodes it: a **permanent spurious `stale` that no `prepare()` could clear**, because the re-encode does not name that draw. It also leaked, keeping a disposed bundle reachable from every live draw that had recorded it. Fixed with `unregisterDrawBundle(draw, bundle)` (wiring over the registry's existing `delete`), called for the draws `rebuild()` drops and for all of them in `dispose()`.

This deliberately spends the ticket's "one new method in `draw.ts`" budget a second time. The alternative was shipping a state machine that stales itself forever; correctness wins over a lane boundary, and the QA agreed.

### The retention probe, and a false positive worth knowing about

The QA's leak probe kept reporting a disposed bundle as retained *after* the fix. It was **an artefact of the probe's own scoping**, and it took an A/B to prove:

| shape | result |
| --- | --- |
| bundle created in a **block scope** of the test body, with an `await` inside it (the probe's shape) | `retained=true` |
| bundle created in **its own function**, only the `WeakRef` escaping | `retained=false` |

V8 keeps block-scoped bindings alive in the enclosing async context, so the bundle reads as retained even when the registry is clean. Causality confirmed from the other side: commenting out *only* the `dispose()` unregister loop flips shape B back to `retained=true`. The QA's growth probe had agreed all along (2000 create+dispose cycles over the same draw: 0/4 samples alive, `set()` cost flat at 0.15ms → 0.08ms). `droppedBundleStillRetained=true` is correct by design, by the way: a bundle that was merely dropped *is* retained by its draws' registry — that is the R3 staleness mechanism.

That probe now lives in the suite (`tests/bundle/bundle-retention.test.ts`, guarded by `typeof gc() !== "function"`, the shape `packages/render`'s leak-detector already uses), with the trap written down in the file. **Note for whoever touches `dispose()` next**, because the QA is right about this: the `dispose()` unit test is *tautological* — it asserts what `dispose()` sets (status `disposed`, every replay throwing) and it passed happily while the leak was there. The GC probe is the only net under that fix, and it is skipped unless you run with `--expose-gc`.

## Mutation testing

The QA harness runs 31 mutants of the state machine. **29 killed.** Two survive and are **equivalent mutants, not gaps** — audited through their readers rather than waved away:

- *"`rebuild()` does not clear the retained error"*: `bundle.error` is gated on `status === "failed"` (contract #15: error is defined only while failed), so a retained `#error` under any other status has no public reader, and the next failure overwrites it.
- *"a materialize does not clear the retained stale event"*: the event is only ever read to build the message of a `stale` bundle, and reaching `stale` again requires a fresh `markStale()` that overwrites it (last-wins). `rebuild()` clears it on its own path.

Two other survivors *were* real gaps in my suite and are now pinned: the encode's `pendingPipelines` hand-off to the recorded draws (invisible while the train's default is `"sync"`, so the test inits the gpu with `"throw"` and replays with an explicit frame `"sync"`), and the empty-list early return in `p.bundles()` (only observable when *every* bundle of the call is skipped — `executeBundles([])` is a native call for nothing, every frame of a loop that is waiting for its pipelines; the test also spies the real `executeBundles`, since the mock's no-op stub hid a hole in the list).

## Pre-existing: `recordingDepth` (#334)

An identity change performed **inside** a recording closure is swallowed by the global `recordingDepth` guard, and the bundle replays without throwing: `[B1-suppressed] replayAfterInsideClosureBind=NO-THROW executedBundles=1 VERDICT=STALE-CONTENT-DRAWN`.

This is **pre-existing, and verified identical on `b4d39016` with the same probe** — not introduced here, and out of this ticket's scope. It must not be read as a minor detail either, because **this branch widens the window**: the recording closure used to run once, at construction, and now it also runs at replay time under `"sync"` (and on every `prepare()`), so there are strictly more moments during which an identity change can be swallowed. Tracked in #334.

## Budgets

`#333` (unified frame) landed first, so this branch merged `next/0.4` and **both sides were rebuilt and re-measured** — two branches that each fit their own budget do not fit the union's. The one conflict was the budget block itself, resolved as the union (max per entry) and then measured:

| entry | base `8d08d18f` | merged | union budget | new budget |
| --- | --: | --: | --: | --: |
| `vgpu` [client, hard] | 42403 | 43220 | 42496 | **43520** |
| `full-root` [client, hard] | 42499 | 43304 | 43008 | **43520** |
| `vgpu/node` [tooling] | 42568 | 43388 | 43008 | **43520** |
| `vgpu/mock` [tooling] | 42490 | 43308 | 42496 | **43520** |

**+817 B gzip on the hard `vgpu` client entry**, in line with the +851 B this branch cost on `b4d39016` alone (a little less here — part of it is code `#333` already pulled in). All four land on the next 512 B multiple strictly above their measurement, the convention `bundle-check --update` uses, leaving 300/216/132/212 B of headroom. Every other entry keeps `#333`'s numbers, which already covered it. The ~800 B is the state machine itself, after a shrink pass that merged the two recorder classes (tracking and encoding) into one and dropped the now-dead `assertReplayable`.

The source merge was clean, including the two files both branches touch: `#333` owns `Frame`/`FrameRunner`, this branch owns `FramePass.bundles()` and `FrameBundleProtocol` — exactly the lane split the tickets drew.

## Gates (on the merge result)

- `pnpm typecheck` (`tsc -b` + fixtures): clean
- `pnpm test`: **2052 passed | 141 skipped (255 files)** — both lanes' suites
- `pnpm bundle-check`: exit 0, no warnings
- QA harness: 29/31 mutants killed, `T7b afterBindOfDROPPEDdraw=ready`, retention `false` in the correct probe shape
