### PR TITLE
fix(typecheck): close the apps/docs blind spot in root pnpm typecheck (T04-14)

### DIFF
--- a/apps/docs/tsconfig.fixtures.json
+++ b/apps/docs/tsconfig.fixtures.json
@@ -1,0 +1,18 @@
+{
+  "$comment": "T04-14: narrow typecheck fixture for the apps/docs blind spot (T04-10, incidents #328/#337). Extends the real tsconfig.json (same `strict: true`) but only INCLUDEs examples/**, components/hero/** and the generated examples registry -- NOT app/**/content/** which need Next's generated route types (LayoutProps/RouteContext) that only exist after `next build`/`next dev` (see apps/docs/package.json `$comment:typecheck`). Do not widen `include` to app/** without also giving this project the generated .next/types.",
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "incremental": false,
+    "plugins": []
+  },
+  "include": [
+    "examples/**/*.ts",
+    "examples/**/*.tsx",
+    "components/hero/**/*.ts",
+    "components/hero/**/*.tsx",
+    "lib/examples-source.generated.ts",
+    "wgsl.d.ts",
+    "webgpu-types.d.ts"
+  ],
+  "exclude": ["node_modules"]
+}

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "build": "tsc -b && node packages/vgpu-api/scripts/copy-cli.mjs && node -e \"require('fs').copyFileSync('packages/wgsl/src/wgsl-types.d.ts', 'packages/wgsl/dist/wgsl-types.d.ts')\"",
     "typecheck": "tsc -b && pnpm run typecheck:fixtures",
-    "typecheck:fixtures": "tsc -p packages/core/tests/tsconfig.create-sampler-types.json && tsc -p packages/core/tests/tsconfig.types.json && tsc -p packages/vgpu-api/tests/uniforms/tsconfig.types.json && tsc -p packages/vgpu-api/tests/compute/tsconfig.types.json && tsc -p packages/vgpu-api/tests/frame/tsconfig.types.json && tsc -p packages/vgpu-api/tests/surface/tsconfig.types.json",
+    "typecheck:fixtures": "tsc -p packages/core/tests/tsconfig.create-sampler-types.json && tsc -p packages/core/tests/tsconfig.types.json && tsc -p packages/vgpu-api/tests/uniforms/tsconfig.types.json && tsc -p packages/vgpu-api/tests/compute/tsconfig.types.json && tsc -p packages/vgpu-api/tests/frame/tsconfig.types.json && tsc -p packages/vgpu-api/tests/surface/tsconfig.types.json && tsc -p apps/docs/tsconfig.fixtures.json --noEmit",
     "docs:verify-snippets": "node scripts/verify-docs-snippets.mjs",
     "test": "vitest run",
     "test:fast": "vitest run packages/adapter-mock packages/core packages/wgsl packages/render scripts",


### PR DESCRIPTION
## Gap

Root `pnpm typecheck` is `tsc -b && pnpm run typecheck:fixtures`. `tsc -b` only builds `packages/{wgsl,core,adapter-mock,adapter-node,render,vgpu-api}` — **`apps/docs` is not referenced**, and nothing in the root chain ever invoked its own `tsc --noEmit`. A type error in `apps/docs/examples/**` or `apps/docs/components/hero/**` passed `pnpm typecheck`/CI's required `pnpm -w typecheck` step (`.github/workflows/ci.yml:24` in `test-fast`, `:60` in `docker-gpu`) clean, and only surfaced red in the much slower `docs-app-build`/`docs-parity` CI jobs (`next build`), minutes later.

This is exactly the blind spot T04-10 documented, with 2 real past incidents:

- **#328** (T04-01, unified-signature overload): `Parameters<typeof compute>[1]` resolves against the **last declared overload**. `apps/docs/examples/fft-ocean-surface/scene.ts` derives `ShaderSrc` from that position — the fix (`19e5030d`) had to reorder `compute()`'s/`effect()`'s overloads so the single-object form comes first, purely to keep that docs-only consumer's derived type intact.
- **#337** (T04-10, Surface/Target split): `apps/docs/examples/nextjs-flare/pipeline.ts` held a `Target`-typed field/constructor param for a value that is actually a `Surface` — had to be widened to `RenderDestination` once `Surface` stopped extending `Target`.

Both were only caught by a human/CI running `next build`, never by the local/CI-required `pnpm -w typecheck` step.

## Fix

`apps/docs/tsconfig.fixtures.json` — a narrow tsconfig (extends the real `apps/docs/tsconfig.json`, same `strict: true`, no divergence) that only `include`s `examples/**`, `components/hero/**`, and the generated examples registry.

Deliberately does **not** include `app/**`/`content/**`: `apps/docs`'s own `typecheck` script needs a prior `next build`/`dev` for the generated `.next/types` (`LayoutProps`/`RouteContext`) — confirmed empirically: running `pnpm --dir apps/docs typecheck` on a clean tree (even after root `tsc -b`) fails with exactly:
```
app/[lang]/(home)/layout.tsx(5,45): error TS2304: Cannot find name 'LayoutProps'.
app/[lang]/docs/layout.tsx(4,45): error TS2304: Cannot find name 'LayoutProps'.
app/[lang]/layout.tsx(9,45): error TS2304: Cannot find name 'LayoutProps'.
app/[lang]/og/[...slug]/route.tsx(9,15): error TS2304: Cannot find name 'RouteContext'.
app/[lang]/og/[...slug]/route.tsx(88,4): error TS2304: Cannot find name 'RouteContext'.
app/[lang]/rss.xml/route.ts(17,15): error TS2304: Cannot find name 'RouteContext'.
```
Widening this fixture to `app/**` would break `pnpm typecheck` on a tree that hasn't run `next build`, which is the common case locally — exactly the failure mode the ticket warned against.

`typecheck:fixtures` (`package.json:12`) gets one more link: `tsc -p apps/docs/tsconfig.fixtures.json --noEmit`. Cold `pnpm typecheck` time: ~7-9s (was ~2s before this change).

## Retroactive acceptance test (both incidents)

Simulated each pre-fix regression by reverting the actual historical fix, confirmed the new fixture goes red with the exact real error, then reverted the simulation and confirmed green again:

- **#328**: restored `packages/vgpu-api/src/compute.ts`'s overload order to its pre-`19e5030d` state (single-object form declared last) → `tsc -p apps/docs/tsconfig.fixtures.json --noEmit` fails with **16 errors** in `fft-ocean-surface/{scene,renderer}.ts`, e.g.:
  ```
  examples/fft-ocean-surface/scene.ts:139:37 - error TS2345: Argument of type 'ComputeOptions & { readonly shader: string | ShaderSource; }' is not assignable to parameter of type 'string | ShaderSource'.
  ```
  → reverted → clean again.
- **#337**: reverted `nextjs-flare/pipeline.ts`'s `RenderDestination` annotations back to `Target` → fixture fails:
  ```
  examples/nextjs-flare/renderer.ts(212,39): error TS2345: Argument of type 'Surface' is not assignable to parameter of type 'Target'.
    Type 'Surface' is missing the following properties from type 'Target': color, colors
  ```
  → reverted → clean again.

## Regression test (DoD)

Inserted a deliberate type error into `apps/docs/examples/triangle-led-front/led-buffer.ts` (bad param type + shifted positional arg) → root `pnpm typecheck` fails (exit 2, 3 errors) → reverted → `pnpm typecheck` passes again.

## Verification

- `pnpm run typecheck` (clean tree, no `dist`/`.tsbuildinfo`, no `.next`): exit 0, ~7-9s.
- `pnpm run test:fast`: 769 passed, 76 skipped (GPU-only, expected without hardware) — no regressions.
- Independent adversarial QA pass (separate agent session) re-ran all of the above plus a false-positive scan: traced every import reachable from `examples/**`/`components/hero/**` through their `lib/**` helpers, confirmed zero `next/...`/fumadocs/`.source`/`LayoutProps`/`RouteContext` imports anywhere in that reachable set — **PASS**, no bugs found.
- No `packages/**/src/**` files touched. `apps/docs/tsconfig.json` (the real Next config) is unmodified — only the new sibling `tsconfig.fixtures.json` was added.

## Files changed

- `package.json` — 1 line, new link in `typecheck:fixtures`.
- `apps/docs/tsconfig.fixtures.json` — new file, 18 lines.