### PR TITLE
fix(bundle): recording a bundle against a Surface outside frame() is legal (contract #8)

### DIFF
--- a/packages/vgpu-api/src/bundle.ts
+++ b/packages/vgpu-api/src/bundle.ts
@@ -3,8 +3,7 @@ import { InternalDraw, drawUsesBlendConstant, drawUsesStencilReference, encodeDr
 import { InternalEffect, effectDraw, type Effect } from "./effect.ts";
 import type { CompileTarget, Target, TargetSignature } from "./target.ts";
 import { normalizeSignature, signatureKeyOf, validateTargetSignature } from "./pipeline-store.ts";
-import { bundleBlendConstantError, bundleDisposedError, bundleStencilReferenceError, compileFailedError, pipelinePendingError, surfaceNotInFrameError, VGPUError } from "./errors.ts";
-import { isFrameActive, isSurface } from "./surface.ts";
+import { bundleBlendConstantError, bundleDisposedError, bundleStencilReferenceError, compileFailedError, pipelinePendingError, VGPUError } from "./errors.ts";
 import { FRAME_BUNDLE, type FrameBundleProtocol } from "./frame-protocols.ts";
 import { assertDeviceUsable } from "./lifecycle.ts";
 import { liveKernel } from "./live-kernel.ts";
@@ -140,7 +139,6 @@ let recordingDepth = 0;
 /** Records explicit WebGPU render bundles and keeps the R3 stale signature checked at replay time. */
 export function createBundle(host: BundleHost, opts: BundleOptions, record: (recorder: BundleRecorder) => void): Bundle {
   const id = opts.label ?? `bundle${nextBundleId++}`;
-  if (isSurface(opts.target) && !isFrameActive()) throw surfaceNotInFrameError("bundle");
   const signature = normalizeBundleSignature(opts.target);
   const bundle = new RecordedBundle(host, id, signature);
   bundle.track(record);

--- a/packages/vgpu-api/tests/bundle-signature.test.ts
+++ b/packages/vgpu-api/tests/bundle-signature.test.ts
@@ -1,6 +1,7 @@
 import { expect, test, vi } from "vitest";
 import { getMockGPUDeviceInstrumentation } from "@vgpu/core";
-import { init, bundle, effect, frame, target } from "../src/mock.ts";
+import { init, bundle, effect, frame, prepare, surface, target } from "../src/mock.ts";
+import type { Frame } from "../src/mock.ts";
 
 const SOLID = `
 @fragment fn main(@location(0) uv: vec2f) -> @location(0) vec4f {
@@ -121,5 +122,66 @@ test("the first sync replay of a cold bundle uses the sync pipeline path and rep
       detail: { signature: "rgba8unorm:none:1" },
     }),
   ]);
+  gpu.dispose();
+});
+
+// ---------------------------------------------------------------------------
+// Contract #8 / §4 — recording a bundle needs only formats, never `getCurrentTexture()`, so it is
+// legal outside `frame()`, exactly like `prepare()`.
+// ---------------------------------------------------------------------------
+
+function bundleTestCanvas(): HTMLCanvasElement {
+  const canvas: Record<string, unknown> = { width: 4, height: 4 };
+  canvas.getContext = (kind: string) => kind === "webgpu" ? {
+    configure: () => undefined,
+    unconfigure: () => undefined,
+    getCurrentTexture: () => ({ createView: () => ({}) }),
+  } : null;
+  return canvas as HTMLCanvasElement;
+}
+
+test("bundle(gpu, { target: surface }, ...) outside frame() is legal, exactly like prepare()", async () => {
+  const gpu = await init();
+  const canvasSurface = surface(gpu, bundleTestCanvas());
+  const shader = effect(gpu, SOLID, { label: "outOfFrameFx" });
+
+  let recorded: ReturnType<typeof bundle> | undefined;
+  expect(() => { recorded = bundle(gpu, { target: canvasSurface, label: "outOfFrameBundle" }, (b) => b.draw(shader)); }).not.toThrow();
+  expect(recorded!.status).toBe("pending-pipelines");
+
+  // `prepare()` materializes it — still without ever opening a frame.
+  await prepare(gpu, [{ bundle: recorded! }]);
+  expect(recorded!.status).toBe("ready");
+  gpu.dispose();
+});
+
+test("Frame.pass() over a surface, called through an escaped Frame after its callback already submitted, still throws VGPU-SURFACE-NOT-IN-FRAME", async () => {
+  const gpu = await init();
+  const canvasSurface = surface(gpu, bundleTestCanvas());
+  const shader = effect(gpu, SOLID, { label: "escapedFramePassFx" });
+  let escaped: Frame | undefined;
+
+  frame(gpu, (f) => {
+    escaped = f;
+    f.pass(canvasSurface, (p) => p.draw(shader));
+  });
+
+  expect(() => escaped!.pass(canvasSurface, (p) => p.draw(shader))).toThrowError(
+    expect.objectContaining({ code: "VGPU-SURFACE-NOT-IN-FRAME" }),
+  );
+  gpu.dispose();
+});
+
+test("bundle(gpu, { target: disposedSurface }, ...) still throws — VGPU-SURFACE-DISPOSED, not the removed frame guard", async () => {
+  const gpu = await init();
+  const canvasSurface = surface(gpu, bundleTestCanvas());
+  const shader = effect(gpu, SOLID, { label: "disposedSurfaceFx" });
+  canvasSurface.dispose();
+
+  // `normalizeSignature()` reads `surface.pipelineSignature`, whose getter asserts liveness before
+  // returning anything — a disposed surface never reaches (or needs) the frame-activity guard.
+  expect(() => bundle(gpu, { target: canvasSurface, label: "disposedSurfaceBundle" }, (b) => b.draw(shader))).toThrowError(
+    expect.objectContaining({ code: "VGPU-SURFACE-DISPOSED" }),
+  );
   gpu.dispose();
 });

--- a/packages/vgpu-api/tests/bundle-signature.test.ts
+++ b/packages/vgpu-api/tests/bundle-signature.test.ts
@@ -130,19 +130,20 @@ test("the first sync replay of a cold bundle uses the sync pipeline path and rep
 // legal outside `frame()`, exactly like `prepare()`.
 // ---------------------------------------------------------------------------
 
-function bundleTestCanvas(): HTMLCanvasElement {
+function bundleTestCanvas(ledger?: { currentTextures: number }): HTMLCanvasElement {
   const canvas: Record<string, unknown> = { width: 4, height: 4 };
   canvas.getContext = (kind: string) => kind === "webgpu" ? {
     configure: () => undefined,
     unconfigure: () => undefined,
-    getCurrentTexture: () => ({ createView: () => ({}) }),
+    getCurrentTexture: () => { if (ledger) ledger.currentTextures += 1; return { createView: () => ({}) }; },
   } : null;
   return canvas as HTMLCanvasElement;
 }
 
 test("bundle(gpu, { target: surface }, ...) outside frame() is legal, exactly like prepare()", async () => {
   const gpu = await init();
-  const canvasSurface = surface(gpu, bundleTestCanvas());
+  const ledger = { currentTextures: 0 };
+  const canvasSurface = surface(gpu, bundleTestCanvas(ledger));
   const shader = effect(gpu, SOLID, { label: "outOfFrameFx" });
 
   let recorded: ReturnType<typeof bundle> | undefined;
@@ -152,6 +153,10 @@ test("bundle(gpu, { target: surface }, ...) outside frame() is legal, exactly li
   // `prepare()` materializes it — still without ever opening a frame.
   await prepare(gpu, [{ bundle: recorded! }]);
   expect(recorded!.status).toBe("ready");
+  // The clause is literal about the REASON this is legal — "needs only formats, never
+  // `getCurrentTexture()`". Without this the whole path could be re-implemented on the presentation
+  // texture and every assertion above would still pass (mutation-verified).
+  expect(ledger.currentTextures).toBe(0);
   gpu.dispose();
 });
 

--- a/packages/vgpu-api/tests/compile-api.test.ts
+++ b/packages/vgpu-api/tests/compile-api.test.ts
@@ -45,7 +45,9 @@ test("surface encoding is rejected outside frame(gpu) with an offscreen precompi
 
   expectOutsideFrame(() => drawable.draw(canvasSurface));
   expectOutsideFrame(() => shader1.draw(canvasSurface));
-  expectOutsideFrame(() => bundle(gpu, { target: canvasSurface }, () => undefined));
+  // Contract #8 / §4: recording a bundle needs only formats, never `getCurrentTexture()` — legal
+  // outside frame(), exactly like compiling (see bundle-signature.test.ts for the dedicated coverage).
+  expect(() => bundle(gpu, { target: canvasSurface }, () => undefined)).not.toThrow();
   await expect(drawable.compile(canvasSurface)).resolves.toBe(drawable);
   expect(() => drawable.compileSync(canvasSurface)).not.toThrow();
   await expect(shader1.compile(canvasSurface)).resolves.toBe(shader1);

--- a/packages/vgpu-api/tests/surface-split.test.ts
+++ b/packages/vgpu-api/tests/surface-split.test.ts
@@ -142,8 +142,8 @@ test("a Surface is still a render destination: pass(), prepare({ target }) and b
   const fx = effect(gpu, SOLID, { label: "destinationFx" });
 
   await prepare(gpu, [{ draw: fx, target: screen }]);
-  // Recording a bundle over a surface stays a frame-scoped operation (VGPU-SURFACE-NOT-IN-FRAME outside
-  // one) — unchanged by the split: what matters here is that the surface is still a legal bundle target.
+  // Recording a bundle over a surface is legal in or out of a frame (contract #8 / §4: recording needs
+  // only formats) — unchanged by the split: what matters here is that the surface is a legal bundle target.
   expect(codeOf(() => frame(gpu, () => { bundle(gpu, { target: screen, label: "surfaceBundle" }, (b) => b.draw(fx)); }))).toBe("NO-THROW");
 
   expect(codeOf(() => frame(gpu, (f) => f.pass(screen, (p) => p.draw(fx)), { pendingPipelines: "throw" }))).toBe("NO-THROW");


### PR DESCRIPTION
Ticket **T04-13** (ola de corte, tren vgpu 0.4). Closes the contradiction between `bundle()`'s own
doc-comment and its first statement.

## What

`createBundle()` threw `VGPU-SURFACE-NOT-IN-FRAME` for a `Surface` target outside `frame()`. That guard
was a leftover from before `Surface` had a frame-independent pipeline signature (#327/#337) and before
bundle construction became tracking-only (#335). It contradicted:

- the doc-comment two lines above `bundle()`: *"Recording needs only formats — never
  `getCurrentTexture()` — so `bundle(gpu, { target: surface }, …)` is legal outside `frame()`, exactly
  like `prepare()`"*;
- rev6.1 §4 and contract #8 (`prepare()` against a surface outside `frame()` resolves, and the resolved
  signature equals the one used encoding inside a frame — `bundle()` is another target-signature
  consumer in the same terms).

One line of `src` deleted, plus the three imports it was the last user of. Net **-29 B** gzip across the
measured entries; **no budget ceiling moved**.

## Behavior, end to end

`bundle(gpu, { target: surface }, rec)` with no frame open → born `"pending-pipelines"` →
`await prepare(gpu, [{ bundle }])` → `"ready"`, **without ever opening a frame or fetching the
presentation texture** → replayed inside a later `frame()` under `pendingPipelines: "throw"`, it executes
the native bundle produced by `prepare()` into the surface's own presentation view, compiling nothing
extra (the signature resolved outside the frame is byte-identical to the one resolved inside).

## Out of scope (deliberately untouched)

The other three users of `surfaceNotInFrameError` guard **encoding**, which genuinely needs the current
texture, and stay loud:

- `draw.ts:434` (`InternalDraw.draw()` legacy one-shot encode-and-submit) and `effect().draw()` through it;
- `frame.ts:235` — `Frame.pass()` on an already-submitted frame. Different semantics: not "outside a frame
  that never existed" but "the frame that existed already ended".

Retiring the one-shot spelling is T04-22's call, not this PR's.

## Tests

- `bundle-signature.test.ts`: the newly-legal path (construct + `prepare()`, no frame ever opened, and
  `getCurrentTexture()` never called); a regression test that `Frame.pass()` through an escaped frame after
  submit still throws `VGPU-SURFACE-NOT-IN-FRAME` (**this guard had no test at all before this PR** —
  verified by mutating it away on `next/0.4`, where the whole corpus stays green); a disposed-surface
  negative that pins the rejection on `VGPU-SURFACE-DISPOSED` (the liveness assert in
  `Surface.pipelineSignature`), not on the deleted guard.
- `compile-api.test.ts`: one assertion updated — it encoded the old, buggy behavior. Its sibling
  assertions for the one-shot paths are unchanged and still kill a mutant that drops their guard.

## Verification

Full corpus **2116 passed / 141 skipped**, `pnpm typecheck` clean, `pnpm bundle-check` green with every
ceiling unchanged. Adversarial QA + mutation pass: 6 mutants, all the load-bearing ones killed by the
suite — reintroducing the deleted guard kills the new positive test, deleting the liveness assert behind
the signature getter kills the disposed test, and removing either out-of-scope guard kills its own test.
