### PR TITLE
feat(api): device loss is terminal — gpu.lost, loops stop, the whole graph refuses

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -45,7 +45,7 @@
     "build": "tsc -b"
   },
   "vgpuBundleAudience": "tooling",
-  "vgpuBundleBudgetGzipBytes": 35328,
+  "vgpuBundleBudgetGzipBytes": 36864,
   "vgpuBundleBudgetNote": "Gzip ceilings use 512-byte granularity: each budget is the next 512-byte multiple strictly above the measured size. Regenerate with `pnpm bundle-check --update`. vgpuBundleAudience/vgpuExportBundleAudiences select the gate: \"client\" entries ship to browsers and fail on any byte over budget; \"tooling\" entries (loaders, Node runtime, CLI, package tarballs) only warn until growth passes vgpuBundleBudgetGrowthThreshold (default 5%). Tarballs measure published dist bytes with sourcemap sourcesContent stripped and *.docs.md excluded.",
   "dependencies": {
     "@vgpu/wgsl": "workspace:*"

--- a/packages/core/src/device.ts
+++ b/packages/core/src/device.ts
@@ -27,6 +27,16 @@ export class Device {
   private state: DeviceState = "alive";
   private lossInfo: GPUDeviceLostInfo | undefined;
   private observeLoss = true;
+  /**
+   * Resolves **only** on a real device loss (design §9): the same transition that flips `state` to
+   * `"lost"`, never a deliberate `destroy()`/`dispose()`. WebGPU resolves the native `GPUDevice.lost`
+   * with reason `"destroyed"` when the device is destroyed, and `observeLoss` (cleared by `destroy()`
+   * before anything else) is what keeps that resolution from reaching here. A device that is disposed,
+   * or whose native handle exposes no `lost` promise at all, leaves this pending forever — pending is
+   * the honest answer to "was this device lost?" when it was not.
+   */
+  readonly lost: Promise<GPUDeviceLostInfo | undefined>;
+  private resolveLost: ((info: GPUDeviceLostInfo | undefined) => void) | undefined;
 
   constructor(gpu: GPUDevice, adapterInfo?: GPUAdapterInfo | null, options?: DeviceOptions);
   constructor(
@@ -41,12 +51,16 @@ export class Device {
     this.isCompatibilityMode = opts.isCompatibilityMode ?? false;
     this.queue = new (Queue as unknown as new (gpu: GPUQueue, guard: (where: string) => void) => Queue)(gpu.queue, (where) => this.#assertUsable(where));
     this.readback = new Readback(gpu);
+    this.lost = new Promise<GPUDeviceLostInfo | undefined>((resolve) => { this.resolveLost = resolve; });
     const lost = gpu.lost;
     if (lost && typeof (lost as PromiseLike<GPUDeviceLostInfo>).then === "function") {
       void Promise.resolve(lost).then((info) => {
         if (!this.observeLoss || this.state !== "alive") return;
         this.lossInfo = info;
         this.state = "lost";
+        // Same callback, same guard: `lost` is the existing transition made observable, not a second
+        // subscription that could disagree with `state` about whether this device was lost.
+        this.resolveLost?.(info);
       }, () => undefined);
     }
   }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -13,8 +13,8 @@ export { VGPUError, ValidationError, unsupportedFeaturesError, validateRequiredF
 export { bind, createBindGroup, createBindGroupLayout, createPipelineLayout, createSampler } from "./bind.ts";
 export { attachBindGroupLayoutMetadata, attachBindGroupMetadata, bindGroupLayoutMetadata, bindGroupMetadataFor } from "./bind-group-metadata.ts";
 export type { BindGroupLayoutMetadata, BindGroupMetadata } from "./bind-group-metadata.ts";
-export { createMockGPUDevice, getMockGPUDeviceInstrumentation } from "./mock-gpu.ts";
-export type { MockGPUDeviceInstrumentation, MockGPUDeviceOptions } from "./mock-gpu.ts";
+export { createMockGPUDevice, getMockGPUDeviceInstrumentation, loseMockGPUDevice } from "./mock-gpu.ts";
+export type { MockGPUDeviceInstrumentation, MockGPUDeviceLossOptions, MockGPUDeviceOptions } from "./mock-gpu.ts";
 export type { BufferPingPong, PingPongCore, TexturePingPong } from "./ping-pong.ts";
 export type {
   BufferOptions,

--- a/packages/core/src/mock-gpu.ts
+++ b/packages/core/src/mock-gpu.ts
@@ -31,18 +31,48 @@ export interface MockGPUDeviceInstrumentation {
 }
 
 const mockInstrumentationKey = "__vgpuMockInstrumentation";
+const mockLossKey = "__vgpuMockLoss";
 
-type InstrumentedGPUDevice = GPUDevice & { [mockInstrumentationKey]?: MockGPUDeviceInstrumentation };
+type MockLossResolver = (info: GPUDeviceLostInfo) => void;
+type InstrumentedGPUDevice = GPUDevice & { [mockInstrumentationKey]?: MockGPUDeviceInstrumentation; [mockLossKey]?: MockLossResolver };
 
 export interface MockGPUDeviceOptions {
   /** Features the mock device reports through GPUDevice.features. Defaults to none, matching a device requested without requiredFeatures. */
   readonly features?: readonly GPUFeatureName[];
 }
 
+/** How a simulated loss describes itself, mirroring `GPUDeviceLostInfo`. */
+export interface MockGPUDeviceLossOptions {
+  /** Defaults to `"unknown"` — a REAL loss. `"destroyed"` is what `device.destroy()` reports by itself. */
+  readonly reason?: GPUDeviceLostReason;
+  readonly message?: string;
+}
+
+/**
+ * Simulates a **real** device loss on a mock device: the native `GPUDevice.lost` promise resolves
+ * on its own, exactly as a driver reset or a TDR does — not as a consequence of `destroy()`.
+ *
+ * Genuinely async, like the real thing: the returned promise settles after the native promise did,
+ * so a test can await it (or `gpu.lost`) instead of guessing microtask counts. Resolving twice is a
+ * no-op — a device is lost once.
+ */
+export function loseMockGPUDevice(device: GPUDevice, options: MockGPUDeviceLossOptions = {}): Promise<GPUDeviceLostInfo> {
+  const resolve = (device as InstrumentedGPUDevice)[mockLossKey];
+  if (!resolve) throw new Error("GPUDevice was not created by createMockGPUDevice()");
+  const info = { reason: options.reason ?? "unknown", message: options.message ?? "" } as GPUDeviceLostInfo;
+  resolve(info);
+  return Promise.resolve(device.lost);
+}
+
 export function createMockGPUDevice(options: MockGPUDeviceOptions = {}): GPUDevice {
   const instrumentation = createMockGPUDeviceInstrumentation();
+  let loseDevice!: MockLossResolver;
+  // One promise per device, resolved at most once: WebGPU's `lost` never rejects and never resets.
+  const lost = new Promise<GPUDeviceLostInfo>((resolve) => { loseDevice = resolve; });
   const device: InstrumentedGPUDevice = {
     [mockInstrumentationKey]: instrumentation,
+    [mockLossKey]: loseDevice,
+    lost,
     limits: createMockSupportedLimits(),
     features: createMockSupportedFeatures(options.features),
     createBuffer(desc: GPUBufferDescriptor): MockGPUBuffer {
@@ -178,7 +208,11 @@ export function createMockGPUDevice(options: MockGPUDeviceOptions = {}): GPUDevi
       // Mock command encoder: only copy/render/finish methods used by core/render are implemented.
       } as unknown as GPUCommandEncoder;
     },
-    destroy() {},
+    destroy() {
+      // Faithful to WebGPU: destroy() resolves `lost` with reason "destroyed". It is NOT a real loss,
+      // and vgpu must suppress it (Device.destroy stops observing before it gets here).
+      loseDevice({ reason: "destroyed", message: "" } as GPUDeviceLostInfo);
+    },
     queue: {
       submit() {},
       writeBuffer(buffer: GPUBuffer, offset: number, data: BufferSource, dataOffset = 0, size?: number) {

--- a/packages/core/tests/device-loss.test.ts
+++ b/packages/core/tests/device-loss.test.ts
@@ -1,0 +1,73 @@
+import { expect, test } from "vitest";
+import { createMockGPUDevice, Device, loseMockGPUDevice } from "../src/index.ts";
+
+/**
+ * Design §9 "Device loss is terminal", core half: a REAL device loss (the native `GPUDevice.lost`
+ * promise resolving on its own) is observable through `device.lost`, while a deliberate
+ * `dispose()`/`destroy()` — which also resolves the native promise, with reason `"destroyed"` —
+ * must NEVER resolve it. Loss and disposal are two spellings for two different semantics.
+ */
+
+test("device.lost resolves with the native GPUDeviceLostInfo on a real loss, with no intermediate call", async () => {
+  const device = new Device(createMockGPUDevice());
+
+  void loseMockGPUDevice(device.gpu, { reason: "unknown", message: "simulated loss" });
+  const info = await device.lost;
+
+  expect(info?.reason).toBe("unknown");
+  expect(info?.message).toBe("simulated loss");
+});
+
+test("every operation on a lost device throws VGPU-DEVICE-LOST carrying the loss info as cause", async () => {
+  const device = new Device(createMockGPUDevice());
+  const info = await loseMockGPUDevice(device.gpu, { reason: "unknown", message: "simulated loss" });
+  await device.lost;
+
+  expect(() => device.createBuffer({ size: 16, usage: ["storage"] })).toThrow(expect.objectContaining({ code: "VGPU-DEVICE-LOST", where: "Device.createBuffer" }));
+  expect(() => device.createTexture({ size: [2, 2], format: "rgba8unorm", usage: ["render_attachment"] })).toThrow(expect.objectContaining({ code: "VGPU-DEVICE-LOST" }));
+  try { device.createShader("@fragment fn main() -> @location(0) vec4f { return vec4f(1); }"); }
+  catch (error) { expect((error as { cause?: unknown }).cause).toBe(info); }
+});
+
+test("device.lost never resolves after a deliberate destroy(), even though the native promise resolves with \"destroyed\"", async () => {
+  const device = new Device(createMockGPUDevice());
+
+  device.destroy();
+  // The mock resolves its native `lost` on destroy(), exactly like a real device does.
+  await Promise.resolve();
+
+  expect(await settledWithin(device.lost, 25)).toBe("pending");
+  expect(() => device.createBuffer({ size: 16, usage: ["storage"] })).toThrow(expect.objectContaining({ code: "VGPU-DEVICE-DISPOSED" }));
+});
+
+test("destroy() after a real loss stays idempotent and does not re-destroy the native device", async () => {
+  let destroyed = 0;
+  const gpu = createMockGPUDevice();
+  const nativeDestroy = gpu.destroy.bind(gpu);
+  gpu.destroy = () => { destroyed += 1; nativeDestroy(); };
+  const device = new Device(gpu);
+
+  void loseMockGPUDevice(gpu, { reason: "unknown" });
+  await device.lost;
+  expect(() => device.destroy()).not.toThrow();
+  expect(() => device.destroy()).not.toThrow();
+
+  // The device is already gone: destroying it again is the one call vgpu must not make.
+  expect(destroyed).toBe(0);
+  expect(() => device.createBuffer({ size: 16, usage: ["storage"] })).toThrow(expect.objectContaining({ code: "VGPU-DEVICE-DISPOSED" }));
+});
+
+test("a device whose native handle has no `lost` promise simply never resolves device.lost", async () => {
+  const gpu = createMockGPUDevice() as GPUDevice & { lost?: unknown };
+  delete gpu.lost;
+  const device = new Device(gpu);
+
+  expect(await settledWithin(device.lost, 25)).toBe("pending");
+});
+
+async function settledWithin(promise: Promise<unknown>, ms: number): Promise<"settled" | "pending"> {
+  return Promise.race([
+    promise.then(() => "settled" as const, () => "settled" as const),
+    new Promise<"pending">((resolve) => setTimeout(() => resolve("pending"), ms)),
+  ]);
+}

--- a/packages/vgpu-api/package.json
+++ b/packages/vgpu-api/package.json
@@ -92,7 +92,7 @@
   },
   "vgpuExportBundleBudgetsGzipBytes": {
     ".": 44032,
-    "./node": 44032,
+    "./node": 44544,
     "./mock": 44032,
     "./scene": 12800,
     "./client": 512,
@@ -105,7 +105,7 @@
     "init-only": 1536,
     "effect-only": 28672,
     "triangle-low-level": 31744,
-    "draw-recipe-box": 32768,
+    "draw-recipe-box": 33280,
     "full-root": 44032
   },
   "vgpuSceneBundleBudgetNote": "The scene barrel retains all recipe builders after the geometry redesign; direct primitive imports retain only their selected mesh, as the experience fixtures assert."

--- a/packages/vgpu-api/src/bundle.ts
+++ b/packages/vgpu-api/src/bundle.ts
@@ -6,6 +6,7 @@ import { normalizeSignature, signatureKeyOf, validateTargetSignature } from "./p
 import { bundleBlendConstantError, bundleDisposedError, bundleStencilReferenceError, compileFailedError, pipelinePendingError, surfaceNotInFrameError, VGPUError } from "./errors.ts";
 import { isFrameActive, isSurface } from "./surface.ts";
 import { FRAME_BUNDLE, type FrameBundleProtocol } from "./frame-protocols.ts";
+import { assertDeviceUsable } from "./lifecycle.ts";
 import { liveKernel } from "./live-kernel.ts";
 import type { PendingPipelines } from "./pending-pipelines.ts";
 import type { Gpu } from "./kernel.ts";
@@ -33,6 +34,7 @@ export function bundle(gpu: Gpu, opts: BundleOptions, record: (recorder: BundleR
     pendingPipelinesDefault: () => kernel.pendingPipelinesDefault(),
     reportError: (error) => { void kernel.reportError(error); },
     trackSettled: (promise) => { void kernel.trackDelivery(promise); },
+    assertDeviceUsable: (where) => assertDeviceUsable(kernel.device, where),
   }, opts, record);
 }
 
@@ -124,6 +126,12 @@ export interface BundleHost {
   reportError?(error: VGPUError): void;
   /** Joins `gpu.settled()`: background preparation started by a `"skip"` replay is observable. */
   trackSettled?(promise: Promise<unknown>): void;
+  /**
+   * Device-state guard of the owning gpu (contract #19): throws `VGPU-DEVICE-LOST` after a real loss
+   * and `VGPU-DEVICE-DISPOSED` after `gpu.dispose()`. Optional like the rest of this host, so a bundle
+   * built over a hand-made host (tests) keeps working — the guard is a capability, not a requirement.
+   */
+  assertDeviceUsable?(where: string): void;
 }
 
 let nextBundleId = 1;
@@ -205,6 +213,11 @@ class RecordedBundle implements Bundle, BundleBackReference {
    */
   prepareCombination(): Promise<GPURenderBundle> {
     if (this.#status === "disposed") return Promise.reject(bundleDisposedError(this.id, "prepare"));
+    // A lost/disposed device beats every readiness state, including the ready fast path below: there is
+    // nothing to compile against and nothing to replay. Rejected, not thrown, so the async entry point
+    // stays async for its callers.
+    try { this.host.assertDeviceUsable?.(`bundle '${this.id}' prepare`); }
+    catch (error) { return Promise.reject(error); }
     // prepare() on a ready bundle is a no-op: no new pipeline, no re-encode (contract #7, bundle half).
     if (this.#status === "ready" && this.#gpu) return Promise.resolve(this.#gpu);
     if (this.#preparing) return this.#preparing;
@@ -222,6 +235,9 @@ class RecordedBundle implements Bundle, BundleBackReference {
       const settled = await Promise.allSettled([...this.#draws].map((draw) => draw.pipelineForAsync(this.signature)));
       // dispose() is terminal, including for work that was already in flight when it landed.
       if (this.#status === "disposed") throw bundleDisposedError(this.id, "prepare");
+      // So is a device loss that landed mid-compile: encoding the bundle now would hand back a handle
+      // for a dead device. Thrown raw (not through #fail): the bundle did not fail, the device did.
+      this.host.assertDeviceUsable?.(`bundle '${this.id}' prepare`);
       // rebuild() replaced the recording mid-flight: prepare() prepares whatever recording is
       // current when it finishes, so warm the new one instead of encoding the old command list.
       if (this.#generation !== generation) continue;
@@ -244,6 +260,8 @@ class RecordedBundle implements Bundle, BundleBackReference {
   resolveForReplay(target: Target, policy?: PendingPipelines): GPURenderBundle | undefined {
     // Terminal beats policy: a disposed bundle has no native bundle to replay under any of them.
     if (this.#status === "disposed") throw bundleDisposedError(this.id, "replay");
+    // Same for the device behind it — a lost device cannot execute even an already-encoded bundle.
+    this.host.assertDeviceUsable?.(`bundle '${this.id}' replay`);
     // A different target signature is a usage error, not a readiness state: it is checked before the
     // policy and no policy can turn it into a skip or an inline re-encode.
     this.#assertSignature(target);
@@ -266,6 +284,7 @@ class RecordedBundle implements Bundle, BundleBackReference {
 
   rebuild(record: (recorder: BundleRecorder) => void): void {
     if (this.#status === "disposed") throw bundleDisposedError(this.id, "rebuild");
+    this.host.assertDeviceUsable?.(`bundle '${this.id}' rebuild`);
     this.#generation += 1;
     // The retained error belonged to the recording being replaced, so it goes away with it.
     this.#error = undefined;

--- a/packages/vgpu-api/src/kernel.ts
+++ b/packages/vgpu-api/src/kernel.ts
@@ -57,6 +57,19 @@ export interface Gpu {
   readonly gpu: GPUDevice;
   /** True once `dispose()` ran. Reads stay legal; new work does not. */
   readonly disposed: boolean;
+  /**
+   * Resolves **only** when this device is really lost (design §9, contract #19) — a driver reset, a
+   * TDR, a tab evicted from the GPU process — with the native `GPUDeviceLostInfo` when the platform
+   * gives one. A deliberate `dispose()` leaves it pending forever: disposal is observed through
+   * `disposed`, loss through this promise, and there is deliberately no `onLost()` callback (one
+   * spelling per semantic).
+   *
+   * A real loss is terminal and graph-wide: by the time this resolves, every frame loop this gpu owns
+   * is stopped, and every operation on any object of this graph throws `VGPU-DEVICE-LOST`. vgpu never
+   * restores, reattaches or re-points anything at a replacement device — recovery is
+   * `init()` again, from scratch.
+   */
+  readonly lost: Promise<GPUDeviceLostInfo | undefined>;
   onError(cb: GpuErrorListener): () => void;
   settled(): Promise<void>;
   dispose(): void;
@@ -112,6 +125,13 @@ export interface Kernel {
   peekService<T>(token: ServiceToken<T>): T | undefined;
   /** Registers a teardown callback in `phase`; returns the release that unregisters it. */
   own(phase: OwnershipPhase, disposer: Disposer): Release;
+  /**
+   * A real device loss landed: stop the `scheduler` phase (the rAF/timer loops this gpu owns) and
+   * nothing else. Resources and services are deliberately left alone — a lost device has nothing to
+   * release, and every object of the graph is already terminal through `Device.assertUsable`.
+   * `disposed` stays `false`: loss is not disposal.
+   */
+  notifyDeviceLost(): void;
   addErrorListener(cb: GpuErrorListener): Release;
   /** Delivers asynchronously to the listeners (or `console.error`). Never rejects, never throws. */
   reportError(error: VGPUError): Promise<void>;
@@ -212,15 +232,21 @@ class KernelImpl implements Kernel {
     await Promise.allSettled(snapshot);
   }
 
+  notifyDeviceLost(): void {
+    this.#runPhase("scheduler");
+  }
+
+  #runPhase(phase: OwnershipPhase): void {
+    const set = this.#owners.get(phase)!;
+    // Copy: a disposer usually calls its own release(), mutating the set while we walk it.
+    for (const disposer of [...set]) disposer();
+    set.clear();
+  }
+
   dispose(): void {
     if (this.#disposed) return;
     this.#disposed = true;
-    for (const phase of PHASES) {
-      const set = this.#owners.get(phase)!;
-      // Copy: a disposer usually calls its own release(), mutating the set while we walk it.
-      for (const disposer of [...set]) disposer();
-      set.clear();
-    }
+    for (const phase of PHASES) this.#runPhase(phase);
     this.#services.clear();
     this.#settledSources.clear();
     this.#errorListeners.clear();
@@ -231,10 +257,16 @@ class KernelImpl implements Kernel {
 /** Builds the minimal `Gpu` for an already-created device and registers its kernel. */
 export function attachKernel(device: Device, opts: Pick<InitOptions, "pendingPipelines"> = {}): Gpu {
   const kernel = new KernelImpl(device, opts.pendingPipelines ?? DEFAULT_PENDING_PIPELINES);
+  // One reaction to the loss, wired here and not per consumer: the loops are stopped inside this
+  // handler, so anyone awaiting `gpu.lost` already observes a graph that stopped ticking. `device.lost`
+  // stays pending after a deliberate `dispose()` (core suppresses it), which is exactly why no extra
+  // "was it disposed?" check is needed here.
+  const lost = device.lost.then((info) => { kernel.notifyDeviceLost(); return info; });
   const gpu: Gpu = {
     device,
     gpu: device.gpu,
     get disposed(): boolean { return kernel.disposed; },
+    lost,
     onError: (cb: GpuErrorListener) => kernel.addErrorListener(cb),
     settled: () => kernel.settled(),
     dispose: () => { kernel.dispose(); },

--- a/packages/vgpu-api/src/live-kernel.ts
+++ b/packages/vgpu-api/src/live-kernel.ts
@@ -10,18 +10,26 @@
  * feature families, and so the guard costs one tiny function in any bundle that uses a factory.
  */
 import { VGPUError } from "./errors.ts";
+import { assertDeviceUsable } from "./lifecycle.ts";
 import { kernelOf, type Gpu, type Kernel, type Release } from "./kernel.ts";
 import type { QueryHostOptions } from "./query-ring.ts";
 
 /**
- * Kernel of `gpu`, or a thrown error when the gpu is disposed (`VGPU-GPU-DISPOSED`) or was not
- * created by `init()` (`VGPU-GPU-FOREIGN`, from `kernelOf`).
+ * Kernel of `gpu`, or a thrown error when the gpu is disposed (`VGPU-GPU-DISPOSED`), its device was
+ * really lost (`VGPU-DEVICE-LOST`) or it was not created by `init()` (`VGPU-GPU-FOREIGN`, from
+ * `kernelOf`).
+ *
+ * The loss check is the factory half of contract #19: a real device loss is terminal and graph-wide,
+ * so building anything new on that gpu — a surface, a target, a bundle, a `prepare()` batch — must
+ * fail at the door with the device-lost error, instead of handing back a doomed handle. It is NOT
+ * `disposed`: `gpu.dispose()` and a real loss stay two distinct signals with two distinct codes.
  *
  * @internal
  */
 export function liveKernel(gpu: Gpu, where: string): Kernel {
   const kernel = kernelOf(gpu);
   if (kernel.disposed) throw gpuDisposedError(where);
+  assertDeviceUsable(kernel.device, where);
   return kernel;
 }
 

--- a/packages/vgpu-api/src/surface.ts
+++ b/packages/vgpu-api/src/surface.ts
@@ -9,6 +9,7 @@ import {
   surfaceResizeReentrantError,
 } from "./errors.ts";
 import { frameState } from "./frame-state.ts";
+import { assertDeviceUsable } from "./lifecycle.ts";
 import { liveKernel } from "./live-kernel.ts";
 import { serviceToken, type Gpu, type Kernel } from "./kernel.ts";
 
@@ -184,6 +185,7 @@ export class CanvasSurface implements Surface {
    */
   get color(): Texture {
     this.#assertLive();
+    assertDeviceUsable(this.device, "surface.color");
     return new Texture(this.device, this.context.getCurrentTexture(), {
       size: this.size,
       format: this.format,
@@ -192,7 +194,7 @@ export class CanvasSurface implements Surface {
     }, "external");
   }
   get colors(): readonly [Texture, ...Texture[]] { return [this.color]; }
-  get depth(): Texture | undefined { this.#assertLive(); this.#syncAttachments(); return this.#depthTexture; }
+  get depth(): Texture | undefined { this.#assertLive(); assertDeviceUsable(this.device, "surface.depth"); this.#syncAttachments(); return this.#depthTexture; }
   get sampleCount(): 1 | 4 { this.#assertLive(); return this.#sampleCount; }
   /**
    * Pipeline signature of this surface, derived from its configuration alone: the format fixed by
@@ -215,12 +217,16 @@ export class CanvasSurface implements Surface {
 
   resize(size: readonly [number, number]): void {
     this.#assertLive();
+    assertDeviceUsable(this.device, "surface.resize");
     if (this.#notifying) throw surfaceResizeReentrantError(this.options.label);
     this.#applyResize(sanitizeSize(size), this.#currentDpr, true);
   }
 
   applyAutoResize(): void {
     if (this.#isDisposed || !this.autoResize || !this.layoutBacked) return;
+    // Reached from the frame clock, not from user code: a lost device stops the auto-resize the same
+    // way it stops everything else, instead of quietly reconfiguring a canvas whose device is gone.
+    assertDeviceUsable(this.device, "surface.applyAutoResize");
     const nextDpr = effectiveDpr(this.options.dpr);
     const nextSize = layoutCanvasSize(this.canvas, nextDpr);
     this.#applyResize(nextSize, nextDpr, true);
@@ -228,6 +234,7 @@ export class CanvasSurface implements Surface {
 
   onResize(cb: (event: SurfaceResizeEvent) => void): () => void {
     this.#assertLive();
+    assertDeviceUsable(this.device, "surface.onResize");
     this.#callbacks.add(cb);
     this.#notifying = true;
     resizeCallbackDepth += 1;
@@ -236,14 +243,15 @@ export class CanvasSurface implements Surface {
     return () => { this.#callbacks.delete(cb); };
   }
 
-  async read(): Promise<Uint8Array> { this.#assertLive(); return this.color.read(); }
-  async readFloats(): Promise<Float32Array> { this.#assertLive(); return this.color.readFloats(); }
+  async read(): Promise<Uint8Array> { this.#assertLive(); assertDeviceUsable(this.device, "surface.read"); return this.color.read(); }
+  async readFloats(): Promise<Float32Array> { this.#assertLive(); assertDeviceUsable(this.device, "surface.readFloats"); return this.color.readFloats(); }
   onDestroy(cb: ResourceDestroyCallback<Target>): UnsubscribeResourceDestroy { this.#assertLive(); return this.#destroySignal.onDestroy(this, cb); }
   onTexturesRecreated(cb: () => void): () => void { this.#assertLive(); this.#texturesRecreatedCallbacks.add(cb); return () => { this.#texturesRecreatedCallbacks.delete(cb); }; }
 
   renderPassDescriptor(opts: RenderPassDescriptorOptions = {}): GPURenderPassDescriptor {
     const { clear = [0, 0, 0, 1], preserve, clearDepth, clearStencil, depthReadOnly } = opts;
     this.#assertLive();
+    assertDeviceUsable(this.device, "surface.renderPassDescriptor");
     // Encoding is the only path that needs the current texture — and the only one that needs the
     // internal attachments to match its size.
     this.#syncAttachments();
@@ -352,6 +360,14 @@ export class CanvasSurface implements Surface {
     return { width: size[0], height: size[1], dpr: this.#currentDpr, surface: this };
   }
 
+  /**
+   * Disposal of the surface itself. Every method that touches the device pairs it with
+   * `assertDeviceUsable(this.device, "surface.<method>")` (contract #19): after a real device loss the
+   * surface is terminal too, and it says so naming the method the caller wrote — instead of failing
+   * later inside `Device.createTexture`, or not failing at all for a surface without depth/MSAA
+   * attachments, which would keep encoding against the canvas of a device that is gone. Disposal is
+   * checked first: it is the more local fact, and it keeps its own error.
+   */
   #assertLive(): void {
     if (this.#isDisposed) throw surfaceDisposedError(this.options.label);
   }

--- a/packages/vgpu-api/src/target-offscreen.ts
+++ b/packages/vgpu-api/src/target-offscreen.ts
@@ -1,6 +1,7 @@
 import { Texture, createResourceIdentity, DestroySignal, type Device, type ResourceDestroyCallback, type ResourceIdentity, type UnsubscribeResourceDestroy } from "@vgpu/core";
 import type { RenderPassDescriptorOptions, Target, TargetOptions, TargetTextureOptions } from "./target.ts";
 import { BUILT_IN_CLEAR_COLOR, colorAttachment, copyClearColor, colorSpecsFor, depthAttachment, depthFormatFor, sampleCountFor, sameSize, validateClearColor, validateTargetOptions, type ClearColor } from "./target-utils.ts";
+import { assertDeviceUsable } from "./lifecycle.ts";
 import { liveKernel } from "./live-kernel.ts";
 import type { Gpu } from "./kernel.ts";
 
@@ -50,17 +51,21 @@ export class OffscreenTarget implements Target {
   get sampleCount(): 1 | 4 { return sampleCountFor(this.options); }
 
   resize(size: readonly [number, number]): void {
+    // Contract #19: after a real device loss the target is terminal like everything else in the graph,
+    // and it names `target.resize` rather than failing inside the `Device.createTexture` it would reach.
+    assertDeviceUsable(this.device, "target.resize");
     if (sameSize(this.#currentSize, size)) return;
     this.#recreateTextures(size);
   }
 
-  async read(): Promise<Uint8Array> { return this.color.read(); }
-  async readFloats(): Promise<Float32Array> { return this.color.readFloats(); }
+  async read(): Promise<Uint8Array> { assertDeviceUsable(this.device, "target.read"); return this.color.read(); }
+  async readFloats(): Promise<Float32Array> { assertDeviceUsable(this.device, "target.readFloats"); return this.color.readFloats(); }
   onDestroy(cb: ResourceDestroyCallback<Target>): UnsubscribeResourceDestroy { return this.#destroySignal.onDestroy(this, cb); }
   onTexturesRecreated(cb: () => void): () => void { this.#texturesRecreatedCallbacks.add(cb); return () => { this.#texturesRecreatedCallbacks.delete(cb); }; }
   destroy(): void { this.#destroySignal.emit(this); this.#texturesRecreatedCallbacks.clear(); this.#destroyTextures(); }
 
   renderPassDescriptor(opts: RenderPassDescriptorOptions = {}): GPURenderPassDescriptor {
+    assertDeviceUsable(this.device, "target.renderPassDescriptor");
     const { clear = [0, 0, 0, 1], preserve, clearDepth, clearStencil, depthReadOnly } = opts;
     return {
       colorAttachments: this.#currentColors.map((resolved, index) => colorAttachment(resolved, this.#currentMsaaColors?.[index], clear, preserve)),

--- a/packages/vgpu-api/tests/device-loss.test.ts
+++ b/packages/vgpu-api/tests/device-loss.test.ts
@@ -16,7 +16,7 @@ import { loseMockGPUDevice } from "@vgpu/core";
 import { init, bundle, effect, frame, frameLoop, prepare, surface, target } from "../src/mock.ts";
 import type { Gpu } from "../src/kernel.ts";
 import { FRAME_BUNDLE } from "../src/frame-protocols.ts";
-import type { Bundle } from "../src/bundle.ts";
+import { createBundle, type Bundle } from "../src/bundle.ts";
 import type { Target } from "../src/target.ts";
 
 const SOLID = `
@@ -218,6 +218,23 @@ test("a prepare() in flight when the loss lands rejects with VGPU-DEVICE-LOST in
   expect(failure?.cause?.code).toBe("VGPU-DEVICE-LOST");
   expect(recorded.gpu).toBeUndefined();
   expect(recorded.status).not.toBe("ready");
+});
+
+test("the bundle host guard is a capability, not a requirement: a host without it still records and replays", async () => {
+  const gpu = await init();
+  const scene = target(gpu, { size: [4, 4] });
+  const fx = effect(gpu, SOLID);
+  // The reduced host shape (`render-service.ts` builds one) defines no assertDeviceUsable: calling it
+  // must stay optional, never a crash on an undefined member.
+  const bare = createBundle({ device: { gpu: gpu.gpu } }, { target: scene }, (r) => r.draw(fx));
+
+  expect(bare.status).toBe("pending-pipelines");
+  expect(() => replay(bare, scene)).not.toThrow();
+  expect(bare.status).toBe("ready");
+
+  await lose(gpu);
+  // Still no crash: a host that was given no guard simply cannot report the loss itself.
+  expect(() => replay(bare, scene)).not.toThrow();
 });
 
 // --- Helpers -------------------------------------------------------------------------------------

--- a/packages/vgpu-api/tests/device-loss.test.ts
+++ b/packages/vgpu-api/tests/device-loss.test.ts
@@ -1,0 +1,288 @@
+/**
+ * Contract #19 + design rule §9 "Device loss is terminal".
+ *
+ * A REAL device loss (the native `GPUDevice.lost` promise resolving on its own) is graph-wide and
+ * terminal: `gpu.lost` resolves with no intermediate operation, every frame loop vgpu owns stops by
+ * itself, and every subsequent operation on that graph — surface, offscreen target, bundle, draw,
+ * compute, frame — throws `VGPU-DEVICE-LOST`, naming the method the caller wrote. Nothing is ever
+ * re-pointed at a replacement device and there is no API to ask for it.
+ *
+ * A deliberate `gpu.dispose()` is the OTHER semantic: `gpu.disposed` flips, `gpu.lost` stays pending
+ * forever (WebGPU resolves the native promise with reason `"destroyed"`, and vgpu suppresses it),
+ * and operations throw `VGPU-DEVICE-DISPOSED`. One spelling per semantic — there is no `onLost()`.
+ */
+import { afterEach, expect, test, vi } from "vitest";
+import { loseMockGPUDevice } from "@vgpu/core";
+import { init, bundle, effect, frame, frameLoop, prepare, surface, target } from "../src/mock.ts";
+import type { Gpu } from "../src/kernel.ts";
+import { FRAME_BUNDLE } from "../src/frame-protocols.ts";
+import type { Bundle } from "../src/bundle.ts";
+import type { Target } from "../src/target.ts";
+
+const SOLID = `
+@fragment fn main(@location(0) uv: vec2f) -> @location(0) vec4f { return vec4f(uv, 0.0, 1.0); }
+`;
+
+type RafCallback = (timestamp: number) => void;
+const originalRequestAnimationFrame = globalThis.requestAnimationFrame;
+const originalCancelAnimationFrame = globalThis.cancelAnimationFrame;
+
+afterEach(() => {
+  globalThis.requestAnimationFrame = originalRequestAnimationFrame;
+  globalThis.cancelAnimationFrame = originalCancelAnimationFrame;
+});
+
+// --- gpu.lost: resolves only on a real loss ------------------------------------------------------
+
+test("gpu.lost resolves with the loss info after a real device loss, with no intermediate operation", async () => {
+  const gpu = await init();
+
+  void loseMockGPUDevice(gpu.gpu, { reason: "unknown", message: "simulated loss" });
+  const info = await gpu.lost;
+
+  expect(info?.reason).toBe("unknown");
+  expect(info?.message).toBe("simulated loss");
+  // Loss is not disposal: nothing was released, the graph is simply terminal.
+  expect(gpu.disposed).toBe(false);
+});
+
+test("gpu.dispose() never resolves gpu.lost; it only flips gpu.disposed", async () => {
+  const gpu = await init();
+
+  gpu.dispose();
+
+  expect(gpu.disposed).toBe(true);
+  expect(await settledWithin(gpu.lost, 25)).toBe("pending");
+  expect(() => effect(gpu, SOLID)).toThrow(expect.objectContaining({ code: "VGPU-GPU-DISPOSED" }));
+});
+
+test("dispose() after a real loss stays idempotent, and gpu.disposed only tracks dispose()", async () => {
+  const gpu = await init();
+  await lose(gpu);
+
+  expect(gpu.disposed).toBe(false);
+  expect(() => gpu.dispose()).not.toThrow();
+  expect(() => gpu.dispose()).not.toThrow();
+  expect(gpu.disposed).toBe(true);
+  // The loss already resolved: dispose() cannot take that back.
+  await expect(gpu.lost).resolves.toMatchObject({ reason: "unknown" });
+});
+
+// --- Frame loops stop by themselves --------------------------------------------------------------
+
+test("a real device loss stops every frame loop the gpu owns, without disposing it", async () => {
+  const callbacks = mockAnimationFrames();
+  const gpu = await init();
+  const scene = target(gpu, { size: [4, 4] });
+  const fx = effect(gpu, SOLID);
+
+  let calls = 0;
+  frameLoop(gpu, (currentFrame) => { calls += 1; currentFrame.pass(scene, fx); });
+  fire(callbacks, 1, 0);
+  expect(calls).toBe(1);
+
+  const queuedTick = callbacks.get(2);
+  expect(queuedTick).toBeDefined();
+  await lose(gpu);
+
+  // The loop was cancelled by the loss itself, and the tick already queued when it landed returns
+  // without re-entering the user callback (which would throw on every frame, forever).
+  expect(callbacks.size).toBe(0);
+  expect(() => queuedTick?.(16)).not.toThrow();
+  expect(calls).toBe(1);
+  expect(gpu.disposed).toBe(false);
+});
+
+test("the loops are stopped before anyone awaiting gpu.lost observes the loss", async () => {
+  const callbacks = mockAnimationFrames();
+  const gpu = await init();
+  frameLoop(gpu, () => undefined);
+  fire(callbacks, 1, 0);
+  expect(callbacks.size).toBe(1);
+
+  void loseMockGPUDevice(gpu.gpu, { reason: "unknown" });
+  await gpu.lost;
+
+  expect(callbacks.size).toBe(0);
+});
+
+// --- Every object of the graph is terminal -------------------------------------------------------
+
+test("surface operations throw VGPU-DEVICE-LOST naming the surface method, not an internal device call", async () => {
+  const gpu = await init();
+  const canvas = canvasLike(8, 4);
+  const view = surface(gpu, canvas, { depth: true });
+  await lose(gpu);
+
+  expect(() => view.resize([16, 8])).toThrow(expect.objectContaining({ code: "VGPU-DEVICE-LOST", where: "surface.resize" }));
+  expect(() => view.color).toThrow(expect.objectContaining({ code: "VGPU-DEVICE-LOST", where: "surface.color" }));
+  expect(() => view.depth).toThrow(expect.objectContaining({ code: "VGPU-DEVICE-LOST", where: "surface.depth" }));
+  expect(() => view.renderPassDescriptor()).toThrow(expect.objectContaining({ code: "VGPU-DEVICE-LOST", where: "surface.renderPassDescriptor" }));
+  await expect(view.read()).rejects.toMatchObject({ code: "VGPU-DEVICE-LOST", where: "surface.read" });
+  await expect(view.readFloats()).rejects.toMatchObject({ code: "VGPU-DEVICE-LOST", where: "surface.readFloats" });
+});
+
+test("an offscreen target is terminal too, naming the target method", async () => {
+  const gpu = await init();
+  const scene = target(gpu, { size: [4, 4] });
+  await lose(gpu);
+
+  expect(() => scene.resize([8, 8])).toThrow(expect.objectContaining({ code: "VGPU-DEVICE-LOST", where: "target.resize" }));
+  expect(() => scene.renderPassDescriptor()).toThrow(expect.objectContaining({ code: "VGPU-DEVICE-LOST", where: "target.renderPassDescriptor" }));
+  await expect(scene.read()).rejects.toMatchObject({ code: "VGPU-DEVICE-LOST", where: "target.read" });
+  await expect(scene.readFloats()).rejects.toMatchObject({ code: "VGPU-DEVICE-LOST", where: "target.readFloats" });
+});
+
+test("a recorded bundle refuses to prepare, replay or rebuild after a real loss", async () => {
+  const gpu = await init();
+  const scene = target(gpu, { size: [4, 4] });
+  const fx = effect(gpu, SOLID);
+  const recorded = bundle(gpu, { target: scene }, (r) => r.draw(fx));
+  await prepare(gpu, { bundle: recorded });
+  expect(recorded.status).toBe("ready");
+
+  await lose(gpu);
+
+  await expect(prepare(gpu, { bundle: recorded })).rejects.toMatchObject({ code: "VGPU-DEVICE-LOST", where: "prepare" });
+  expect(() => recorded.rebuild((r) => r.draw(fx))).toThrow(expect.objectContaining({ code: "VGPU-DEVICE-LOST" }));
+  // Replay goes through the frame protocol: a lost device beats the "this bundle is ready" fast path.
+  expect(() => replay(recorded, scene)).toThrow(expect.objectContaining({ code: "VGPU-DEVICE-LOST" }));
+});
+
+test("draw, compute-style set/bind, frame() and prepare() stay terminal after a loss (regression of the 34 existing guards)", async () => {
+  const gpu = await init();
+  const scene = target(gpu, { size: [4, 4] });
+  const fx = effect(gpu, SOLID);
+  await lose(gpu);
+
+  expect(() => frame(gpu, () => undefined)).toThrow(expect.objectContaining({ code: "VGPU-DEVICE-LOST" }));
+  expect(() => frameLoop(gpu, () => undefined)).toThrow(expect.objectContaining({ code: "VGPU-DEVICE-LOST" }));
+  expect(() => fx.set({})).toThrow(expect.objectContaining({ code: "VGPU-DEVICE-LOST" }));
+  expect(() => effect(gpu, SOLID)).toThrow(expect.objectContaining({ code: "VGPU-DEVICE-LOST" }));
+  expect(() => target(gpu, { size: [2, 2] })).toThrow(expect.objectContaining({ code: "VGPU-DEVICE-LOST" }));
+  await expect(prepare(gpu, { draw: fx, target: scene })).rejects.toMatchObject({ code: "VGPU-DEVICE-LOST" });
+});
+
+test("nothing is ever re-pointed: objects of a lost gpu stay terminal next to a brand new gpu", async () => {
+  const lost = await init();
+  const oldScene = target(lost, { size: [4, 4] });
+  const oldEffect = effect(lost, SOLID);
+  await lose(lost);
+
+  const fresh = await init();
+  // No restore(), no reattach(), no generation proxy: the old objects belong to the dead device forever.
+  expect(Object.keys(lost)).not.toContain("restore");
+  expect(() => frame(fresh, (f) => f.pass(oldScene, oldEffect))).toThrow(expect.objectContaining({ code: "VGPU-DEVICE-LOST" }));
+  expect(() => oldScene.resize([8, 8])).toThrow(expect.objectContaining({ code: "VGPU-DEVICE-LOST" }));
+  fresh.dispose();
+});
+
+// --- Races: dispose vs a loss landing at the same time -------------------------------------------
+
+test("dispose() winning the race suppresses the loss the destroy itself causes", async () => {
+  const callbacks = mockAnimationFrames();
+  const gpu = await init();
+  let calls = 0;
+  frameLoop(gpu, () => { calls += 1; });
+
+  gpu.dispose();
+  // The native promise resolves right after destroy(); a late resolution must not turn a disposed
+  // gpu into a "lost" one, nor resolve gpu.lost.
+  void loseMockGPUDevice(gpu.gpu, { reason: "destroyed" });
+  await tick();
+
+  expect(await settledWithin(gpu.lost, 25)).toBe("pending");
+  expect(gpu.disposed).toBe(true);
+  expect(callbacks.size).toBe(0);
+  expect(calls).toBe(0);
+  expect(() => effect(gpu, SOLID)).toThrow(expect.objectContaining({ code: "VGPU-GPU-DISPOSED" }));
+});
+
+test("a prepare() in flight when the loss lands rejects with VGPU-DEVICE-LOST instead of encoding", async () => {
+  const gpu = await init();
+  const scene = target(gpu, { size: [4, 4] });
+  const fx = effect(gpu, SOLID);
+  const gate = deferred();
+  const native = gpu.gpu as unknown as { createRenderPipelineAsync(desc: GPURenderPipelineDescriptor): Promise<GPURenderPipeline> };
+  const original = native.createRenderPipelineAsync.bind(native);
+  native.createRenderPipelineAsync = async (desc: GPURenderPipelineDescriptor) => { await gate.promise; return original(desc); };
+
+  const recorded = bundle(gpu, { target: scene }, (r) => r.draw(fx));
+  const preparing = prepare(gpu, { bundle: recorded });
+  await lose(gpu);
+  gate.resolve();
+
+  // prepare() batches: the combination failed with the device error, reported as its cause.
+  const failure = await preparing.then(() => undefined, (error: unknown) => error as { code: string; cause?: { code?: string } });
+  expect(failure?.code).toBe("VGPU-PREPARE-FAILED");
+  expect(failure?.cause?.code).toBe("VGPU-DEVICE-LOST");
+  expect(recorded.gpu).toBeUndefined();
+  expect(recorded.status).not.toBe("ready");
+});
+
+// --- Helpers -------------------------------------------------------------------------------------
+
+/** Simulates a real (non-`destroy()`) device loss and waits until the whole graph observed it. */
+async function lose(gpu: Gpu): Promise<void> {
+  void loseMockGPUDevice(gpu.gpu, { reason: "unknown", message: "simulated loss" });
+  await gpu.lost;
+}
+
+function replay(recorded: Bundle, on: Target): GPURenderBundle | undefined {
+  return (recorded as unknown as { [FRAME_BUNDLE]: { resolveForReplay(target: Target): GPURenderBundle | undefined } })[FRAME_BUNDLE].resolveForReplay(on);
+}
+
+function deferred(): { promise: Promise<void>; resolve: () => void } {
+  let resolve!: () => void;
+  const promise = new Promise<void>((r) => { resolve = r; });
+  return { promise, resolve };
+}
+
+async function tick(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+async function settledWithin(promise: Promise<unknown>, ms: number): Promise<"settled" | "pending"> {
+  return Promise.race([
+    promise.then(() => "settled" as const, () => "settled" as const),
+    new Promise<"pending">((resolve) => setTimeout(() => resolve("pending"), ms)),
+  ]);
+}
+
+function mockAnimationFrames(): Map<number, RafCallback> {
+  const callbacks = new Map<number, RafCallback>();
+  let nextId = 1;
+  globalThis.requestAnimationFrame = ((cb: FrameRequestCallback) => {
+    const id = nextId++;
+    callbacks.set(id, cb);
+    return id;
+  }) as typeof requestAnimationFrame;
+  globalThis.cancelAnimationFrame = ((id: number) => { callbacks.delete(id); }) as typeof cancelAnimationFrame;
+  return callbacks;
+}
+
+function fire(callbacks: Map<number, RafCallback>, id: number, timestamp: number): void {
+  const cb = callbacks.get(id);
+  callbacks.delete(id);
+  cb?.(timestamp);
+}
+
+function canvasLike(width = 10, height = 5): HTMLCanvasElement {
+  const context = {
+    configure: vi.fn(),
+    unconfigure: vi.fn(),
+    getCurrentTexture: () => ({ createView: () => ({}) }),
+  };
+  const canvas: Record<string, unknown> = {
+    width: 0,
+    height: 0,
+    clientWidth: width,
+    clientHeight: height,
+    getContext(kind: string) {
+      if (kind !== "webgpu") return null;
+      return { ...context, canvas };
+    },
+  };
+  return canvas as unknown as HTMLCanvasElement;
+}

--- a/packages/vgpu-api/tests/qa-t04-11-adversarial.test.ts
+++ b/packages/vgpu-api/tests/qa-t04-11-adversarial.test.ts
@@ -1,0 +1,252 @@
+/**
+ * QA T04-11 — adversarial suite for contract #19 / design §9 "Device loss is terminal".
+ *
+ * Every test here exists because a MUTANT survived the branch's own suite (see
+ * /tmp/debug/scripts/vgpu-t04-11-device-loss-qa/README.md), or because the instance-method matrix
+ * needed pinning. Each test names the mutant it kills.
+ */
+import { afterEach, expect, test, vi } from "vitest";
+import { createMockGPUDevice, Device, loseMockGPUDevice } from "@vgpu/core";
+import { createMockAdapter, init, bundle, effect, frameLoop, geometry, prepare, storage, surface, target, timer, visibility } from "../src/mock.ts";
+import { uniforms } from "../src/uniforms.ts";
+import { compute } from "../src/compute.ts";
+import { kernelOf, type Gpu } from "../src/kernel.ts";
+import { FRAME_BUNDLE } from "../src/frame-protocols.ts";
+
+const SOLID = `@fragment fn main(@location(0) uv: vec2f) -> @location(0) vec4f { return vec4f(uv, 0.0, 1.0); }`;
+const U_COMPUTE = `struct U { scale: f32 }; @group(0) @binding(0) var<uniform> u: U; @compute @workgroup_size(1) fn main() { let x = u.scale; }`;
+
+type RafCallback = (timestamp: number) => void;
+const originalRequestAnimationFrame = globalThis.requestAnimationFrame;
+const originalCancelAnimationFrame = globalThis.cancelAnimationFrame;
+afterEach(() => {
+  globalThis.requestAnimationFrame = originalRequestAnimationFrame;
+  globalThis.cancelAnimationFrame = originalCancelAnimationFrame;
+});
+
+async function lose(gpu: Gpu): Promise<void> {
+  void loseMockGPUDevice(gpu.gpu, { reason: "unknown", message: "simulated loss" });
+  await gpu.lost;
+}
+
+// --- The mock is the instrument: if it lies, every test above it is decoration ------------------
+
+test("[kills M07] the mock's destroy() really resolves the native lost promise with reason \"destroyed\"", async () => {
+  const native = createMockGPUDevice();
+  const nativeLost = native.lost;
+
+  native.destroy();
+
+  // Without this, "device.lost stays pending after destroy()" passes for the wrong reason: there
+  // would be no resolution to suppress in the first place.
+  await expect(nativeLost).resolves.toMatchObject({ reason: "destroyed" });
+
+  const device = new Device(createMockGPUDevice());
+  device.destroy();
+  await Promise.resolve();
+  expect(await settledWithin(device.lost, 25)).toBe("pending");
+});
+
+test("[kills M06] loseMockGPUDevice hands back the NATIVE loss promise: a device is lost once, and the second call cannot re-describe it", async () => {
+  const native = createMockGPUDevice();
+
+  const first = await loseMockGPUDevice(native, { reason: "unknown", message: "the real one" });
+  const second = await loseMockGPUDevice(native, { reason: "destroyed", message: "too late" });
+
+  // Same object, not just same shape: the returned promise is `device.lost`, so a test that awaits
+  // it has genuinely waited for the native resolution instead of one microtask of its own.
+  expect(second).toBe(first);
+  expect(first.message).toBe("the real one");
+});
+
+// --- Kernel phase discipline: loss stops schedulers, and only once ------------------------------
+
+test("[kills M04] a real loss leaves the resource and service phases untouched — the app can still read its resources to report the failure", async () => {
+  const gpu = await init();
+  const kernel = kernelOf(gpu);
+  let scheduler = 0, resource = 0, service = 0;
+  kernel.own("scheduler", () => { scheduler += 1; });
+  kernel.own("resource", () => { resource += 1; });
+  kernel.own("service", () => { service += 1; });
+  const scene = target(gpu, { size: [4, 4] });
+
+  await lose(gpu);
+
+  expect(scheduler).toBe(1);
+  expect(resource).toBe(0);
+  expect(service).toBe(0);
+  expect(gpu.disposed).toBe(false);
+  // Nothing was released: the textures are still there to be read by the app's error path, they
+  // simply refuse new device work.
+  expect(scene.size).toEqual([4, 4]);
+  expect(() => scene.resize([8, 8])).toThrow(expect.objectContaining({ code: "VGPU-DEVICE-LOST" }));
+});
+
+test("[kills M21] the scheduler phase runs exactly once: a dispose() after a real loss does not stop the same loops twice", async () => {
+  const gpu = await init();
+  const kernel = kernelOf(gpu);
+  let stops = 0;
+  kernel.own("scheduler", () => { stops += 1; });
+
+  await lose(gpu);
+  expect(stops).toBe(1);
+
+  gpu.dispose();
+  // A disposer that already ran is gone from the set; running it again would double-stop loops and
+  // double-free whatever a real disposer owns.
+  expect(stops).toBe(1);
+  expect(gpu.disposed).toBe(true);
+});
+
+test("loss-wins race: a dispose() landing after a resolved loss is idempotent and cannot un-resolve gpu.lost", async () => {
+  const gpu = await init();
+  const callbacks = mockAnimationFrames();
+  let calls = 0;
+  frameLoop(gpu, () => { calls += 1; });
+  fire(callbacks, 1, 0);
+
+  await lose(gpu);
+  const info = await gpu.lost;
+
+  expect(() => gpu.dispose()).not.toThrow();
+  expect(() => gpu.dispose()).not.toThrow();
+  expect(await gpu.lost).toBe(info);
+  expect(gpu.disposed).toBe(true);
+  expect(calls).toBe(1);
+  // Spelling matrix: after a loss THEN a dispose, core's destroy() moves the device to "disposed",
+  // so the door reports the disposal — the more recent, more local fact.
+  expect(() => effect(gpu, SOLID)).toThrow(expect.objectContaining({ code: "VGPU-GPU-DISPOSED" }));
+});
+
+// --- Surface ------------------------------------------------------------------------------------
+
+test("[kills M17] applyAutoResize refuses a lost device, naming surface.applyAutoResize", async () => {
+  const gpu = await init();
+  const canvas = canvasLike(8, 4);
+  const view = surface(gpu, canvas);
+  expect(view.autoResize).toBe(true);
+
+  await lose(gpu);
+
+  expect(() => (view as unknown as { applyAutoResize(): void }).applyAutoResize())
+    .toThrow(expect.objectContaining({ code: "VGPU-DEVICE-LOST", where: "surface.applyAutoResize" }));
+});
+
+test("[kills M16] disposal is the more local fact: a disposed surface on a lost device keeps its own error", async () => {
+  const gpu = await init();
+  const view = surface(gpu, canvasLike(8, 4));
+  view.dispose();
+
+  await lose(gpu);
+
+  expect(() => view.resize([16, 8])).toThrow(expect.objectContaining({ code: "VGPU-SURFACE-DISPOSED" }));
+  expect(() => view.color).toThrow(expect.objectContaining({ code: "VGPU-SURFACE-DISPOSED" }));
+  await expect(view.read()).rejects.toMatchObject({ code: "VGPU-SURFACE-DISPOSED" });
+});
+
+// --- Bundle -------------------------------------------------------------------------------------
+
+test("[kills M09] the bundle's own prepare guard is load-bearing: the frame protocol path rejects too, not only prepare()'s door", async () => {
+  const gpu = await init();
+  const scene = target(gpu, { size: [4, 4] });
+  const fx = effect(gpu, SOLID);
+  const recorded = bundle(gpu, { target: scene }, (r) => r.draw(fx));
+  await prepare(gpu, { bundle: recorded });
+  expect(recorded.status).toBe("ready");
+
+  await lose(gpu);
+
+  // Reached without liveKernel: this is the guard inside RecordedBundle, and it must beat the
+  // "already ready, resolve immediately" fast path.
+  const protocol = (recorded as unknown as { [FRAME_BUNDLE]: { prepareCombination(): Promise<unknown> } })[FRAME_BUNDLE];
+  await expect(protocol.prepareCombination()).rejects.toMatchObject({ code: "VGPU-DEVICE-LOST" });
+});
+
+// --- Instance matrix: what contract #19 really covers -------------------------------------------
+
+test("instance writes are terminal after a real loss, transitively through the buffer guard", async () => {
+  const gpu = await init();
+  const warm = uniforms(gpu, { scale: 1 });
+  compute(gpu, U_COMPUTE).set({ u: warm });        // adopts the layout, creates the backing buffer
+  const buf = storage(gpu, 256, "read-write");
+  const geom = geometry(gpu, { buffers: [{ data: new Float32Array(9), stride: 12, attributes: { position: "float32x3" as GPUVertexFormat } }] });
+
+  warm.set({ scale: 2 });
+  buf.write(new Float32Array([1, 2, 3, 4]));
+
+  await lose(gpu);
+
+  // These objects have no guard of their own — they inherit it from core `Buffer.write`/`Buffer.read`,
+  // which is why the `where` names the buffer and not the caller's method. Documented, not silent.
+  expect(() => warm.set({ scale: 3 })).toThrow(expect.objectContaining({ code: "VGPU-DEVICE-LOST" }));
+  expect(() => buf.write(new Float32Array([5]))).toThrow(expect.objectContaining({ code: "VGPU-DEVICE-LOST" }));
+  await expect(buf.read()).rejects.toMatchObject({ code: "VGPU-DEVICE-LOST" });
+  expect(() => (geom as unknown as { write(d: BufferSource): void }).write(new Float32Array(9)))
+    .toThrow(expect.objectContaining({ code: "VGPU-DEVICE-LOST" }));
+});
+
+test("every factory fails at the door after a real loss (the liveKernel decision)", async () => {
+  const gpu = await init({ adapter: createMockAdapter({ features: ["timestamp-query"] }), requiredFeatures: ["timestamp-query"] });
+  await lose(gpu);
+
+  for (const [name, factory] of [
+    ["uniforms", () => uniforms(gpu, { scale: 1 })],
+    ["storage", () => storage(gpu, 64)],
+    ["timer", () => timer(gpu)],
+    ["visibility", () => visibility(gpu)],
+    ["geometry", () => geometry(gpu, { buffers: [{ data: new Float32Array(3), stride: 12, attributes: { position: "float32x3" as GPUVertexFormat } }] })],
+    ["target", () => target(gpu, { size: [2, 2] })],
+    ["effect", () => effect(gpu, SOLID)],
+  ] as const) {
+    expect(factory, `${name}() must fail at the door`).toThrow(expect.objectContaining({ code: "VGPU-DEVICE-LOST", where: name }));
+  }
+});
+
+test("KNOWN GAP (T04-11 scope decision): timer and visibility hand out handles after a real loss instead of throwing", async () => {
+  const gpu = await init({ adapter: createMockAdapter({ features: ["timestamp-query"] }), requiredFeatures: ["timestamp-query"] });
+  const t = timer(gpu);
+  const vis = visibility(gpu);
+
+  await lose(gpu);
+
+  // Their private #assertUsable checks the object's OWN disposed flag, not the device state, so
+  // these are pure bookkeeping calls that cannot fail. No device work is dropped (the query sets
+  // are only touched from inside a frame, and frames are terminal), but by the letter of contract
+  // #19 these should throw. Tripwire: if a later ticket closes the gap, this test must be updated.
+  expect(() => t.span("pass")).not.toThrow();
+  expect(() => t.onResults(() => undefined)).not.toThrow();
+  expect(() => vis.query("thing")).not.toThrow();
+  expect(() => vis.reset()).not.toThrow();
+});
+
+// --- Helpers -------------------------------------------------------------------------------------
+
+async function settledWithin(promise: Promise<unknown>, ms: number): Promise<"settled" | "pending"> {
+  return Promise.race([
+    promise.then(() => "settled" as const, () => "settled" as const),
+    new Promise<"pending">((resolve) => setTimeout(() => resolve("pending"), ms)),
+  ]);
+}
+
+function mockAnimationFrames(): Map<number, RafCallback> {
+  const callbacks = new Map<number, RafCallback>();
+  let nextId = 1;
+  globalThis.requestAnimationFrame = ((cb: FrameRequestCallback) => { const id = nextId++; callbacks.set(id, cb); return id; }) as typeof requestAnimationFrame;
+  globalThis.cancelAnimationFrame = ((id: number) => { callbacks.delete(id); }) as typeof cancelAnimationFrame;
+  return callbacks;
+}
+
+function fire(callbacks: Map<number, RafCallback>, id: number, timestamp: number): void {
+  const cb = callbacks.get(id);
+  callbacks.delete(id);
+  cb?.(timestamp);
+}
+
+function canvasLike(width = 10, height = 5): HTMLCanvasElement {
+  const context = { configure: vi.fn(), unconfigure: vi.fn(), getCurrentTexture: () => ({ createView: () => ({}) }) };
+  const canvas: Record<string, unknown> = {
+    width: 0, height: 0, clientWidth: width, clientHeight: height,
+    getContext(kind: string) { if (kind !== "webgpu") return null; return { ...context, canvas }; },
+  };
+  return canvas as unknown as HTMLCanvasElement;
+}


### PR DESCRIPTION
Closes the last contract of the 0.4 train: **#19 — device loss is terminal** (design §9).

A real device loss (`GPUDevice.lost` resolving on its own — a driver reset, a TDR, a tab evicted
from the GPU process) is now observable and graph-wide terminal:

- **`gpu.lost`** resolves with the native `GPUDeviceLostInfo`, with no intermediate operation. A
  deliberate `gpu.dispose()` leaves it **pending forever** — disposal is observed through
  `gpu.disposed`, loss through this promise, and there is deliberately no `onLost()` callback (one
  spelling per semantic).
- **Every frame loop the gpu owns stops by itself** on a loss, reusing the `own("scheduler", …)`
  registrations `frame.ts` already makes — `frame.ts` is untouched.
- **`gpu.disposed` stays `false`** after a loss, and the `resource`/`service` phases are left alone:
  a lost device has nothing to release, and the app must still be able to read its own resources to
  report the failure.
- The gaps the ticket's audit confirmed are closed: `surface`, `target` (offscreen) and `bundle` now
  refuse to operate after a loss, **naming the method the caller wrote** (`surface.resize`,
  `target.renderPassDescriptor`, `bundle '<id>' replay`) instead of failing deep inside
  `Device.createTexture` — or not failing at all, which is what a surface with no depth/MSAA
  attachment used to do.

Nothing is ever restored, reattached or re-pointed at a replacement device, and no hook was left to
add it later. Recovery is `init()` again, from scratch.

## Scope decision: one line outside the ticket's list

The ticket lists `surface.ts`, `target-offscreen.ts` and `bundle.ts` as the gaps to close, and
requires any expansion to be recorded here. One line was added outside that list:

```ts
// live-kernel.ts
export function liveKernel(gpu: Gpu, where: string): Kernel {
  const kernel = kernelOf(gpu);
  if (kernel.disposed) throw gpuDisposedError(where);
  assertDeviceUsable(kernel.device, where);   // <- this
  return kernel;
}
```

Without it, contract #19's "any operation on any object of the graph" is false for creation:
`sampler(gpu, …)`, `timer(gpu)`, `visibility(gpu)`, `geometry(gpu, …)`, `uniforms(gpu, …)` and
`storage(gpu, …)` would each hand back a doomed handle built on a dead device. With it, **every
factory fails at the door** with `VGPU-DEVICE-LOST`. Adversarial QA confirmed the line is
load-bearing: removing it kills tests across the whole loss suite.

It is deliberately **not** `disposed`: `gpu.dispose()` and a real loss stay two distinct signals
with two distinct codes, and the disposed check runs first so the pre-existing spellings are kept.

## Instance-method matrix after a real loss

The ticket left `uniforms`/`storage`/`timer`/`visibility`/`sampler`/`geometry` unaudited and asked
for the decision to be recorded. Every instance method was executed against a lost mock device:

| verdict | methods |
|---|---|
| **throws `VGPU-DEVICE-LOST`** | every factory (via `liveKernel`); `uniforms.set()` once a shader adopted the layout; `storage.write()`/`read()`; `geometry.write()`; `core.Uniform.write()`; `core.StorageBuffer.write()`; `draw`/`compute`/`effect.set()`; `target.resize()` |
| **throws, different code** | `geometry.writeIndices()` with no owned index buffer → `VGPU-MESH-WRITE-RANGE`, a usage error checked before device state. Noisy, not silent |
| **silent, intentional** | every pure getter and every `destroy()`/`dispose()` — reads stay legal and teardown must never be blocked by a loss |
| **silent, benign** | `uniforms.set()` *before* any shader bound it (no adopted layout ⇒ no buffer ⇒ nothing to write, identical on a live device); `geometry.slice()` (pure CPU descriptor math) |
| **silent, real gap — recorded, not closed here** | `timer.span()`, `timer.onResults()`, `visibility.query()`, `visibility.reset()` |

The transitively-covered writes reach the guard through core `Buffer.write`/`Buffer.read`, so their
`where` names the buffer rather than the caller's method — the same imprecision this PR fixes for
`surface`, left as-is for those objects because it costs a guard per method on budgets that are
already at the edge (see below).

The `timer`/`visibility` gap is real but narrow: their private `#assertUsable` checks the object's
own disposed flag, never device state. **No GPU work is dropped** — their query sets are only
touched from inside a frame, and frames are terminal — so what leaks is a handle, not data. It is
pinned by a named tripwire test (`KNOWN GAP (T04-11 scope decision)`) so closing it later is a
deliberate act, and it is **not** expanded into this PR, per the ticket's prohibition.

Out of scope but worth a follow-up ticket: `UniformPool.endFrame()` and `StructuredUniform.write()`
(Ring-1 `vgpu/core` escape hatches, never used by vgpu itself) upload through the **raw**
`device.gpu.queue.writeBuffer`, bypassing the guarded `Device.queue` wrapper, so a post-loss upload
is silently dropped. Byte-identical on `next/0.4` — pre-existing, not a regression of this branch.

## Spelling matrix — three codes, none of them overlapping

| situation | code | where |
|---|---|---|
| real loss, any guarded operation | `VGPU-DEVICE-LOST` | the method the caller wrote |
| `gpu.dispose()`, then any **factory** | `VGPU-GPU-DISPOSED` | the factory name |
| `gpu.dispose()`, then a **core `Device`** operation | `VGPU-DEVICE-DISPOSED` | `Device.<method>` |

All three are pinned by tests, including the ordering that keeps them apart: swapping the two checks
in `liveKernel` turns `VGPU-GPU-DISPOSED` into `VGPU-DEVICE-DISPOSED` at every factory door, and a
test catches it. A loss followed by a dispose reports the disposal — the more recent, more local
fact — which is also pinned.

## Bundle budgets

Three ceilings were stepped in 81d9a3c2; the table there reproduces digit for digit from a wiped
`dist/` (`rm -rf packages/*/dist && pnpm build && pnpm bundle-check` is byte-identical to a warm
run):

| entry | measured | budget | headroom |
|---|---|---|---|
| experience draw-recipe-box | 32866 | 33280 | 414 |
| @vgpu/core (tarball) | 36752 | 36864 | 112 |
| vgpu/node | 44112 | 44544 | 432 |
| vgpu | 43947 | 44032 | 85 |
| **experience full-root** | 44026 | 44032 | **6** |
| **vgpu/mock** | 44031 | 44032 | **1** |
| effect-only | 28620 | 28672 | 52 |

The `+1429` on the `@vgpu/core` tarball was verified by unpacking the tarball built from this branch
and from `ec8b0b92`: of the **+3935 raw bytes** added to `dist/*.js` + `dist/*.d.ts`, **+2798 (71 %)
are comments/JSDoc** and only **+1137 is code** — the mock's loss machinery (+595), `Device.lost`'s
plumbing (+148), the new re-exports (+64) and the emitted `.d.ts` signatures (+330). Sourcemaps add
+1331 raw on top. It is a packed tarball, not a minified bundle, which is why it moves ~14× more
than the client bundles do for the same change.

⚠️ **`full-root` is 6 B and `vgpu/mock` is 1 B under their ceilings.** Both were already that thin
before this branch and neither is touched here, so nothing is stepped that still fits — but the next
change to either entry, however small, will fail the gate. Flagging it for the release cut rather
than spending a step on it here.

## Verification

- `pnpm test` — **2114 passed / 141 skipped**, whole monorepo.
- `pnpm typecheck` — clean. `pnpm bundle-check` — green and reproducible from a clean rebuild.
- **Mutation testing:** 22 mutants across `device.ts`, `mock-gpu.ts`, `kernel.ts`, `live-kernel.ts`,
  `bundle.ts`, `surface.ts` and `target-offscreen.ts`, each run against the whole corpus.
  **20 killed, 2 equivalent, 0 real survivors.** Six of the kills come from the tests added in the
  last commit, which exist precisely because those properties were unpinned:
  the mock's `destroy()` really resolving `lost` with `"destroyed"` (without it, the core
  suppression test was vacuously green), `loseMockGPUDevice` handing back the native promise,
  `#runPhase` clearing its set (or a dispose-after-loss re-runs every scheduler disposer),
  the resource/service phases staying untouched, `surface.applyAutoResize`'s guard (which had no
  test at all) and surface disposal precedence.
- The two equivalent mutants, for the record: deleting `observeLoss = false` from `Device.destroy()`
  changes nothing, because `destroy()` already set `state = "disposed"` and the loss callback bails
  on `state !== "alive"` too — the design doc credits `observeLoss` with the suppression, but the
  load-bearing half is the `state` check; and splitting the `attachKernel` wiring into two `.then()`s
  cannot be observed, because `gpu.lost` is a chained promise and any consumer handler is queued at
  least one microtask behind both internal ones.
- Races covered by tests: dispose wins (loss suppressed, `gpu.lost` pending forever, factories
  `VGPU-GPU-DISPOSED`); loss wins (later `dispose()` idempotent, the resolved `lost` cannot be
  un-resolved); and a `prepare()` in flight when the loss lands, which rejects with the device error
  as its cause and leaves the bundle **not** ready instead of encoding against a dead device.
