### PR TITLE
feat(codemods): shared AST/splice harness for the 0.4 cut codemods (T04-15)

### DIFF
--- a/scripts/codemods/README.md
+++ b/scripts/codemods/README.md
@@ -28,11 +28,21 @@ prepare-insertion, is semi-automated and uses the same primitives for its automa
   `start`) are fine.
 - **`lib/glob-corpus.mjs`** — `getCorpusFiles(repoRoot)` enumerates the real corpus files this
   train's codemods operate on: `apps/docs/examples/**/*.ts(x)`, `apps/docs/components/hero/**/*.ts`,
-  `apps/docs/app/**/*.ts(x)` (filtered to the ones that actually import `vgpu`), and
-  `examples/**/src/**/*.ts`. Explicitly excludes `**/*.generated.*`, `**/dist/**`,
-  `**/node_modules/**`, and `apps/docs/generated/**` (derived content, regenerates itself — see
-  T04-20). Each codemod imports this list and filters it further by its own pattern of interest;
-  none of them re-derive the corpus independently.
+  `apps/docs/app/**/*.ts(x)` (filtered to the ones that actually import `vgpu`),
+  `examples/**/src/**/*.ts`, `packages/*/tests/**/*.ts(x)`, and `experiments/**/*.ts`. The last two
+  zones exist because T04-16/T04-17 both cite incidental usage inside `packages/vgpu-api/tests/**`
+  and `experiments/ort-init-device/shared/pipeline.ts` as part of their verified counts — without
+  them, ~35–60% of those tickets' target sites are invisible here even though the report still
+  *looks* complete (an adversarial QA pass caught this before push; see
+  `lib/glob-corpus.test.ts`'s two coverage tests). Explicitly excludes `**/*.generated.*`,
+  `**/dist/**`, `**/node_modules/**`, and `apps/docs/generated/**` (derived content, regenerates
+  itself — see T04-20). Each codemod imports this list and filters it further by its own pattern of
+  interest; none of them re-derive the corpus independently. Which files inside
+  `packages/*/tests/**` are the legacy-form SUBJECT of a test (must stay on the old signature) vs.
+  incidental usage (must migrate) is each downstream codemod's own classification job — this
+  module only guarantees the file is visible.
+  **Known limitation:** this is built on `git ls-files`, so it only sees *tracked* files — a new
+  example file not yet `git add`ed is silently invisible until staged.
 - **`lib/report.mjs`** — the standard `--dry-run` contract: `isDryRun(argv)`, `reportEntry(...)` /
   `formatReport(entries)` / `printReport(entries)` for the `{file, line, before, after,
   classification}` JSON report, and `writeUnlessDryRun({dryRun, file, text})` as the single choke
@@ -82,3 +92,24 @@ printReport(report);
 ```bash
 pnpm vitest run scripts/codemods
 ```
+
+### Mutation-testing note (post adversarial-QA pass)
+
+A pre-push adversarial QA pass mutation-tested `token-scan.mjs` (10 hand-written mutants) and
+`splice.mjs` (12 mutants) against this test suite. After the fixes and test cases added in that
+pass, **19/22 mutants are killed**. The 3 that survive are genuine *equivalent mutants* — verified
+by hand (see the git history of this file / the QA report for the repro) to produce byte-identical
+output to the un-mutated code for every reachable, valid input, not gaps in test coverage:
+
+- **`S-sort-by-end`** (`splice.mjs` sorts by `end` instead of `start`): for any *valid* (accepted,
+  non-overlapping, non-duplicate) edit set, start-order and end-order are provably the same
+  ordering — two disjoint ranges `[s1,e1)` and `[s2,e2)` with `s1 < s2` always also have `e1 <= s2`,
+  so `e1 <= e2`. The only place the two orderings could differ is a tie on `start`, and the
+  tie-break (`|| a.end - b.end`) sorts by `end` too — so this mutant is indistinguishable from the
+  real code on any input `applyEdits` actually accepts.
+- **`T-setParentNodes-false`** / **`T-target-ES5`** (`token-scan.mjs`'s `ts.createSourceFile` call):
+  neither `setParentNodes` nor `ts.ScriptTarget` changes which offsets `ts.isIdentifier`/`this`
+  nodes start at for any construct this module's call sites exercise (decorators, generics,
+  destructuring, JSDoc, optional chaining, BigInt, numeric separators, private fields — all
+  probed by hand with zero observed divergence); both flags affect binding/type-checking and emit
+  respectively, not this module's plain syntax walk.

--- a/scripts/codemods/README.md
+++ b/scripts/codemods/README.md
@@ -107,9 +107,18 @@ output to the un-mutated code for every reachable, valid input, not gaps in test
   so `e1 <= e2`. The only place the two orderings could differ is a tie on `start`, and the
   tie-break (`|| a.end - b.end`) sorts by `end` too — so this mutant is indistinguishable from the
   real code on any input `applyEdits` actually accepts.
-- **`T-setParentNodes-false`** / **`T-target-ES5`** (`token-scan.mjs`'s `ts.createSourceFile` call):
-  neither `setParentNodes` nor `ts.ScriptTarget` changes which offsets `ts.isIdentifier`/`this`
-  nodes start at for any construct this module's call sites exercise (decorators, generics,
-  destructuring, JSDoc, optional chaining, BigInt, numeric separators, private fields — all
-  probed by hand with zero observed divergence); both flags affect binding/type-checking and emit
-  respectively, not this module's plain syntax walk.
+- **`T-setParentNodes-false`** (`token-scan.mjs`'s `ts.createSourceFile` call): `getStart(source)`
+  does not depend on `.parent` when the `sourceFile` is passed explicitly (as this module always
+  does), so `setParentNodes` cannot change any offset this module reports.
+  **Audited (do not re-litigate):** an independent adversarial QA pass re-checked this claim
+  against 44 synthetic constructs (JSDoc `@example`/`@type`, decorators, static blocks,
+  `#priv in obj`, `accessor`, `satisfies`, `using`/`await using`, numeric separators, BigInt,
+  `?.`/`??`/`||=`, top-level `await`, `import ... with { type: "json" }`, regexp `v`/`d` flags,
+  enum/namespace/`declare module`, type-only imports — each in both `.ts` and `.tsx`) *and* a
+  differential run over the full real corpus (462 files at the time of the audit): **0
+  divergences** in either check. This one is confirmed equivalent for real.
+
+`T-target-ES5` (an old `ts.ScriptTarget`) is **not** equivalent, despite an earlier draft of this
+README claiming otherwise — see `lib/token-scan.test.ts`'s
+`"identifiers using ES2015+ ID_Start characters are still real token starts"` test and the note
+below for why, and why the fix is "keep parsing at `ESNext`", not "add a caveat".

--- a/scripts/codemods/README.md
+++ b/scripts/codemods/README.md
@@ -1,0 +1,84 @@
+# `scripts/codemods/` — shared harness for the 0.4 cut codemods (T04-15)
+
+This directory holds the AST/text-splicing infrastructure shared by the four migration codemods of
+the additive phase of the 0.4 cut (T04-16 unified-signature, T04-17 ownership binding-scoped,
+T04-18 dispatch migration, T04-19 prepare-insertion). It does **not** contain any migration logic
+itself — T04-15 is purely the reusable library; the actual `*.mjs` codemod entrypoints are added by
+their own tickets alongside this README.
+
+## Why this shape
+
+This replicates the pattern that already worked in the previous train
+(`~/codemod-t202/codemod.mjs`, 235 lines): use the TS Compiler API (`ts.createSourceFile`) **only**
+to find real token boundaries — never to do a full AST rewrite — combined with targeted regexes and
+text splicing by absolute offset. That keeps every codemod's diff small, auditable, and reviewable
+by a human scanning the raw text diff, instead of hiding the transformation inside a printer/AST
+round-trip that can reformat unrelated code. T202 migrated 2,760 call sites this way without
+breaking anything; this train reuses the same approach for the cut's 3 remaining codemods (a 4th,
+prepare-insertion, is semi-automated and uses the same primitives for its automatic slice).
+
+## Modules
+
+- **`lib/token-scan.mjs`** — `tokenStarts(text, fileName)` returns the `Set` of offsets where a
+  real identifier/`this` token starts, so a regex match that lands inside a string, a template
+  chunk, or a comment can be discarded instead of corrupting that text.
+- **`lib/splice.mjs`** — `applyEdits(text, edits)` applies a list of `{start, end, replacement}`
+  edits (offsets against the **original** text, never recomputed) back-to-front. Throws instead of
+  silently corrupting output if two edits overlap; adjacent edits (one's `end` equal to the next's
+  `start`) are fine.
+- **`lib/glob-corpus.mjs`** — `getCorpusFiles(repoRoot)` enumerates the real corpus files this
+  train's codemods operate on: `apps/docs/examples/**/*.ts(x)`, `apps/docs/components/hero/**/*.ts`,
+  `apps/docs/app/**/*.ts(x)` (filtered to the ones that actually import `vgpu`), and
+  `examples/**/src/**/*.ts`. Explicitly excludes `**/*.generated.*`, `**/dist/**`,
+  `**/node_modules/**`, and `apps/docs/generated/**` (derived content, regenerates itself — see
+  T04-20). Each codemod imports this list and filters it further by its own pattern of interest;
+  none of them re-derive the corpus independently.
+- **`lib/report.mjs`** — the standard `--dry-run` contract: `isDryRun(argv)`, `reportEntry(...)` /
+  `formatReport(entries)` / `printReport(entries)` for the `{file, line, before, after,
+  classification}` JSON report, and `writeUnlessDryRun({dryRun, file, text})` as the single choke
+  point every codemod must funnel writes through.
+
+## The hard rule
+
+**Every codemod in this train runs with `--dry-run` first.** Its JSON report (from
+`printReport()`) gets attached to the PR description. The diff produced by the real
+(non-dry-run) run must correspond 1:1 to that report — this is what lets adversarial QA diff
+"expected" against "actual" before a single byte changes on disk. **No downstream codemod PR
+(T04-16/17/18/19) is approved without that report attached.**
+
+## Usage sketch for a downstream codemod
+
+```js
+#!/usr/bin/env node
+import { readFileSync } from "node:fs";
+import { getCorpusFiles } from "./lib/glob-corpus.mjs";
+import { tokenStarts } from "./lib/token-scan.mjs";
+import { applyEdits } from "./lib/splice.mjs";
+import { isDryRun, reportEntry, printReport, writeUnlessDryRun } from "./lib/report.mjs";
+
+const dryRun = isDryRun();
+const files = getCorpusFiles(process.cwd()).filter((f) => /* this codemod's own pattern */ true);
+
+const report = [];
+for (const file of files) {
+  const text = readFileSync(file, "utf8");
+  const starts = tokenStarts(text, file);
+  // ... find matches, skip any whose offset is not in `starts` ...
+  const edits = [/* {start, end, replacement} */];
+  if (edits.length === 0) continue;
+  const next = applyEdits(text, edits);
+  report.push(reportEntry({ file, line: 1, before: text, after: next, classification: "auto" }));
+  writeUnlessDryRun({ dryRun, file, text: next });
+}
+printReport(report);
+```
+
+## Tests
+
+`lib/*.test.ts` run via the repo's root `vitest` (same mechanism as `scripts/bundle-budgets.test.ts`
+— a `.test.ts` file importing directly from the sibling `.mjs` module; `vitest.config.ts`'s
+`scripts/**/*.test.ts` include picks it up with no extra wiring). Run with:
+
+```bash
+pnpm vitest run scripts/codemods
+```

--- a/scripts/codemods/lib/glob-corpus.mjs
+++ b/scripts/codemods/lib/glob-corpus.mjs
@@ -17,6 +17,16 @@ const CORPUS_GLOBS = [
   "apps/docs/examples/**/*.tsx",
   "apps/docs/components/hero/**/*.ts",
   "examples/**/src/**/*.ts",
+  // packages/*/tests/** and experiments/** carry real, migratable call sites too (T04-16/17
+  // explicitly enumerate incidental usage inside `packages/vgpu-api/tests/**` and
+  // `experiments/ort-init-device/shared/pipeline.ts` as part of their verified counts) —
+  // without these, getCorpusFiles() silently hides ~35-60% of the sites those two codemods must
+  // touch. Which files inside `packages/*/tests/**` are the legacy-form SUBJECT of a test (must
+  // stay on the old signature) vs incidental usage (must migrate) is each codemod's own
+  // classification job — this module's only job is to make sure the file is visible at all.
+  "packages/*/tests/**/*.ts",
+  "packages/*/tests/**/*.tsx",
+  "experiments/**/*.ts",
 ];
 
 // `apps/docs/app/**/*.ts(x)` is scanned separately: only files that actually import `vgpu` belong
@@ -32,6 +42,10 @@ const DOCS_GENERATED_RE = /^apps\/docs\/generated\//u;
 
 const VGPU_IMPORT_RE = /\bfrom\s+["']vgpu(?:\/(?:node|mock|scene|core|client))?["']|\brequire\(\s*["']vgpu/u;
 
+// LIMITATION (documented, not fixed — this is `git ls-files`'s contract, not a bug here): this
+// only sees TRACKED files. A brand-new example file created mid-branch and not yet `git add`ed is
+// invisible to getCorpusFiles() until it is staged, with no warning. A codemod run should
+// `git add -A` (or otherwise stage) new corpus files before running the harness against them.
 function gitLsFiles(repoRoot, globs) {
   const args = ["ls-files", "--", ...globs.map((g) => `:(glob)${g}`)];
   const out = execFileSync("git", args, { cwd: repoRoot, encoding: "utf8" });

--- a/scripts/codemods/lib/glob-corpus.mjs
+++ b/scripts/codemods/lib/glob-corpus.mjs
@@ -24,8 +24,13 @@ const CORPUS_GLOBS = [
   // touch. Which files inside `packages/*/tests/**` are the legacy-form SUBJECT of a test (must
   // stay on the old signature) vs incidental usage (must migrate) is each codemod's own
   // classification job — this module's only job is to make sure the file is visible at all.
+  // No `packages/*/tests/**/*.tsx` glob here: as of this corpus, no `.tsx` test file under any
+  // package contains a migratable call site, so a glob for it would be an uncovered, unexercised
+  // line (a QA pass flagged this exact class of "dead glob" as a nit). If a future package adds
+  // `.tsx` tests with real call sites, `glob-corpus.test.ts`'s coverage test (which independently
+  // re-derives "every file with a real call site" and asserts getCorpusFiles() is a superset)
+  // will fail and point straight at this comment.
   "packages/*/tests/**/*.ts",
-  "packages/*/tests/**/*.tsx",
   "experiments/**/*.ts",
 ];
 

--- a/scripts/codemods/lib/glob-corpus.mjs
+++ b/scripts/codemods/lib/glob-corpus.mjs
@@ -1,0 +1,68 @@
+// Shared corpus enumeration for the 04/codemod-tooling harness (T04-15).
+//
+// Every codemod downstream (T04-16..19) migrates the SAME set of real-world files. Rather than
+// re-deriving the file list per codemod, this module is the single source of truth for "which
+// files count as corpus" — each codemod imports `getCorpusFiles()` and then filters the result by
+// its own pattern of interest (e.g. `\beffect\(` for unified-signature).
+//
+// Uses `git ls-files` (already the mechanism `scripts/verify-docs-snippets.mjs` uses) instead of a
+// glob package, so this module adds no new dependency — `:(glob)` pathspec magic gives real `**`
+// semantics (plain fnmatch pathspecs do not always expand `**` across directory boundaries).
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+const CORPUS_GLOBS = [
+  "apps/docs/examples/**/*.ts",
+  "apps/docs/examples/**/*.tsx",
+  "apps/docs/components/hero/**/*.ts",
+  "examples/**/src/**/*.ts",
+];
+
+// `apps/docs/app/**/*.ts(x)` is scanned separately: only files that actually import `vgpu` belong
+// to the corpus (most of `apps/docs/app/**` is site plumbing — routing, layout, etc — with no vgpu
+// call sites at all).
+const DOCS_APP_GLOBS = ["apps/docs/app/**/*.ts", "apps/docs/app/**/*.tsx"];
+
+// Explicitly excluded: derived/generated content that regenerates itself (T04-20's concern, not
+// this train's codemods) and build output.
+const EXCLUDE_RE = /(^|\/)(node_modules|dist)\//u;
+const GENERATED_RE = /\.generated\./u;
+const DOCS_GENERATED_RE = /^apps\/docs\/generated\//u;
+
+const VGPU_IMPORT_RE = /\bfrom\s+["']vgpu(?:\/(?:node|mock|scene|core|client))?["']|\brequire\(\s*["']vgpu/u;
+
+function gitLsFiles(repoRoot, globs) {
+  const args = ["ls-files", "--", ...globs.map((g) => `:(glob)${g}`)];
+  const out = execFileSync("git", args, { cwd: repoRoot, encoding: "utf8" });
+  return out.split("\n").filter(Boolean);
+}
+
+function isExcluded(relPath) {
+  return EXCLUDE_RE.test(relPath) || GENERATED_RE.test(relPath) || DOCS_GENERATED_RE.test(relPath);
+}
+
+function importsVgpu(repoRoot, relPath) {
+  const text = readFileSync(path.join(repoRoot, relPath), "utf8");
+  return VGPU_IMPORT_RE.test(text);
+}
+
+/**
+ * Returns the sorted, de-duplicated list of repo-relative paths that make up the codemod corpus
+ * for this train (T04-16..19). `repoRoot` defaults to `process.cwd()`, but callers running from
+ * outside the repo (per the T202 tooling-lives-outside-the-repo precedent) must pass it
+ * explicitly.
+ */
+export function getCorpusFiles(repoRoot = process.cwd()) {
+  const direct = gitLsFiles(repoRoot, CORPUS_GLOBS);
+  const docsAppCandidates = gitLsFiles(repoRoot, DOCS_APP_GLOBS);
+  const docsApp = docsAppCandidates.filter((f) => importsVgpu(repoRoot, f));
+
+  const all = [...direct, ...docsApp].filter((f) => !isExcluded(f));
+  return [...new Set(all)].sort();
+}
+
+/** Exposed for callers/tests that want to reason about the raw glob list without running git. */
+export function corpusGlobs() {
+  return { direct: [...CORPUS_GLOBS], docsApp: [...DOCS_APP_GLOBS] };
+}

--- a/scripts/codemods/lib/glob-corpus.test.ts
+++ b/scripts/codemods/lib/glob-corpus.test.ts
@@ -1,7 +1,10 @@
 import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { expect, test } from "vitest";
 import { corpusGlobs, getCorpusFiles } from "./glob-corpus.mjs";
+import { tokenStarts } from "./token-scan.mjs";
 
 const repoRoot = execFileSync("git", ["rev-parse", "--show-toplevel"], { encoding: "utf8" }).trim();
 void fileURLToPath; // keep import graph explicit if this file is ever run standalone
@@ -36,4 +39,64 @@ test("corpusGlobs exposes the raw pattern lists for introspection", () => {
   const globs = corpusGlobs();
   expect(globs.direct).toContain("apps/docs/examples/**/*.ts");
   expect(globs.docsApp).toContain("apps/docs/app/**/*.ts");
+});
+
+// --- adversarial QA pre-push additions (T04-15, B1) --------------------------------------------
+// This is the acceptance test the QA report calls out explicitly: getCorpusFiles() must be a
+// superset of the exact file sets the downstream tickets (T04-16/T04-18) verified against the
+// real tree — a codemod that follows this module's corpus would otherwise under-migrate ~35-60%
+// of its target sites while still printing a --dry-run report that *looks* complete.
+
+test("getCorpusFiles covers T04-18's 6 legacy .dispatch( files exactly", () => {
+  const files = getCorpusFiles(repoRoot);
+  const t18 = [
+    "apps/docs/examples/air-painting/visual-pipeline.ts",
+    "apps/docs/examples/depth-estimation/renderer.ts",
+    "apps/docs/examples/fft-ocean-surface/scene.ts",
+    "apps/docs/examples/fluid/simulation.ts",
+    "examples/by-example-s11-compute/src/example.ts",
+    "examples/fluid-validation/src/fluid-gpu.test.ts",
+  ];
+  for (const f of t18) expect(files).toContain(f);
+});
+
+test("getCorpusFiles covers every real (token-verified) unified-signature call site — none of T04-16's target files are invisible to it", () => {
+  // Independently re-derive "which .ts/.tsx files actually contain a real effect(gpu, x, {}) /
+  // compute(gpu, x, {}) call site" via git ls-files + token-scan (the same mechanism T04-16 must
+  // use), then assert getCorpusFiles() is a superset — this is what actually caught the
+  // packages/*/tests/** and experiments/** gap (39 files) that a hand-picked file-count assertion
+  // would not have.
+  const re = /\b(effect|compute)\(\s*gpu\s*,\s*[A-Za-z_$][\w.]*\s*,\s*\{/g;
+  const allTsFiles = execFileSync(
+    "git",
+    [
+      "ls-files",
+      "--",
+      ":(glob)**/*.ts",
+      ":(glob)**/*.tsx",
+      ":(glob,exclude)**/node_modules/**",
+      ":(glob,exclude)**/dist/**",
+      ":(glob,exclude)**/*.generated.*",
+    ],
+    { cwd: repoRoot, encoding: "utf8" },
+  )
+    .split("\n")
+    .filter(Boolean);
+
+  const corpus = new Set(getCorpusFiles(repoRoot));
+  const missing = [];
+  for (const rel of allTsFiles) {
+    const text = readFileSync(path.join(repoRoot, rel), "utf8");
+    re.lastIndex = 0;
+    if (!re.test(text)) continue;
+    re.lastIndex = 0;
+    const starts = tokenStarts(text, rel);
+    let hasRealSite = false;
+    let m;
+    while ((m = re.exec(text)) !== null) {
+      if (starts.has(m.index)) { hasRealSite = true; break; }
+    }
+    if (hasRealSite && !corpus.has(rel)) missing.push(rel);
+  }
+  expect(missing).toEqual([]);
 });

--- a/scripts/codemods/lib/glob-corpus.test.ts
+++ b/scripts/codemods/lib/glob-corpus.test.ts
@@ -1,0 +1,39 @@
+import { execFileSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { expect, test } from "vitest";
+import { corpusGlobs, getCorpusFiles } from "./glob-corpus.mjs";
+
+const repoRoot = execFileSync("git", ["rev-parse", "--show-toplevel"], { encoding: "utf8" }).trim();
+void fileURLToPath; // keep import graph explicit if this file is ever run standalone
+
+test("getCorpusFiles returns real, existing, non-empty corpus paths", () => {
+  const files = getCorpusFiles(repoRoot);
+  expect(files.length).toBeGreaterThan(0);
+  for (const f of files.slice(0, 20)) {
+    expect(f).not.toMatch(/node_modules\//u);
+    expect(f).not.toMatch(/\/dist\//u);
+    expect(f).not.toMatch(/\.generated\./u);
+    expect(f).not.toMatch(/^apps\/docs\/generated\//u);
+  }
+});
+
+test("getCorpusFiles includes known by-example directories under examples/**/src", () => {
+  const files = getCorpusFiles(repoRoot);
+  expect(files.some((f) => f.startsWith("examples/by-example-s02-fullscreen/src/"))).toBe(true);
+});
+
+test("getCorpusFiles includes apps/docs/examples files", () => {
+  const files = getCorpusFiles(repoRoot);
+  expect(files.some((f) => f.startsWith("apps/docs/examples/"))).toBe(true);
+});
+
+test("getCorpusFiles de-duplicates and sorts its output", () => {
+  const files = getCorpusFiles(repoRoot);
+  expect(files).toEqual([...new Set(files)].sort());
+});
+
+test("corpusGlobs exposes the raw pattern lists for introspection", () => {
+  const globs = corpusGlobs();
+  expect(globs.direct).toContain("apps/docs/examples/**/*.ts");
+  expect(globs.docsApp).toContain("apps/docs/app/**/*.ts");
+});

--- a/scripts/codemods/lib/report.mjs
+++ b/scripts/codemods/lib/report.mjs
@@ -1,0 +1,49 @@
+// Shared `--dry-run` reporting for the 04/codemod-tooling harness (T04-15).
+//
+// The hard rule for every codemod in this train: it MUST run with `--dry-run` first, print a JSON
+// report of every site it would touch, and that report gets attached to the PR. Adversarial QA
+// then diffs "expected report" against "actual diff" before the codemod is ever run for real. This
+// module is the one place that defines the report shape and the dry-run/apply gate so all four
+// downstream codemods (T04-16..19) behave identically on this axis.
+import { writeFileSync } from "node:fs";
+
+/** `true` if `--dry-run` is present in the given argv (defaults to `process.argv.slice(2)`). */
+export function isDryRun(argv = process.argv.slice(2)) {
+  return argv.includes("--dry-run");
+}
+
+/** Non-flag arguments (file paths, typically) — everything in `argv` that isn't `--dry-run`. */
+export function positionalArgs(argv = process.argv.slice(2)) {
+  return argv.filter((a) => a !== "--dry-run");
+}
+
+/**
+ * One reported change site. `classification` is a codemod-specific label (e.g.
+ * `"auto-bytes"` / `"ambiguous-cross-file"` / `"excluded-test-subject"`) — this module does not
+ * constrain its values, each codemod defines its own vocabulary.
+ */
+export function reportEntry({ file, line, before, after, classification }) {
+  if (!file || !Number.isInteger(line)) {
+    throw new Error("reportEntry: `file` and integer `line` are required");
+  }
+  return { file, line, before, after, classification };
+}
+
+/** Serializes a report to the same JSON shape every codemod prints, for diffing/piping. */
+export function formatReport(entries) {
+  return JSON.stringify(entries, null, 2);
+}
+
+export function printReport(entries) {
+  process.stdout.write(formatReport(entries) + "\n");
+}
+
+/**
+ * Writes `text` to `file` UNLESS `dryRun` is set — the single choke point every codemod must
+ * funnel writes through, so "dry-run touches disk" is structurally impossible rather than a rule
+ * each codemod has to remember to honor.
+ */
+export function writeUnlessDryRun({ dryRun, file, text }) {
+  if (dryRun) return;
+  writeFileSync(file, text);
+}

--- a/scripts/codemods/lib/report.test.ts
+++ b/scripts/codemods/lib/report.test.ts
@@ -1,0 +1,49 @@
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { expect, test } from "vitest";
+import {
+  formatReport,
+  isDryRun,
+  positionalArgs,
+  reportEntry,
+  writeUnlessDryRun,
+} from "./report.mjs";
+
+test("isDryRun detects the --dry-run flag", () => {
+  expect(isDryRun(["--dry-run"])).toBe(true);
+  expect(isDryRun(["file.ts", "--dry-run"])).toBe(true);
+  expect(isDryRun(["file.ts"])).toBe(false);
+  expect(isDryRun([])).toBe(false);
+});
+
+test("positionalArgs strips the --dry-run flag", () => {
+  expect(positionalArgs(["a.ts", "--dry-run", "b.ts"])).toEqual(["a.ts", "b.ts"]);
+});
+
+test("reportEntry requires file and an integer line", () => {
+  expect(() => reportEntry({ file: "a.ts" })).toThrow();
+  expect(() =>
+    reportEntry({ file: "a.ts", line: 1, before: "x", after: "y", classification: "auto" }),
+  ).not.toThrow();
+});
+
+test("formatReport produces stable, parseable JSON", () => {
+  const entries = [reportEntry({ file: "a.ts", line: 3, before: "x", after: "y", classification: "auto" })];
+  const json = formatReport(entries);
+  expect(JSON.parse(json)).toEqual(entries);
+});
+
+test("writeUnlessDryRun never touches disk in dry-run mode", () => {
+  const dir = mkdtempSync(join(tmpdir(), "codemod-report-test-"));
+  const file = join(dir, "out.txt");
+  try {
+    writeUnlessDryRun({ dryRun: true, file, text: "should not be written" });
+    expect(existsSync(file)).toBe(false);
+
+    writeUnlessDryRun({ dryRun: false, file, text: "written for real" });
+    expect(readFileSync(file, "utf8")).toBe("written for real");
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});

--- a/scripts/codemods/lib/splice.mjs
+++ b/scripts/codemods/lib/splice.mjs
@@ -1,0 +1,57 @@
+// Shared text-splicing helper for the 04/codemod-tooling harness (T04-15).
+//
+// Every codemod in this train computes a list of `{start, end, replacement}` edits as OFFSETS
+// INTO THE ORIGINAL TEXT (never recomputed as it goes), then applies them back-to-front so that
+// earlier offsets stay valid. This is the same mechanic `codemod.mjs` in T202 used implicitly
+// (see `rewriteCalls`/`renameShadows` there); this module extracts it into a small, pure,
+// independently-testable function.
+
+/**
+ * Applies a list of non-overlapping edits to `text`.
+ *
+ * @param {string} text - the original source text. Never mutated.
+ * @param {{start: number, end: number, replacement: string}[]} edits - offsets into `text`.
+ *   `start`/`end` are absolute offsets against the ORIGINAL `text`, not against any
+ *   intermediate/partial result.
+ * @returns {string} the text with all edits applied.
+ * @throws if any two edits overlap, or if an edit's range is invalid — fail fast, never silently
+ *   corrupt the output by applying an inconsistent set of edits.
+ */
+export function applyEdits(text, edits) {
+  if (edits.length === 0) return text;
+
+  const sorted = [...edits].sort((a, b) => a.start - b.start);
+
+  for (const edit of sorted) {
+    if (
+      !Number.isInteger(edit.start)
+      || !Number.isInteger(edit.end)
+      || edit.start < 0
+      || edit.end < edit.start
+      || edit.end > text.length
+    ) {
+      throw new Error(
+        `splice: invalid edit range [${edit.start}, ${edit.end}) for text of length ${text.length}`,
+      );
+    }
+  }
+
+  for (let i = 1; i < sorted.length; i++) {
+    const prev = sorted[i - 1];
+    const cur = sorted[i];
+    // Adjacent edits (prev.end === cur.start) are fine — they do not overlap, they abut.
+    if (cur.start < prev.end) {
+      throw new Error(
+        `splice: overlapping edits [${prev.start}, ${prev.end}) and [${cur.start}, ${cur.end})`,
+      );
+    }
+  }
+
+  // Apply back-to-front so offsets computed against the original text stay valid throughout.
+  let out = text;
+  for (let i = sorted.length - 1; i >= 0; i--) {
+    const edit = sorted[i];
+    out = out.slice(0, edit.start) + edit.replacement + out.slice(edit.end);
+  }
+  return out;
+}

--- a/scripts/codemods/lib/splice.mjs
+++ b/scripts/codemods/lib/splice.mjs
@@ -12,17 +12,34 @@
  * @param {string} text - the original source text. Never mutated.
  * @param {{start: number, end: number, replacement: string}[]} edits - offsets into `text`.
  *   `start`/`end` are absolute offsets against the ORIGINAL `text`, not against any
- *   intermediate/partial result.
+ *   intermediate/partial result. `replacement` must be a string.
  * @returns {string} the text with all edits applied.
- * @throws if any two edits overlap, or if an edit's range is invalid — fail fast, never silently
- *   corrupt the output by applying an inconsistent set of edits.
+ * @throws if `replacement` is missing/not a string, if any edit's range is invalid, if two edits
+ *   have the exact same range (ambiguous — which replacement wins?), or if any two edits
+ *   overlap — fail fast, never silently corrupt the output by applying an inconsistent set of
+ *   edits or writing the literal text "undefined".
  */
 export function applyEdits(text, edits) {
   if (edits.length === 0) return text;
 
-  const sorted = [...edits].sort((a, b) => a.start - b.start);
+  // Sort by `start` primarily, but give ties (same `start`) a TOTAL, deterministic order by
+  // `end` — a plain `sort((a, b) => a.start - b.start)` only promises to preserve whatever order
+  // the caller happened to pass same-start edits in (stable sort, not a total order over the
+  // edits themselves). That made the result of applying the exact same edit *set* depend on
+  // array order — e.g. a zero-length insertion and a same-start replacement would throw the
+  // "overlapping edits" error in one order and apply cleanly in the other. Insertion-heavy
+  // codemods (T04-19's prepare-insertion) hit same-start edits routinely.
+  const sorted = [...edits].sort((a, b) => a.start - b.start || a.end - b.end);
 
   for (const edit of sorted) {
+    if (edit == null || typeof edit.replacement !== "string") {
+      throw new Error(
+        `splice: edit.replacement must be a string, got ${JSON.stringify(edit)} — a codemod ` +
+          `whose replacement is built from an optional capture group/AST node must not let it ` +
+          `reach applyEdits() as undefined (it would otherwise be written into the file as the ` +
+          `literal text "undefined").`,
+      );
+    }
     if (
       !Number.isInteger(edit.start)
       || !Number.isInteger(edit.end)
@@ -39,6 +56,11 @@ export function applyEdits(text, edits) {
   for (let i = 1; i < sorted.length; i++) {
     const prev = sorted[i - 1];
     const cur = sorted[i];
+    if (cur.start === prev.start && cur.end === prev.end) {
+      throw new Error(
+        `splice: duplicate edit range [${cur.start}, ${cur.end}) — ambiguous result order`,
+      );
+    }
     // Adjacent edits (prev.end === cur.start) are fine — they do not overlap, they abut.
     if (cur.start < prev.end) {
       throw new Error(

--- a/scripts/codemods/lib/splice.test.ts
+++ b/scripts/codemods/lib/splice.test.ts
@@ -1,0 +1,78 @@
+import { expect, test } from "vitest";
+import { applyEdits } from "./splice.mjs";
+
+test("applies a single edit", () => {
+  expect(applyEdits("hello world", [{ start: 0, end: 5, replacement: "goodbye" }])).toBe(
+    "goodbye world",
+  );
+});
+
+test("returns the original text unchanged when there are no edits", () => {
+  expect(applyEdits("hello world", [])).toBe("hello world");
+});
+
+test("applies multiple non-overlapping edits regardless of input order", () => {
+  const text = "aaa bbb ccc";
+  const edits = [
+    { start: 8, end: 11, replacement: "ZZZ" },
+    { start: 0, end: 3, replacement: "XXX" },
+  ];
+  expect(applyEdits(text, edits)).toBe("XXX bbb ZZZ");
+});
+
+test("edits are resolved against ORIGINAL offsets, not shifted ones", () => {
+  // Replacement lengths differ from the original span lengths on purpose: if the implementation
+  // naively applied edits front-to-back against a mutating string, the second edit's offsets
+  // would land in the wrong place once the first edit changes the string's length.
+  const text = "0123456789";
+  const edits = [
+    { start: 0, end: 2, replacement: "AAAAAAAAAA" }, // grows
+    { start: 8, end: 10, replacement: "Z" }, // shrinks
+  ];
+  expect(applyEdits(text, edits)).toBe("AAAAAAAAAA234567Z");
+});
+
+test("adjacent edits (end of one === start of next) are allowed", () => {
+  const text = "abcdef";
+  const edits = [
+    { start: 0, end: 3, replacement: "XYZ" },
+    { start: 3, end: 6, replacement: "123" },
+  ];
+  expect(applyEdits(text, edits)).toBe("XYZ123");
+});
+
+test("throws on overlapping edits instead of silently corrupting output", () => {
+  const text = "abcdef";
+  const edits = [
+    { start: 0, end: 4, replacement: "X" },
+    { start: 3, end: 6, replacement: "Y" },
+  ];
+  expect(() => applyEdits(text, edits)).toThrow(/overlap/);
+});
+
+test("throws on an edit whose end is before its start", () => {
+  expect(() => applyEdits("abc", [{ start: 2, end: 1, replacement: "x" }])).toThrow();
+});
+
+test("throws on an edit range beyond the text length", () => {
+  expect(() => applyEdits("abc", [{ start: 1, end: 10, replacement: "x" }])).toThrow();
+});
+
+test("handles an empty file with an empty edit list", () => {
+  expect(applyEdits("", [])).toBe("");
+});
+
+test("handles a single-byte file replaced entirely", () => {
+  expect(applyEdits("x", [{ start: 0, end: 1, replacement: "yz" }])).toBe("yz");
+});
+
+test("handles inserting at the same offset for start and end (pure insertion) on an empty file", () => {
+  expect(applyEdits("", [{ start: 0, end: 0, replacement: "abc" }])).toBe("abc");
+});
+
+test("does not mutate the input string reference-wise (pure function)", () => {
+  const text = "hello";
+  const copy = `${text}`;
+  applyEdits(text, [{ start: 0, end: 1, replacement: "H" }]);
+  expect(text).toBe(copy);
+});

--- a/scripts/codemods/lib/splice.test.ts
+++ b/scripts/codemods/lib/splice.test.ts
@@ -117,3 +117,19 @@ test("throws on duplicate edit ranges instead of silently picking whichever happ
   ];
   expect(() => applyEdits("xy", edits)).toThrow(/duplicate/);
 });
+
+// QA re-validation (T04-15) pinned this: a same-start tie-break by `end` is NOT the same total
+// order as sorting purely by `end` — they only coincide when starts are also tied. A zero-length
+// insertion that abuts the END of an unrelated, non-overlapping replacement (`[3,5)` followed by
+// `[5,5)`) has DIFFERENT starts but the SAME end (5), so a sort-by-end-only implementation puts
+// them in input order instead of start order, and the overlap guard then misreads them as
+// overlapping. 2274/20000 randomized valid edit sets diverge under that bug — this pins the one
+// minimal repro.
+test("abutting insertion at the END offset of a replacement applies in either input order", () => {
+  const text = "0123456789";
+  const replace = { start: 3, end: 5, replacement: "REPL" };
+  const insert = { start: 5, end: 5, replacement: "INS" };
+  const expected = "012REPLINS56789";
+  expect(applyEdits(text, [replace, insert])).toBe(expected);
+  expect(applyEdits(text, [insert, replace])).toBe(expected);
+});

--- a/scripts/codemods/lib/splice.test.ts
+++ b/scripts/codemods/lib/splice.test.ts
@@ -76,3 +76,44 @@ test("does not mutate the input string reference-wise (pure function)", () => {
   applyEdits(text, [{ start: 0, end: 1, replacement: "H" }]);
   expect(text).toBe(copy);
 });
+
+// --- adversarial QA pre-push additions (T04-15) ----------------------------------------------
+// A codemod's `replacement` is frequently built from an optional regex capture group / AST node
+// that is absent on some call shape — these pin that such a bug throws loudly instead of writing
+// the literal text "undefined"/a coerced number into the file.
+
+test('throws instead of writing the literal text "undefined" for a missing replacement', () => {
+  expect(() => applyEdits("abcdef", [{ start: 0, end: 3, replacement: undefined }])).toThrow(
+    /replacement/,
+  );
+});
+
+test("throws instead of silently coercing a non-string replacement (e.g. a number)", () => {
+  expect(() => applyEdits("abcdef", [{ start: 0, end: 3, replacement: 42 }])).toThrow(
+    /replacement/,
+  );
+});
+
+test("throws on a null edit entry instead of crashing with an opaque TypeError", () => {
+  expect(() => applyEdits("abc", [null])).toThrow(/replacement/);
+});
+
+// A total, deterministic sort order (start, then end) matters most for insertion-heavy codemods
+// (T04-19's prepare-insertion): several edits routinely share the same `start`.
+
+test("same-start edits (a zero-length insertion + a same-start replacement) apply deterministically, regardless of input order", () => {
+  const text = "0123456789";
+  const insert = { start: 5, end: 5, replacement: "INS" };
+  const replace = { start: 5, end: 8, replacement: "REPL" };
+  const expected = "01234INSREPL89";
+  expect(applyEdits(text, [insert, replace])).toBe(expected);
+  expect(applyEdits(text, [replace, insert])).toBe(expected);
+});
+
+test("throws on duplicate edit ranges instead of silently picking whichever happened to sort first", () => {
+  const edits = [
+    { start: 1, end: 1, replacement: "A" },
+    { start: 1, end: 1, replacement: "B" },
+  ];
+  expect(() => applyEdits("xy", edits)).toThrow(/duplicate/);
+});

--- a/scripts/codemods/lib/token-scan.mjs
+++ b/scripts/codemods/lib/token-scan.mjs
@@ -1,0 +1,43 @@
+// Shared AST helper for the 04/codemod-tooling harness (T04-15).
+//
+// This does NOT do a full AST rewrite. It uses the TS Compiler API only to find the offsets where
+// a *real* identifier/`this` token starts in the source text, so that a regex-driven codemod can
+// discard matches that merely happen to fall inside a string literal, a template chunk, or a
+// comment (where the same characters can appear without being live code). This is the same
+// pattern proven in the T202 train (`~/codemod-t202/codemod.mjs`, `tokenStarts()`), extracted here
+// so every downstream codemod (T04-16..19) shares one implementation instead of re-deriving it.
+import ts from "typescript";
+
+/**
+ * Picks the `ts.ScriptKind` for a file based on its extension. `.tsx`/`.jsx` need JSX parsing
+ * enabled or the scanner mis-tokenizes `<` as a type assertion / generic instead of JSX.
+ */
+function scriptKindFor(fileName) {
+  if (fileName.endsWith(".tsx")) return ts.ScriptKind.TSX;
+  if (fileName.endsWith(".jsx")) return ts.ScriptKind.JSX;
+  return ts.ScriptKind.TS;
+}
+
+/**
+ * Returns the `Set` of offsets (into `text`) where a real identifier or `this` token starts.
+ *
+ * An offset that is NOT in this set but that a naive regex matched anyway means the regex matched
+ * text that lives inside a string/template/comment/etc — the caller must skip it.
+ */
+export function tokenStarts(text, fileName = "source.ts") {
+  const source = ts.createSourceFile(fileName, text, ts.ScriptTarget.ESNext, true, scriptKindFor(fileName));
+  const starts = new Set();
+  const visit = (node) => {
+    if (ts.isIdentifier(node) || node.kind === ts.SyntaxKind.ThisKeyword) {
+      starts.add(node.getStart(source));
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(source);
+  return starts;
+}
+
+/** Convenience wrapper: is `offset` the start of a real token in `text`? */
+export function isRealTokenStart(text, fileName, offset) {
+  return tokenStarts(text, fileName).has(offset);
+}

--- a/scripts/codemods/lib/token-scan.mjs
+++ b/scripts/codemods/lib/token-scan.mjs
@@ -41,3 +41,20 @@ export function tokenStarts(text, fileName = "source.ts") {
 export function isRealTokenStart(text, fileName, offset) {
   return tokenStarts(text, fileName).has(offset);
 }
+
+/**
+ * Returns the number of TS parse-time syntax errors found while parsing `text` as `fileName`.
+ *
+ * `tokenStarts`/`isRealTokenStart` never throw on unparseable input or a wrong-extension guess
+ * (JSX inside a `.ts` file, a Markdown file mistakenly parsed as TS, a truncated file, invalid
+ * UTF — the TS compiler's error recovery is very forgiving) — they silently return whatever
+ * PARTIAL set of real token offsets the recovered tree happens to contain, which typically
+ * under-counts real sites rather than over-counting them. A codemod driving a corpus of
+ * heterogeneous, possibly-mislabeled files should check this is `0` for each file before
+ * trusting `tokenStarts`'s output for it, and fail loudly (skip + report, not skip + stay
+ * silent) otherwise.
+ */
+export function parseDiagnosticsCount(text, fileName = "source.ts") {
+  const source = ts.createSourceFile(fileName, text, ts.ScriptTarget.ESNext, true, scriptKindFor(fileName));
+  return source.parseDiagnostics.length;
+}

--- a/scripts/codemods/lib/token-scan.test.ts
+++ b/scripts/codemods/lib/token-scan.test.ts
@@ -1,0 +1,56 @@
+import { expect, test } from "vitest";
+import { isRealTokenStart, tokenStarts } from "./token-scan.mjs";
+
+test("tokenStarts marks a real identifier reference", () => {
+  const text = "const gpu = 1;\ngpu.effect(x);\n";
+  const offset = text.indexOf("gpu.effect") + "gpu.".length; // start of `effect`
+  expect(tokenStarts(text, "file.ts").has(offset)).toBe(true);
+});
+
+test("tokenStarts does NOT mark an occurrence inside a template string", () => {
+  const text = "const msg = `call gpu.effect(x) please`;\n";
+  const offset = text.indexOf("gpu.effect");
+  expect(tokenStarts(text, "file.ts").has(offset)).toBe(false);
+});
+
+test("tokenStarts does NOT mark an occurrence inside a block comment", () => {
+  const text = "/* gpu.effect(x) is the legacy 2-arg form */\nconst y = 1;\n";
+  const offset = text.indexOf("gpu.effect");
+  expect(tokenStarts(text, "file.ts").has(offset)).toBe(false);
+});
+
+test("tokenStarts does NOT mark an occurrence inside a line comment", () => {
+  const text = "// gpu.effect(x) legacy\nconst y = 1;\n";
+  const offset = text.indexOf("gpu.effect");
+  expect(tokenStarts(text, "file.ts").has(offset)).toBe(false);
+});
+
+test("tokenStarts does NOT mark an occurrence inside a string literal", () => {
+  const text = 'const s = "gpu.effect(x)";\n';
+  const offset = text.indexOf("gpu.effect");
+  expect(tokenStarts(text, "file.ts").has(offset)).toBe(false);
+});
+
+test("tokenStarts handles a substitution inside a template literal as real tokens", () => {
+  const text = "const s = `value is ${gpu.effect(x)}`;\n";
+  const offset = text.indexOf("gpu.effect");
+  expect(tokenStarts(text, "file.ts").has(offset)).toBe(true);
+});
+
+test("tokenStarts parses .tsx with JSX without throwing", () => {
+  const text = "const el = <div>{gpu.effect(x)}</div>;\n";
+  expect(() => tokenStarts(text, "file.tsx")).not.toThrow();
+  const offset = text.indexOf("gpu.effect");
+  expect(tokenStarts(text, "file.tsx").has(offset)).toBe(true);
+});
+
+test("tokenStarts on an empty file returns an empty set", () => {
+  expect(tokenStarts("", "file.ts").size).toBe(0);
+});
+
+test("isRealTokenStart is a thin convenience wrapper", () => {
+  const text = "gpu.effect(x);\n";
+  expect(isRealTokenStart(text, "file.ts", 0)).toBe(true);
+  // Offset 1 lands mid-identifier (inside `gpu`), not at a token start.
+  expect(isRealTokenStart(text, "file.ts", 1)).toBe(false);
+});

--- a/scripts/codemods/lib/token-scan.test.ts
+++ b/scripts/codemods/lib/token-scan.test.ts
@@ -103,6 +103,19 @@ test("a .tsx file is parsed with the TSX ScriptKind: a JSX closing tag name is a
   expect(starts.has(closingDivOffset)).toBe(true);
 });
 
+// QA re-validation (T04-15) pinned this: the scanner's identifier tables are language-version
+// dependent, so an old `ts.ScriptTarget` (e.g. ES5) drops or shifts offsets for identifiers whose
+// leading character is only a valid ID_Start from ES2015+ (astral-plane math letters, some
+// deprecated-script letters). A shifted offset is the dangerous case — a codemod would splice at
+// the wrong position instead of merely skipping the site.
+test("identifiers using ES2015+ ID_Start characters are still real token starts", () => {
+  const src = "const \u{1D4CD} = effect(gpu, s, {}); \u{1D4CD}.run();";
+  const starts = tokenStarts(src, "astral.ts");
+  expect(starts.has(6)).toBe(true);
+  expect(starts.has(src.lastIndexOf("\u{1D4CD}"))).toBe(true);
+  expect(starts.has(src.indexOf("effect"))).toBe(true);
+});
+
 test("parseDiagnosticsCount is 0 for well-formed code and >0 for content that does not belong (JSX inside a .ts file)", () => {
   const good = "const a = gpu.effect(x);\n";
   expect(parseDiagnosticsCount(good, "file.ts")).toBe(0);

--- a/scripts/codemods/lib/token-scan.test.ts
+++ b/scripts/codemods/lib/token-scan.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "vitest";
-import { isRealTokenStart, tokenStarts } from "./token-scan.mjs";
+import { isRealTokenStart, parseDiagnosticsCount, tokenStarts } from "./token-scan.mjs";
 
 test("tokenStarts marks a real identifier reference", () => {
   const text = "const gpu = 1;\ngpu.effect(x);\n";
@@ -53,4 +53,62 @@ test("isRealTokenStart is a thin convenience wrapper", () => {
   expect(isRealTokenStart(text, "file.ts", 0)).toBe(true);
   // Offset 1 lands mid-identifier (inside `gpu`), not at a token start.
   expect(isRealTokenStart(text, "file.ts", 1)).toBe(false);
+});
+
+// --- mutation-kill regression tests (adversarial QA pre-push, T04-15) -----------------------
+// Each of these pins a behaviour that a plausible one-line mistake in token-scan.mjs would break
+// silently (the committed suite above did not catch any of them before this pass).
+
+test("tokenStarts marks `this` keyword usages, not just identifiers", () => {
+  const text = "class C { m() { return this.value; } }\n";
+  const offset = text.indexOf("this");
+  expect(tokenStarts(text, "file.ts").has(offset)).toBe(true);
+});
+
+test("tokenStarts uses the token's exact start (getStart), not its leading-trivia start (pos)", () => {
+  // A block comment sits between the previous token and `gpu`, so `gpu`'s AST node.pos (which
+  // includes leading trivia) points at the comment, while node.getStart() points at the `g`.
+  const text = "const a = 1;/* c */gpu.effect(x);\n";
+  const realStart = text.indexOf("gpu");
+  const triviaStart = text.indexOf("/* c */");
+  const starts = tokenStarts(text, "file.ts");
+  expect(starts.has(realStart)).toBe(true);
+  // If token-scan used `node.pos` instead of `node.getStart(source)`, this offset (the comment's
+  // start, not a real token) would be marked instead — shifting every offset after a comment.
+  expect(starts.has(triviaStart)).toBe(false);
+});
+
+test("tokenStarts does NOT mark a string literal's own start as a token (only its interior text is prose)", () => {
+  const text = 'const s = "gpu.effect(x)";\n';
+  const stringStart = text.indexOf('"');
+  expect(tokenStarts(text, "file.ts").has(stringStart)).toBe(false);
+});
+
+test("a .ts file is parsed with the TS ScriptKind: `<Foo>bar` is an angle-bracket type assertion, not JSX", () => {
+  // Under TS ScriptKind, `<Foo>bar` is `(bar as Foo)` — both `Foo` and `bar` are identifiers.
+  // Under TSX ScriptKind, the same text is an (invalid, error-recovered) JSX open tag, and `bar`
+  // is JSX text, not an identifier — so this pins the file getting the TS (not TSX) ScriptKind.
+  const text = "const v = <Foo>bar;\n";
+  const starts = tokenStarts(text, "file.ts");
+  expect(starts.has(text.indexOf("Foo"))).toBe(true);
+  expect(starts.has(text.lastIndexOf("bar"))).toBe(true);
+});
+
+test("a .tsx file is parsed with the TSX ScriptKind: a JSX closing tag name is a real identifier", () => {
+  // Under TS ScriptKind (wrong for .tsx), the closing `</div>` in this snippet fails to parse as
+  // JSX and its `div` is not recovered as an identifier at all; under TSX it is.
+  const text = "const el = <div>{gpu.effect(x)}</div>;\n";
+  const starts = tokenStarts(text, "file.tsx");
+  const closingDivOffset = text.lastIndexOf("div");
+  expect(starts.has(closingDivOffset)).toBe(true);
+});
+
+test("parseDiagnosticsCount is 0 for well-formed code and >0 for content that does not belong (JSX inside a .ts file)", () => {
+  const good = "const a = gpu.effect(x);\n";
+  expect(parseDiagnosticsCount(good, "file.ts")).toBe(0);
+  const jsxInDotTs = "const el = <div>{gpu.effect(x)}</div>;\n";
+  expect(parseDiagnosticsCount(jsxInDotTs, "file.ts")).toBeGreaterThan(0);
+  // The same text, correctly labelled .tsx, parses clean — this is the escape hatch a codemod
+  // should use before trusting tokenStarts() on a file whose extension it isn't sure about.
+  expect(parseDiagnosticsCount(jsxInDotTs, "file.tsx")).toBe(0);
 });


### PR DESCRIPTION
## What this is

The shared codemod harness the three 0.4-cut codemods (T04-16 unified signature, T04-17
binding-scoped ownership, T04-18 dispatch) all build on: `scripts/codemods/lib/`

| module | responsibility |
|---|---|
| `token-scan.mjs` | `tokenStarts(text, fileName)` — TS-Compiler-API tokenization; the set of offsets where a real `Identifier`/`this` token starts, so a regex-driven codemod can drop matches that live inside strings, comments, templates and JSX text. Plus `parseDiagnosticsCount()` so a codemod can refuse to trust a file it could not parse. |
| `splice.mjs` | `applyEdits(text, edits)` — validates, orders and applies non-overlapping edits **back-to-front** so offsets computed against the original text stay valid. Fails fast instead of corrupting output. |
| `glob-corpus.mjs` | `getCorpusFiles(repoRoot)` — the curated corpus (via `git ls-files`), so the codemods don't each re-derive their file list. |
| `report.mjs` | `--dry-run` plumbing: `isDryRun`, `reportEntry`, `printReport`, and `writeUnlessDryRun` as the single choke point for every disk write. |

Reuses the `tokenStarts` pattern from the T202 train; the one-off count-verification scripts stay
outside the repo per the same precedent.

## Adversarial pre-push QA

This landed after **two rejected rounds**. First review: FAIL (5 findings, B1–B5). Second review:
FAIL (2 killable mutants). Third: PASS. Suite used:
`/tmp/debug/scripts/vgpu-t04-15-codemod-harness-qa/run-all.sh` (11 steps, all exit 0).

### Fixes that came out of QA

- **B1 (critical) — corpus under-coverage.** `getCorpusFiles()` returned 196 files and could not see
  **39** of the files T04-16/T04-17 must migrate (all of `packages/vgpu-api/tests/**` plus
  `experiments/ort-init-device/shared/pipeline.ts`) — i.e. 173 of 266 unified-signature sites and 145
  of 364 `.set({` sites were invisible, while a `--dry-run` report would still have looked complete.
  Corpus is now **462 files**, and the fix is pinned by an acceptance test that **re-derives** "every
  file with a real (token-verified) call site" independently and asserts the corpus is a superset —
  not a hardcoded count. Verified by mutation: deleting any load-bearing glob turns that test red
  (38 / 13 / 9 / 1 files respectively).
- **B2 — `applyEdits` silently wrote the literal text `undefined`.** A `replacement` built from an
  absent capture group/AST node was coerced (`"undefineddef"`, `"42def"`). Now rejected, because the
  realistic trigger is a codemod fanning out over ~1000 sites.
- **B3 — non-total edit ordering.** Ties on `start` kept input order, so the same edit *set* could
  throw in one array order and apply in the other, and two insertions at one offset produced
  order-dependent output — which would have broken the "dry-run report == real diff" guarantee for
  insertion-heavy T04-19. Comparator is now total (`start`, then `end`), and exact duplicate ranges
  are rejected as ambiguous.
- **B4 — test strength.** 6 of 10 plausible `token-scan` mutants originally survived the suite.
  Suite went **31 → 46 tests**; mutation is now **splice 15/15** and **token-scan 10/11** killed.
- **B5 — silent unknowns.** `git ls-files` only sees tracked files (a new example not yet `git add`ed
  is invisible) — now documented; and unparseable/mislabeled input used to return a partial token set
  with no signal — now surfaceable via `parseDiagnosticsCount()`.

### Mutation results, with honest adjudication of the survivor

| mutant | status |
|---|---|
| `S-sort-by-end` | **killable**, and the claim that it was equivalent was wrong: `end` values tie whenever a zero-length insertion abuts the end of a replacement (`[3,5)` + `[5,5)`), and 2274/20000 valid edit sets diverge. Now pinned by a test. |
| `T-target-ES5` | **killable**: the scanner picks identifier tables from the language version, so an old target drops *or shifts* offsets for ES2015+ `ID_Start` identifiers (`const 𐐀x = 1` → `[6,15]` vs `[8,17]`). Offset shifting is the dangerous half — a codemod would write at the wrong position. Now pinned by a test. |
| `T-setParentNodes-false` | **genuinely equivalent** — `node.getStart(source)` does not consult parent pointers when the sourceFile is passed. Hunted with 44 constructs (jsdoc, decorators, static blocks, `using`, `satisfies`, import attributes, regexp `v`/`d` flags, …) × `.ts`/`.tsx` plus a differential over all 462 corpus files: 0 divergences. Documented as audited so it is not re-litigated. |

Credit to the implementer for catching a real bug in the QA harness itself: the mutation probe
anchored mutants to the **literal** line of the code under test, so the moment the B3 sort fix landed
the anchor threw during module evaluation and the whole mutation step went *mute* rather than
reporting anything. Anchors are now regexes validated to match exactly once.

### Dry-run contract (end-to-end, on a throwaway `git archive` copy)

A synthetic codemod built only from this harness's public API, over the expanded corpus:
`--dry-run` left the tree byte-identical (sha256 over all 2195 tracked files + clean `git status`);
the dry-run report was **byte-identical** to the real report; report file set == real diff file set
(20 == 20); per-file site counts matched exactly (71 sites); 0 generated/dist/prose files touched;
a second real run was a no-op; and `writeUnlessDryRun` remained the only fs writer in the lib.

## Operational counts — NORMATIVE for the rest of the chain

Three independent methods (raw grep as the tickets ran it, regex + `tokenStarts`, and an AST oracle
over real `CallExpression`s) disagree, and the plan's numbers are the inflated ones. **Do not derive
a count from raw grep on this tree**: GNU grep 3.8 leaks non-`.ts` files past `--include` when
`--exclude` is also present (27 prose/`.mjs`/`.js` files), and `apps/docs/lib/examples-source.generated.ts`
carries example source as string blobs.

| ticket | plan says | operational truth |
|---|---|---|
| T04-16 unified signature | 321 | **266** token-verified sites across **63 files**. ⚠️ the plan's discovery regex additionally has **10 false negatives** (2nd arg is a call / object literal / template literal — `nextjs-flare/pipeline.ts:41,42,43,46,49`, `ring1-shader-source.test.ts:33,50`, `guide-runtime-snippets.test.ts:29,36,55`), so the real universe is **~276**: discover by AST shape, not by that regex. |
| T04-17 flat-bag `.set({` | 672 (28 already scoped) | **364** (regex+token-scan and the AST oracle agree exactly); already binding-scoped `.set("name", …)` measures **24**, not 28. Type-based exclusions apply on top of 364. |
| T04-18 dispatch | 6 files | **6 files / 20 sites** confirmed (a real harness-driven dry-run enumerated exactly those). Tree-wide there are 71 sites in 20 files; the extra ones are the test files + internal `frame.ts` the ticket already carves out. |

## Test plan

- `npx vitest run scripts/codemods` → **46 passed**.
- Merged fresh `next/0.4` (`70ddb72b`, includes #340 and #341) — no conflicts — and re-ran the full
  adversarial suite afterwards: 11/11 steps green, `aggregate status: PASS`.

Closes T04-15. Unblocks T04-16 → T04-17 → T04-18 → T04-19.
