### PR TITLE
T04-18 — codemod: retire the legacy lazy-sync dispatch() call sites

### DIFF
--- a/examples/by-example-s11-compute/src/example.ts
+++ b/examples/by-example-s11-compute/src/example.ts
@@ -18,6 +18,6 @@ export async function runComputeExample() {
   src.write(new Float32Array([1, 2, 3, 4]));
   const sim = compute(gpu, { shader: SIM, label: "sim" });
   sim.set({ dt: 0.5, src, dst });
-  sim.dispatch(1);
+  await sim.dispatchOnce(1);
   return { gpu, dst };
 }

--- a/examples/fluid-validation/src/fluid-gpu.test.ts
+++ b/examples/fluid-validation/src/fluid-gpu.test.ts
@@ -30,10 +30,10 @@ async function projectionFixture(seed: boolean) {
     if (seed) for (let y=0;y<H;y++) for(let x=0;x<W;x++){const i=(y*W+x)*2;initial[i]=Math.sin(x*.71+y*.23)*.7;initial[i+1]=Math.cos(x*.19-y*.83)*.6;}
     velocity.write(initial); projected.write(new Float32Array(N*2)); pressure.read.write(new Float32Array(N)); pressure.write.write(new Float32Array(N));
     const sim={size:[W,H]}; const div=compute(gpu, DIVERGENCE); const jacobi=compute(gpu, PRESSURE); const project=compute(gpu, PROJECT);
-    div.set({sim,velocity,divergence:before}).dispatch(2,2);
-    for(let i=0;i<8;i++){jacobi.set({sim,src:pressure.read,divergence:before,dst:pressure.write}).dispatch(2,2);pressure.swap();}
-    project.set({sim,src:velocity,pressure:pressure.read,dst:projected}).dispatch(2,2);
-    div.set({sim,velocity:projected,divergence:after}).dispatch(2,2);
+    await div.set({sim,velocity,divergence:before}).dispatchOnce(2,2);
+    for(let i=0;i<8;i++){await jacobi.set({sim,src:pressure.read,divergence:before,dst:pressure.write}).dispatchOnce(2,2);pressure.swap();}
+    await project.set({sim,src:velocity,pressure:pressure.read,dst:projected}).dispatchOnce(2,2);
+    await div.set({sim,velocity:projected,divergence:after}).dispatchOnce(2,2);
     const [preBytes,postBytes,projectedBytes,pressureBytes]=await Promise.all([before.read(),after.read(),projected.read(),pressure.read.read()]);
     return { pre:new Float32Array(preBytes),post:new Float32Array(postBytes),projected:new Float32Array(projectedBytes),pressure:new Float32Array(pressureBytes) };
   } finally { gpu.dispose(); }

--- a/experiments/ort-init-device/shared/pipeline.ts
+++ b/experiments/ort-init-device/shared/pipeline.ts
@@ -34,7 +34,7 @@ export async function runPipeline(gpu: Gpu, raw: GPUBuffer, mode: Mode): Promise
     try {
       const consumer = compute(gpu, { shader: WGSL, label: `ort-${mode}-consumer` });
       consumer.set({ source, destination });
-      consumer.dispatch(1);
+      await consumer.dispatchOnce(1);
       lifecycle.push("consumer-submitted");
       await gpu.device.queue.flush();
       lifecycle.push("queue-flushed");

--- a/packages/vgpu-api/tests/dispatch-order-motivation.test.ts
+++ b/packages/vgpu-api/tests/dispatch-order-motivation.test.ts
@@ -1,0 +1,214 @@
+/**
+ * Motivation #1 of the rev6.1 design, verified rather than asserted (T04-18's DoD).
+ *
+ * > "a dispatch issued inside a frame callback submits before the frame's own encoder... Program
+ * > order and execution order diverge."
+ *
+ * `frame-unified.test.ts` already pins the `f.compute()` side of contract #1 (one encoder, one
+ * submit). What it does not pin is the CONTRAST that makes T04-18's migration worth doing: what the
+ * legacy `Compute.dispatch()` actually does to the observable command order when it is called from
+ * inside a frame callback, and that `f.compute()` is what removes it. Both arms are recorded here
+ * off the same mock device, on one timeline, so the claim is a diff between two recordings and not a
+ * pair of independent "it compiles" checks.
+ *
+ * The two shapes are deliberately different failures:
+ *
+ *  - **The `fft-ocean-surface` shape** (compute passes first, then the render that consumes them).
+ *    Program order survives here — WebGPU queue submits are ordered, and the dispatch's own submit
+ *    happens first — so the cost of the legacy form is the EXTRA SUBMITS, one per dispatch, not a
+ *    wrong result. Worth stating plainly: this is why the corpus renders correctly today.
+ *  - **The inverted shape** (a pass first, then a dispatch). Here the legacy form really does
+ *    reorder: the dispatch opens its own encoder and submits it *during* the callback, while the
+ *    pass recorded before it is still sitting in the frame's encoder, unsubmitted. Execution order
+ *    comes out as the REVERSE of program order. That is the divergence motivation #1 names, and
+ *    `f.compute()` removes it.
+ */
+import { afterEach, expect, test, vi } from "vitest";
+import { compute, draw, frame, init, target } from "../src/mock.ts";
+
+const RENDER_WGSL = `
+@vertex fn vs_main(@builtin(vertex_index) vi: u32) -> @builtin(position) vec4f {
+  var pos = array<vec2f, 3>(vec2f(-1.0, -1.0), vec2f(3.0, -1.0), vec2f(-1.0, 3.0));
+  return vec4f(pos[vi], 0.0, 1.0);
+}
+@fragment fn fs_main() -> @location(0) vec4f { return vec4f(1.0); }
+`;
+
+const COMPUTE_WGSL = `@compute @workgroup_size(1) fn main() {}`;
+
+let gpu: Awaited<ReturnType<typeof init>> | undefined;
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  gpu?.dispose();
+  gpu = undefined;
+});
+
+/**
+ * One ordered timeline of everything the device is told to do, across EVERY encoder.
+ *
+ * `spyFrameEncoder()` in `frame-unified.test.ts` deliberately watches only the encoder labelled
+ * `vgpu.frame`, which is the right lens for "did this land in the frame's encoder". It is the wrong
+ * lens here: the whole point is what happens on the OTHER encoders, so this one tags every encoder
+ * by its label, follows each `finish()` to the command buffer it produces, and records submits with
+ * the labels of the buffers they carry.
+ */
+function recordTimeline(device: GPUDevice): string[] {
+  const timeline: string[] = [];
+  const labelOfBuffer = new WeakMap<GPUCommandBuffer, string>();
+  const createCommandEncoder = device.createCommandEncoder.bind(device);
+  vi.spyOn(device, "createCommandEncoder").mockImplementation((desc?: GPUCommandEncoderDescriptor) => {
+    const encoder = createCommandEncoder(desc);
+    const label = desc?.label ?? "<unlabelled>";
+    const beginRenderPass = encoder.beginRenderPass.bind(encoder);
+    const beginComputePass = encoder.beginComputePass.bind(encoder);
+    const finish = encoder.finish.bind(encoder);
+    (encoder as { beginRenderPass: unknown }).beginRenderPass = (d: GPURenderPassDescriptor) => {
+      timeline.push(`encode ${label}: renderPass`);
+      return beginRenderPass(d);
+    };
+    (encoder as { beginComputePass: unknown }).beginComputePass = (d?: GPUComputePassDescriptor) => {
+      timeline.push(`encode ${label}: computePass`);
+      return beginComputePass(d);
+    };
+    (encoder as { finish: unknown }).finish = (d?: GPUCommandBufferDescriptor) => {
+      const buffer = finish(d);
+      labelOfBuffer.set(buffer, label);
+      return buffer;
+    };
+    return encoder;
+  });
+  const submit = device.queue.submit.bind(device.queue);
+  vi.spyOn(device.queue, "submit").mockImplementation((buffers: Iterable<GPUCommandBuffer>) => {
+    const list = [...buffers];
+    timeline.push(`submit  ${list.map((b) => labelOfBuffer.get(b) ?? "<unknown>").join(", ")}`);
+    submit(list);
+  });
+  return timeline;
+}
+
+const submits = (timeline: readonly string[]) => timeline.filter((e) => e.startsWith("submit")).length;
+
+/** The order the GPU actually runs the work in: passes, in the order their SUBMIT reached the queue. */
+function executionOrder(timeline: readonly string[]): string[] {
+  const pending = new Map<string, string[]>();
+  const executed: string[] = [];
+  for (const event of timeline) {
+    const encoded = /^encode (?<label>.+): (?<kind>renderPass|computePass)$/u.exec(event);
+    if (encoded) {
+      const label = encoded.groups!["label"]!;
+      pending.set(label, [...(pending.get(label) ?? []), encoded.groups!["kind"]!]);
+      continue;
+    }
+    const submitted = /^submit {2}(?<labels>.+)$/u.exec(event);
+    if (!submitted) continue;
+    for (const label of submitted.groups!["labels"]!.split(", ")) {
+      executed.push(...(pending.get(label) ?? []));
+      pending.delete(label);
+    }
+  }
+  return executed;
+}
+
+// --- the fft-ocean-surface shape: computes, then the render that consumes them -------------------
+
+test("legacy dispatch() in a frame callback costs one extra submit per dispatch (the fft-ocean shape)", async () => {
+  gpu = await init();
+  const hdr = target(gpu, { size: [4, 4] });
+  const rowPass = compute(gpu, { shader: COMPUTE_WGSL, label: "fft-row" });
+  const colPass = compute(gpu, { shader: COMPUTE_WGSL, label: "fft-col" });
+  const ocean = draw(gpu, { shader: RENDER_WGSL, label: "ocean" });
+  const timeline = recordTimeline(gpu.device.gpu);
+
+  frame(gpu, (f) => {
+    rowPass.dispatch(1);
+    colPass.dispatch(1);
+    f.pass({ target: hdr }, (p) => p.draw(ocean));
+  });
+
+  expect(timeline).toEqual([
+    "encode fft-row.encoder: computePass",
+    "submit  fft-row.encoder",
+    "encode fft-col.encoder: computePass",
+    "submit  fft-col.encoder",
+    "encode vgpu.frame: renderPass",
+    "submit  vgpu.frame",
+  ]);
+  // Three submits for one frame, and the two computes are in flight before the frame's encoder is
+  // even finished. Program order does survive here — which is exactly why the corpus renders
+  // correctly today and why this migration is not a bug fix in this shape.
+  expect(submits(timeline)).toBe(3);
+  expect(executionOrder(timeline)).toEqual(["computePass", "computePass", "renderPass"]);
+});
+
+test("f.compute() collapses the same frame to one encoder and one submit, in program order (contract #1)", async () => {
+  gpu = await init();
+  const hdr = target(gpu, { size: [4, 4] });
+  const rowPass = compute(gpu, { shader: COMPUTE_WGSL, label: "fft-row" });
+  const colPass = compute(gpu, { shader: COMPUTE_WGSL, label: "fft-col" });
+  const ocean = draw(gpu, { shader: RENDER_WGSL, label: "ocean" });
+  const timeline = recordTimeline(gpu.device.gpu);
+
+  frame(gpu, (f) => {
+    f.compute(rowPass, 1);
+    f.compute(colPass, 1);
+    f.pass({ target: hdr }, (p) => p.draw(ocean));
+  });
+
+  expect(timeline).toEqual([
+    "encode vgpu.frame: computePass",
+    "encode vgpu.frame: computePass",
+    "encode vgpu.frame: renderPass",
+    "submit  vgpu.frame",
+  ]);
+  expect(submits(timeline)).toBe(1);
+  expect(executionOrder(timeline)).toEqual(["computePass", "computePass", "renderPass"]);
+});
+
+// --- the inverted shape: this is where the legacy form is actually WRONG --------------------------
+
+test("legacy dispatch() AFTER a pass inverts execution order against program order (motivation #1)", async () => {
+  gpu = await init();
+  const hdr = target(gpu, { size: [4, 4] });
+  const sim = compute(gpu, { shader: COMPUTE_WGSL, label: "sim" });
+  const ocean = draw(gpu, { shader: RENDER_WGSL, label: "ocean" });
+  const timeline = recordTimeline(gpu.device.gpu);
+
+  frame(gpu, (f) => {
+    f.pass({ target: hdr }, (p) => p.draw(ocean));   // program order: render FIRST
+    sim.dispatch(1);                                  // program order: compute SECOND
+  });
+
+  // The pass was recorded into the frame's encoder, which is not submitted until the callback
+  // returns; the dispatch opened its own encoder and submitted it immediately, mid-callback.
+  expect(timeline).toEqual([
+    "encode vgpu.frame: renderPass",
+    "encode sim.encoder: computePass",
+    "submit  sim.encoder",
+    "submit  vgpu.frame",
+  ]);
+  expect(submits(timeline)).toBe(2);
+  // Program order says render-then-compute. Execution order says the opposite.
+  expect(executionOrder(timeline)).toEqual(["computePass", "renderPass"]);
+});
+
+test("f.compute() in the same position keeps program order and execution order identical", async () => {
+  gpu = await init();
+  const hdr = target(gpu, { size: [4, 4] });
+  const sim = compute(gpu, { shader: COMPUTE_WGSL, label: "sim" });
+  const ocean = draw(gpu, { shader: RENDER_WGSL, label: "ocean" });
+  const timeline = recordTimeline(gpu.device.gpu);
+
+  frame(gpu, (f) => {
+    f.pass({ target: hdr }, (p) => p.draw(ocean));
+    f.compute(sim, 1);
+  });
+
+  expect(timeline).toEqual([
+    "encode vgpu.frame: renderPass",
+    "encode vgpu.frame: computePass",
+    "submit  vgpu.frame",
+  ]);
+  expect(submits(timeline)).toBe(1);
+  expect(executionOrder(timeline)).toEqual(["renderPass", "computePass"]);
+});

--- a/scripts/codemods/README.md
+++ b/scripts/codemods/README.md
@@ -48,6 +48,38 @@ prepare-insertion, is semi-automated and uses the same primitives for its automa
   classification}` JSON report, and `writeUnlessDryRun({dryRun, file, text})` as the single choke
   point every codemod must funnel writes through.
 
+## Codemod entrypoints
+
+- **`unified-signature.mjs`** (T04-16) — 3-argument `effect(gpu, shader, opts)` onto the unified
+  options bag. Shape-only; needs no checker.
+- **`ownership-binding-scoped.mjs`** (T04-17) — the flat `.set({…})` bag onto binding-scoped
+  `.set("b", v)` / `.bind("b", r)` / construction-time `bindings`. Three oracles (checker for the
+  receiver, checker for each value, WGSL reflection for each key).
+- **`dispatch-migration.mjs`** (T04-18) — legacy lazy-sync `Compute.dispatch()` at the call sites
+  onto `f.compute(inst, n)` (inside a frame callback, one shared submit) or
+  `await inst.dispatchOnce(n)` (standalone). **The `await` is the whole difficulty**: `dispatchOnce()`
+  is async and `dispatch()` is not, so the transform is only sound where inserting an `await` costs
+  nothing observable — an already-`async` enclosing function, or the top level of an ES module.
+  Every other context (a sync callback handed to a third party, a method whose `: void` return is
+  fixed by an interface the module exports, a generator, a call whose value is consumed) goes to a
+  named `ambiguous-*` bucket **with a reason**, because forcing async there would change a published
+  contract. `dispatch()` cannot be deleted in T04-22 while those buckets are non-empty, so leaving
+  them silent would turn a design decision into a build break three tickets later.
+  Buckets: `auto-f-compute` · `auto-dispatch-once` · `ambiguous-sync-context` ·
+  `ambiguous-indirect-options` (`f.compute()` has no `indirect` overload) · `ambiguous-await-position`
+  · `ambiguous-arguments` · `unresolved-receiver` · `not-a-compute` · `excluded-test-subject` ·
+  `skipped-parse-error`.
+
+### Standing corpus invariants (`*.corpus.test.ts`)
+
+Two of these codemods ship a `.corpus.test.ts` next to their unit suite. They are not unit tests:
+they re-run the codemod's own classifier over the **real, migrated tree** and assert a property of
+the result (T04-17: no construction site pins a value read through a mutated object; T04-18: no
+`.dispatch()` remains in a context the codemod could have migrated on its own). They exist because
+the behaviour at these call sites is only asserted by suites gated behind `VGPU_DOCKER_TEST`, so on
+a normal CI run *nothing else in the repo would notice* a regression there. They are also what makes
+a new example file with a legacy call site fail immediately instead of at the cut.
+
 ## The hard rule
 
 **Every codemod in this train runs with `--dry-run` first.** Its JSON report (from

--- a/scripts/codemods/dispatch-migration.corpus.test.ts
+++ b/scripts/codemods/dispatch-migration.corpus.test.ts
@@ -1,0 +1,116 @@
+// A standing invariant over the MIGRATED corpus, not a unit test of a transform.
+//
+// `dispatch-migration.test.ts` pins the RULE against in-memory fixtures; this file pins the RESULT
+// against the real tree: after T04-18, no `.dispatch()` call anywhere in the corpus may still sit in
+// a context the codemod would have migrated on its own. That is the check that keeps the migration
+// from silently regressing — a new example added later, in an `async` function, with a legacy
+// `dispatch()` in it, fails here instead of surfacing as a build break in T04-22 when the method is
+// deleted.
+//
+// It matters that this runs over the real tree rather than fixtures, and that it is STRUCTURAL. The
+// behaviour the migrated sites have is only asserted by suites gated on real hardware
+// (`describe.skipIf(process.env.VGPU_DOCKER_TEST !== '1')` in `examples/fluid-validation`, and
+// `tests/gpu/*`), so on a normal CI run nothing else in the suite would notice a regression at these
+// call sites at all. Same reasoning, and same shape, as T04-17's
+// `ownership-binding-scoped.corpus.test.ts`.
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { createCorpusProgram } from "./lib/corpus-program.mjs";
+import { planProgram, LEGACY_DISPATCH_TEST_SUBJECTS } from "./dispatch-migration.mjs";
+
+const REPO_ROOT = path.resolve(import.meta.dirname, "../..");
+
+/**
+ * The `.dispatch()` sites T04-18 deliberately left behind, and why. Every one is a call whose
+ * containing function is synchronous and whose `void` return is part of a signature the module
+ * publishes, so `await dispatchOnce()` cannot be inserted without changing that contract, and no
+ * `Frame` is lexically in scope to offer `f.compute()` instead.
+ *
+ * This table is DEBT, pinned so it cannot grow by accident: **T04-22 cannot delete `dispatch()`
+ * until it is empty.** Each of these needs a hand decision that is a design change, not a rewrite —
+ * either thread a `Frame` into the function (which is what the rev6.1 design actually wants: it puts
+ * these dispatches in the same submit as the render that consumes them) or make the function async
+ * and propagate that to its callers.
+ *
+ * Counted per file rather than pinned per line so that unrelated edits above a site do not fail
+ * this test, while adding or removing a site does.
+ */
+const AMBIGUOUS_DEBT: ReadonlyArray<readonly [file: string, sites: number, reason: string]> = [
+  ["apps/docs/examples/air-painting/visual-pipeline.ts", 3, "`dispatchCrop` is module-local but its two callers `cropDetectorInput()`/`cropLandmarkInput()` and `consumeHandLandmarks()` are all declared `: void` on the exported `VisualPipeline` interface, and `ort-runtime.ts` calls them from sync paths."],
+  ["apps/docs/examples/depth-estimation/renderer.ts", 1, "`SideBySidePipeline.draw()` is declared `: void`. This one has a `runFrame()` five lines below it in the SAME method — the natural migration is to move the reduce inside that frame callback as `f.compute(reducer, 1)`, which is code motion, not a rewrite the codemod may do."],
+  ["apps/docs/examples/fft-ocean-surface/scene.ts", 4, "`OceanScene.simulate()`/`rebuildSpectrum()` are declared `: void`. `renderer.ts` calls `scene.simulate(dt)` from INSIDE a `frameLoop((currentFrame) => …)` callback — dynamically in a frame, but not lexically, so there is no `f` at the dispatch. Threading the `Frame` into `simulate()` is the migration the design wants and it changes the example's published interface."],
+  ["apps/docs/examples/fluid/simulation.ts", 7, "`stepFluid()` is an exported `: void` function called in tight loops (up to 5,000 iterations in `validation.ts`); 7 awaits per step is a different program, not the same one. This one wants a `Frame` threaded through, not async propagation."],
+];
+
+function planCorpus() {
+  const ctx = createCorpusProgram(REPO_ROOT);
+  return { ...ctx, ...planProgram(ctx) };
+}
+
+describe("the migrated corpus", () => {
+  it("has no `.dispatch()` left that the codemod could have migrated on its own", () => {
+    const { entries, fileTexts } = planCorpus();
+    // Named rather than counted: a regression should say which site and why, not just "1 != 0".
+    const migratable = entries
+      .filter((e: any) => String(e.classification).startsWith("auto-"))
+      .map((e: any) => `${e.file}:${e.line}  ${e.classification}  ${e.before}`);
+    expect(migratable).toEqual([]);
+    // The same claim from the other side: re-running the codemod for real would write nothing.
+    expect([...fileTexts.keys()]).toEqual([]);
+  });
+
+  it("pins the ambiguous debt T04-22 has to clear by hand", () => {
+    const { entries } = planCorpus();
+    const byFile = new Map<string, number>();
+    for (const e of entries as any[]) {
+      if (!String(e.classification).startsWith("ambiguous")) continue;
+      byFile.set(e.file, (byFile.get(e.file) ?? 0) + 1);
+    }
+    expect([...byFile].sort()).toEqual(AMBIGUOUS_DEBT.map(([file, n]) => [file, n]).sort());
+    // Every ambiguous site carries a machine-readable reason and a human-readable note — "classified,
+    // never silent" is the property, and an empty reason would satisfy the count check above.
+    for (const e of entries as any[]) {
+      if (!String(e.classification).startsWith("ambiguous")) continue;
+      expect(e.reason, `${e.file}:${e.line} has no reason`).toBeTruthy();
+      expect(e.note, `${e.file}:${e.line} has no note`).toBeTruthy();
+    }
+  });
+
+  it("keeps LEGACY_DISPATCH_TEST_SUBJECTS honest", () => {
+    // An exclusion that outlives its reason is an exemption nobody re-reads. Both halves are pinned:
+    // the file must still be in the corpus AND still contain a `.dispatch()` site, or the entry is
+    // dead and hiding nothing.
+    const { entries, corpus } = planCorpus();
+    for (const [rel, reason] of LEGACY_DISPATCH_TEST_SUBJECTS) {
+      expect(corpus, `${rel} is excluded but not in the corpus`).toContain(rel);
+      expect(
+        (entries as any[]).some((e) => e.file === rel && e.classification === "excluded-test-subject"),
+        `${rel} no longer has a \`.dispatch()\` site — drop the exclusion`,
+      ).toBe(true);
+      expect(reason.length, `${rel} has no stated reason`).toBeGreaterThan(40);
+    }
+  });
+
+  it("still sees the corpus it is supposed to be checking", () => {
+    // Without this the tests above pass vacuously the day the corpus enumeration breaks — the
+    // silent-zero failure mode #342's B1 finding was about. Measured on this branch: the tree-wide
+    // universe was 74 sites in 21 files immediately before the migration was applied, and 68 sites
+    // in 18 files after it (the three migrated files no longer contain a legacy `.dispatch()` at
+    // all). The assertions are floors, not equalities, so an unrelated new call site does not fail
+    // here — the first test in this file catches the ones that matter.
+    const { entries, corpus, sourceFileFor } = planCorpus();
+    expect(entries.length).toBeGreaterThanOrEqual(60);
+    expect(new Set((entries as any[]).map((e) => e.file)).size).toBeGreaterThanOrEqual(17);
+    // The three files T04-18 migrated are the other half of the same claim: they must still be
+    // ENUMERATED (or "nothing left to migrate" is true because the codemod stopped looking) and they
+    // must actually hold the migrated spelling.
+    for (const rel of [
+      "examples/by-example-s11-compute/src/example.ts",
+      "examples/fluid-validation/src/fluid-gpu.test.ts",
+      "experiments/ort-init-device/shared/pipeline.ts",
+    ]) {
+      expect(corpus, `${rel} vanished from the corpus enumeration`).toContain(rel);
+      expect(sourceFileFor(rel)?.text ?? "", `${rel} lost its migrated call`).toMatch(/await\s+[^;]*\.dispatchOnce\(/u);
+    }
+  });
+});

--- a/scripts/codemods/dispatch-migration.mjs
+++ b/scripts/codemods/dispatch-migration.mjs
@@ -1,0 +1,542 @@
+#!/usr/bin/env node
+// T04-18 — codemod 3 of the 0.4 cut: retire the legacy lazy-sync `Compute.dispatch()` at the call
+// sites, onto the two paths the rev6.1 design defines:
+//
+//   frame(gpu, (f) => { sim.dispatch(n) })   ->  frame(gpu, (f) => { f.compute(sim, n) })
+//   sim.dispatch(n)            (standalone)  ->  await sim.dispatchOnce(n)
+//
+// ADDITIVE PHASE. `compute.ts` is untouched — `dispatch()` the METHOD stays alive until T04-22.
+// This codemod only migrates callers.
+//
+// ## Why this is the most delicate transform of the chain, despite being the smallest
+//
+// `dispatchOnce()` is **async**. `dispatch()` is not. Inserting an `await` is therefore not a
+// rename: it splits the containing function at that point, and every caller of that function now
+// observes work that used to be finished on return still in flight. The transform is only sound
+// where the `await` costs nothing observable — where the enclosing function is ALREADY async (its
+// callers already await it, its declared return type is already a promise), or at the top level of
+// an ES module (top-level await). Anywhere else — a sync callback handed to a third party, a method
+// whose `: void` return type is fixed by an interface the module exports, a `expect(() => …)` arm —
+// forcing async would change the module's contract, so the site goes to a NAMED bucket with the
+// reason, and a human decides. `dispatch()` cannot be removed in T04-22 until those buckets are
+// empty; leaving them silent would let T04-22 discover them as build breaks instead.
+//
+// `f.compute()` has the opposite property: it is sync, so it is always safe where it applies. What
+// limits it is scope — it needs the frame's `f` in hand. "Inside a frame" here means LEXICALLY
+// inside the callback and directly in it, not merely reached from one at runtime: a `f.compute()`
+// nested inside `f.pass(…)`/`f.raw(…)` throws VGPU-FRAME-ENCODER-LOCKED, and a dispatch that a
+// frame callback reaches through a helper in another module has no `f` to name. (The corpus's
+// motivating example, `fft-ocean-surface`, is exactly that second case — see the report.)
+//
+// ## Oracles, no heuristics
+//
+//  1. **Type checker** (`lib/corpus-program.mjs`) decides that a `.dispatch()` receiver really is
+//     one of our `Compute` instances — structurally, by carrying both `dispatch` and `dispatchOnce`
+//     — never by variable name, and never by the method name alone (any object may own a
+//     `.dispatch()`). An unresolvable receiver is a bucket, never a silent skip.
+//  2. **Type checker** again for the ARGUMENTS: `dispatch(x, y?, z?)` and `dispatch(opts)` are two
+//     overloads and only the first has an `f.compute()` twin (`f.compute` takes no `indirect`).
+//     Number-like arguments pick the counts overload; anything else is the options overload.
+//  3. **AST scope** for the context: the nearest enclosing function-like node, whether it is async,
+//     and whether it is the frame callback itself.
+//
+// Usage:
+//   node scripts/codemods/dispatch-migration.mjs --dry-run          # report only, no writes
+//   node scripts/codemods/dispatch-migration.mjs                    # apply
+//   node scripts/codemods/dispatch-migration.mjs --dry-run a.ts     # restrict to paths
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import ts from "typescript";
+import { createCorpusProgram, assertCorpusProgram, unwrap } from "./lib/corpus-program.mjs";
+import { getCorpusFiles } from "./lib/glob-corpus.mjs";
+import { tokenStarts, parseDiagnosticsCount } from "./lib/token-scan.mjs";
+import { applyEdits } from "./lib/splice.mjs";
+import { isDryRun, positionalArgs, reportEntry, printReport, writeUnlessDryRun } from "./lib/report.mjs";
+
+/**
+ * Files whose SUBJECT is `dispatch()` itself — the lazy-sync legacy path, its overloads, its
+ * validation, and its interaction with the paths that replace it. Their calls are the assertion,
+ * not a way of getting work onto the GPU: migrating them would delete the proof that the behaviour
+ * T04-22 is about to remove still behaves as documented while it is still shipped. T04-22 owns
+ * their deletion/rewrite, together with the method.
+ *
+ * Every entry is checked against the real corpus on each run (see `main()`): an entry that no
+ * longer matches a site is a stale exemption and fails the run rather than quietly covering
+ * nothing. The context each excluded site WOULD have been classified as is still computed and
+ * reported (`contextWouldBe`), so the exclusion never hides an inconvenient site.
+ */
+export const LEGACY_DISPATCH_TEST_SUBJECTS = new Map([
+  ["packages/vgpu-api/tests/compute/dispatch-once.test.ts", "T04-04's acceptance suite: it pins dispatch() vs dispatchOnce() side by side (pipeline reuse across the two, the sync-compile-wins race, shared VGPU-R1-DISPATCH-COUNT validation, VGPU-DEVICE-DISPOSED). Every assertion needs a live legacy dispatch() to make."],
+  ["packages/vgpu-api/tests/compute/aliasing.test.ts", "The writable-storage aliasing preflight is asserted THROUGH dispatch() (`expect(() => sim.dispatch(1)).toThrowError(...)`): the call is the trigger under test, and its synchronous throw is what the assertion shape depends on."],
+  ["packages/vgpu-api/tests/compute/compute-pipeline-types.ts", "A `tsc`-only type fixture for the Compute surface: it exists to prove the legacy `dispatch()` overloads still type-check. It is never executed."],
+  ["packages/vgpu-api/tests/indirect.test.ts", "Subject is the `dispatch(opts: DispatchOptions)` overload (VGPU-INDIRECT-INVALID for size/alignment, buffer+offset form). f.compute() has no indirect overload at all, so these sites cannot move until T04-22 decides indirect's final home."],
+  ["packages/vgpu-api/tests/settled-queue.test.ts", "T04-03 pins that legacy dispatch() returns `undefined` synchronously (`const result = sim.dispatch(1)`) while the queue settles separately — the sync return IS the assertion."],
+  ["packages/vgpu-api/tests/frame-unified.test.ts", "T04-08 compares f.compute()'s error codes against legacy dispatch()'s on the same input (`caught(() => sim.dispatch(1))?.code`): the legacy call is the reference side of the comparison."],
+  ["packages/vgpu-api/tests/unified-signature.test.ts", "T04-01 pins that a Compute built from either signature spelling is dispatchable on the legacy path (`expect(() => x.dispatch(1)).not.toThrow()`) — the legacy path is half of the parity claim."],
+  ["packages/vgpu-api/tests/prepare.test.ts", "T04-05 pins the interaction between prepare()/pendingPipelines and the lazy-sync compile that only dispatch() performs: it is the un-prepared control arm."],
+  ["packages/vgpu-api/tests/external-device-init.test.ts", "Pins VGPU-DEVICE-DISPOSED / VGPU-DEVICE-LOST on the synchronous path; an awaited twin would report through a rejected promise instead and stop testing the sync guard."],
+  ["packages/vgpu-api/tests/ownership.test.ts", "T04-06's acceptance suite (already the excluded subject of T04-17): its dispatch() calls are what force the bind-group build whose ownership latching the file asserts."],
+  ["packages/vgpu-api/tests/override-constants.test.ts", "The override constants only reach the GPU through the pipeline dispatch() compiles inline, lazily, at the call — the lazy-sync compile is the mechanism under test."],
+  ["packages/vgpu-api/tests/entry-selection.test.ts", "Same mechanism: entry-point selection is observed through the pipeline that the lazy-sync dispatch() compiles."],
+  ["packages/vgpu-api/tests/dispatch-order-motivation.test.ts", "T04-18's own motivation-#1 recording: it runs legacy dispatch() inside a frame callback ON PURPOSE, next to the f.compute() arm, to record that the legacy form costs an extra submit per dispatch and inverts execution order when it follows a pass. Migrating those calls would delete the control arm and leave two identical recordings. (This file was caught by dispatch-migration.corpus.test.ts on its first full run — the invariant works.)"],
+  ["packages/vgpu-api/tests/gpu/compute.test.ts", "The real-device (`VGPU_DOCKER_TEST`) arm for the legacy dispatch path; it is the only place its end-to-end behaviour on hardware is pinned."],
+]);
+
+// --------------------------------------------------------------------------------------------------
+// oracle 1 — is the receiver one of our Compute instances?
+// --------------------------------------------------------------------------------------------------
+
+/**
+ * `"compute" | "foreign" | "unresolved"` for a `.dispatch()` receiver.
+ *
+ * Structural, never nominal: a `Compute` is the thing that carries BOTH `dispatch` and
+ * `dispatchOnce`. `dispatch` alone is far too common (schedulers, stores, event buses) and the
+ * corpus's own `renderer.ts` has an unrelated `.draw()`-shaped object; keying on the method name
+ * would migrate somebody else's API.
+ */
+export function classifyReceiver(expr, checker) {
+  const type = checker.getTypeAtLocation(expr);
+  if (!type) return { kind: "unresolved", typeText: "<no type>" };
+  const parts = type.isUnion() ? type.types : [type];
+  let compute = false;
+  let foreign = false;
+  let unresolved = false;
+  for (const t of parts) {
+    if (t.flags & (ts.TypeFlags.Undefined | ts.TypeFlags.Null)) continue;
+    if (t.flags & (ts.TypeFlags.Any | ts.TypeFlags.Unknown)) { unresolved = true; continue; }
+    if (t.getProperty("dispatch") && t.getProperty("dispatchOnce")) { compute = true; continue; }
+    foreign = true;
+  }
+  const typeText = checker.typeToString(type);
+  if (unresolved) return { kind: "unresolved", typeText };
+  // A union of "ours" and "not ours" is not migratable either way.
+  if (compute && foreign) return { kind: "unresolved", typeText };
+  if (compute) return { kind: "compute", typeText };
+  return { kind: "foreign", typeText };
+}
+
+// --------------------------------------------------------------------------------------------------
+// oracle 2 — which `dispatch()` overload is this call?
+// --------------------------------------------------------------------------------------------------
+
+/**
+ * `"counts" | "options" | "unresolved"`.
+ *
+ * `dispatch(x, y?, z?)` maps onto `f.compute(inst, x, y?, z?)` and onto `dispatchOnce(x, y?, z?)`.
+ * `dispatch({ indirect })` maps onto `dispatchOnce({ indirect })` but has NO `f.compute()` twin
+ * (`FrameComputeOptions` carries no `indirect`), so the two destinations disagree and the overload
+ * has to be known before a destination is chosen.
+ */
+export function classifyOverload(call, checker) {
+  if (call.arguments.length === 0) return "unresolved";
+  if (call.arguments.length > 3) return "unresolved";
+  let sawNumber = false;
+  let sawOther = false;
+  for (const arg of call.arguments) {
+    if (ts.isSpreadElement(arg)) return "unresolved";
+    const inner = unwrap(arg);
+    if (ts.isObjectLiteralExpression(inner)) { sawOther = true; continue; }
+    const type = checker.getTypeAtLocation(inner);
+    const parts = type?.isUnion() ? type.types : [type];
+    let numeric = parts != null && parts.length > 0;
+    for (const t of parts ?? []) {
+      if (t.flags & (ts.TypeFlags.Undefined | ts.TypeFlags.Null)) continue;
+      if (!(t.flags & ts.TypeFlags.NumberLike)) { numeric = false; break; }
+    }
+    if (numeric) sawNumber = true;
+    else sawOther = true;
+  }
+  if (sawNumber && !sawOther) return "counts";
+  if (sawOther && !sawNumber && call.arguments.length === 1) return "options";
+  return "unresolved";
+}
+
+// --------------------------------------------------------------------------------------------------
+// oracle 3 — lexical context
+// --------------------------------------------------------------------------------------------------
+
+const FUNCTION_LIKE = new Set([
+  ts.SyntaxKind.FunctionDeclaration,
+  ts.SyntaxKind.FunctionExpression,
+  ts.SyntaxKind.ArrowFunction,
+  ts.SyntaxKind.MethodDeclaration,
+  ts.SyntaxKind.GetAccessor,
+  ts.SyntaxKind.SetAccessor,
+  ts.SyntaxKind.Constructor,
+  ts.SyntaxKind.ClassStaticBlockDeclaration,
+]);
+
+/** The nearest enclosing function-like node, or `null` when the node sits at module top level. */
+export function enclosingFunction(node) {
+  for (let cur = node.parent; cur; cur = cur.parent) {
+    if (FUNCTION_LIKE.has(cur.kind)) return cur;
+    if (ts.isSourceFile(cur)) return null;
+  }
+  return null;
+}
+
+const isAsyncFunction = (fn) =>
+  fn != null && ts.canHaveModifiers(fn) && (ts.getModifiers(fn) ?? []).some((m) => m.kind === ts.SyntaxKind.AsyncKeyword);
+
+const isGeneratorFunction = (fn) => fn != null && "asteriskToken" in fn && fn.asteriskToken != null;
+
+/**
+ * If `fn` is the callback of a `frame(...)`/`frameLoop(...)`, returns the identifier the frame is
+ * bound to; otherwise `null`.
+ *
+ * Decided by TYPE, not by callee name: the callback's first parameter is typed `Frame` by
+ * `FrameCallback<R>`, so the checker answers this for `frame`, `frameLoop`, an aliased import
+ * (`frame as runFrame`, which two corpus files use) and a re-export alike. A destructured or
+ * missing parameter yields `{ frame: true, param: null }` — a real frame callback with no name to
+ * write, which is a bucket rather than a skip.
+ */
+export function frameCallbackParam(fn, checker) {
+  if (fn == null) return null;
+  if (!ts.isArrowFunction(fn) && !ts.isFunctionExpression(fn)) return null;
+  const param = fn.parameters[0];
+  if (!param) return null;
+  const type = checker.getTypeAtLocation(param);
+  const name = (type?.getSymbol() ?? type?.aliasSymbol)?.getName();
+  // Structural fallback keeps this working if `Frame` is ever renamed or intersected: the frame is
+  // the object that owns `compute`, `pass` and `copyBuffer` together.
+  const structural = type != null && type.getProperty("compute") != null && type.getProperty("pass") != null && type.getProperty("copyBuffer") != null;
+  if (name !== "Frame" && !structural) return null;
+  return { param: ts.isIdentifier(param.name) ? param.name.text : null };
+}
+
+/** Names the enclosing function for the report, falling back to its syntactic role. */
+function describeFunction(fn, sf) {
+  if (fn == null) return "<module top level>";
+  if (ts.isFunctionDeclaration(fn) || ts.isMethodDeclaration(fn)) {
+    return fn.name ? fn.name.getText(sf) : "<anonymous>";
+  }
+  if (ts.isConstructorDeclaration(fn)) return "constructor";
+  if (ts.isClassStaticBlockDeclaration(fn)) return "static {}";
+  const parent = fn.parent;
+  if (parent && ts.isVariableDeclaration(parent) && ts.isIdentifier(parent.name)) return parent.name.text;
+  if (parent && ts.isPropertyAssignment(parent) && !ts.isComputedPropertyName(parent.name)) return parent.name.getText(sf);
+  if (parent && ts.isCallExpression(parent)) return `<callback of ${parent.expression.getText(sf)}()>`;
+  return "<anonymous>";
+}
+
+/**
+ * Evidence that the enclosing function's `void` return is part of a contract this module publishes,
+ * i.e. that making it `async` would change an exported signature rather than a local detail.
+ *
+ * Two shapes, both mechanical: an `export`ed declaration, and a member of an object literal whose
+ * CONTEXTUAL type declares that member (the `return { simulate(dt) {…} }` shape every example in
+ * this corpus uses to implement its published interface). Reported, never acted on — the codemod
+ * refuses these sites either way; this only tells the human reading the bucket which of the two
+ * kinds of change they would be signing up for.
+ */
+export function publicSignatureEvidence(fn, checker, sf) {
+  if (fn == null) return null;
+  if (ts.canHaveModifiers(fn) && (ts.getModifiers(fn) ?? []).some((m) => m.kind === ts.SyntaxKind.ExportKeyword)) {
+    return { kind: "exported-declaration", detail: describeFunction(fn, sf) };
+  }
+  const parent = fn.parent;
+  const member = parent && (ts.isPropertyAssignment(parent) || ts.isMethodDeclaration(parent) ? parent : null);
+  const owner = ts.isMethodDeclaration(fn) ? fn.parent : member?.parent;
+  if (!owner || !ts.isObjectLiteralExpression(owner)) return null;
+  const nameNode = ts.isMethodDeclaration(fn) ? fn.name : member?.name;
+  if (!nameNode || ts.isComputedPropertyName(nameNode)) return null;
+  const contextual = checker.getContextualType(owner);
+  if (!contextual) return null;
+  const prop = contextual.getProperty(nameNode.getText(sf));
+  if (!prop) return null;
+  return {
+    kind: "declared-interface-member",
+    detail: `${checker.typeToString(contextual)}.${nameNode.getText(sf)}`,
+  };
+}
+
+// --------------------------------------------------------------------------------------------------
+// site collection
+// --------------------------------------------------------------------------------------------------
+
+/**
+ * Every `<expr>.dispatch(...)` call in the file, with the token-scan guard applied so a `.dispatch(`
+ * that lives inside a string/template/comment can never reach the planner.
+ */
+export function collectSites(sf, checker, relPath) {
+  if (parseDiagnosticsCount(sf.text, relPath) > 0) {
+    return { parseError: true, sites: [] };
+  }
+  const starts = tokenStarts(sf.text, relPath);
+  const sites = [];
+  const visit = (node) => {
+    if (
+      ts.isCallExpression(node)
+      && ts.isPropertyAccessExpression(node.expression)
+      && node.expression.name.text === "dispatch"
+      && starts.has(node.expression.name.getStart(sf))
+    ) {
+      sites.push({
+        file: relPath,
+        sourceFile: sf,
+        call: node,
+        nameNode: node.expression.name,
+        receiverExpr: node.expression.expression,
+        line: sf.getLineAndCharacterOfPosition(node.getStart(sf)).line + 1,
+      });
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(sf);
+  return { parseError: false, sites };
+}
+
+// --------------------------------------------------------------------------------------------------
+// planning
+// --------------------------------------------------------------------------------------------------
+
+/** `true` if the raw text of `[start, end)` contains a comment opener we would delete by splicing. */
+function hasCommentBetween(text, start, end) {
+  const slice = text.slice(start, end);
+  return slice.includes("//") || slice.includes("/*");
+}
+
+/** Offset just past the call's `(`, i.e. where the first argument's text begins. */
+function argumentListStart(call, sf) {
+  const first = call.arguments[0];
+  const open = call.expression.end;
+  // `first.getFullStart()` includes the argument's leading trivia, which is exactly what must be
+  // preserved when the head `.dispatch(` is replaced by `, `.
+  return first ? first.getFullStart() : open;
+}
+
+/**
+ * Decides the destination of one site. Returns `{ classification, reason?, note?, frameParam?,
+ * publicSignature? }`. Never returns undefined for a site — "no bucket" is the failure mode this
+ * whole chain exists to avoid.
+ */
+export function planSite(site, checker) {
+  const sf = site.sourceFile;
+  const receiver = classifyReceiver(site.receiverExpr, checker);
+  if (receiver.kind === "unresolved") {
+    return { classification: "unresolved-receiver", note: `receiver type: ${receiver.typeText}` };
+  }
+  if (receiver.kind === "foreign") {
+    return { classification: "not-a-compute", note: `receiver type: ${receiver.typeText}` };
+  }
+
+  const overload = classifyOverload(site.call, checker);
+  const fn = enclosingFunction(site.call);
+  const frameCb = frameCallbackParam(fn, checker);
+  const fnName = describeFunction(fn, sf);
+  const publicSignature = publicSignatureEvidence(fn, checker, sf);
+
+  // ---- path A: lexically the frame callback's own body -> f.compute(), sync, same encoder.
+  if (frameCb) {
+    if (frameCb.param == null) {
+      return {
+        classification: "ambiguous-sync-context",
+        reason: "frame-callback-without-named-parameter",
+        note: "the enclosing frame callback destructures (or omits) its Frame parameter, so there is no `f` to write",
+      };
+    }
+    if (overload === "options") {
+      return {
+        classification: "ambiguous-indirect-options",
+        reason: "no-f-compute-indirect-overload",
+        note: `f.compute() takes no \`indirect\`; \`${fnName}\` is a frame callback so dispatchOnce() would re-introduce the extra submit f.compute() exists to remove`,
+      };
+    }
+    if (overload === "unresolved") {
+      return { classification: "ambiguous-arguments", reason: "overload-unresolved", note: `${site.call.arguments.length} argument(s), not all number-like` };
+    }
+    if (hasCommentBetween(sf.text, site.receiverExpr.end, argumentListStart(site.call, sf))) {
+      return { classification: "ambiguous-arguments", reason: "comment-inside-call-head", note: "a comment between the receiver and the first argument would be deleted by the splice" };
+    }
+    return { classification: "auto-f-compute", frameParam: frameCb.param };
+  }
+
+  // ---- path B: standalone -> await dispatchOnce(). Only where the `await` is free.
+  const inEsModule = ts.isExternalModule(sf);
+  const context = fn == null
+    ? (inEsModule ? "top-level-module" : "top-level-script")
+    : isGeneratorFunction(fn) ? "generator"
+      : isAsyncFunction(fn) ? "async-function" : "sync-function";
+
+  if (context === "async-function" || context === "top-level-module") {
+    if (overload === "unresolved") {
+      return { classification: "ambiguous-arguments", reason: "overload-unresolved", note: `${site.call.arguments.length} argument(s), not all number-like` };
+    }
+    // `await x` is an expression, so it is only a drop-in where the call's VALUE is discarded and
+    // no enclosing operator changes meaning around it. Every other position (an argument, an
+    // arrow body, an operand) would need parentheses and/or would change what the surrounding
+    // expression evaluates to, so it is reported instead of guessed at.
+    if (!ts.isExpressionStatement(site.call.parent)) {
+      return {
+        classification: "ambiguous-await-position",
+        reason: "call-is-not-an-expression-statement",
+        note: `the call's value is consumed by a ${ts.SyntaxKind[site.call.parent.kind]}; inserting \`await\` there needs parentheses and changes the surrounding expression`,
+      };
+    }
+    return { classification: "auto-dispatch-once", context };
+  }
+
+  const reason = fn == null
+    ? "top-level-of-a-non-module-script"
+    : context === "generator"
+      ? "enclosing-generator-cannot-await"
+      : ts.isArrowFunction(fn) && fn.parent && ts.isCallExpression(fn.parent)
+        ? "sync-callback-argument"
+        : publicSignature?.kind === "declared-interface-member"
+          ? "sync-member-of-a-declared-interface"
+          : publicSignature?.kind === "exported-declaration"
+            ? "sync-exported-function"
+            : "sync-local-function";
+  return {
+    classification: "ambiguous-sync-context",
+    reason,
+    note: `\`${fnName}\` is synchronous and is not a frame callback; \`await dispatchOnce()\` would make it async`
+      + (publicSignature ? ` and change its published signature (${publicSignature.kind}: ${publicSignature.detail})` : "")
+      + ". Migrating it needs a human decision (thread a `Frame` through, or propagate async to its callers).",
+  };
+}
+
+// --------------------------------------------------------------------------------------------------
+// emission
+// --------------------------------------------------------------------------------------------------
+
+/**
+ * The edits for one planned site. Both transforms are expressed as the SMALLEST pair of splices
+ * that produce the new text, so the resulting diff shows only the head of the call and leaves the
+ * receiver and every argument byte-for-byte untouched (including multi-line bags and their
+ * indentation).
+ */
+export function emitEdits(site, plan) {
+  const sf = site.sourceFile;
+  const callStart = site.call.getStart(sf);
+  if (plan.classification === "auto-f-compute") {
+    return [
+      { start: callStart, end: callStart, replacement: `${plan.frameParam}.compute(` },
+      { start: site.receiverExpr.end, end: argumentListStart(site.call, sf), replacement: "," },
+    ];
+  }
+  if (plan.classification === "auto-dispatch-once") {
+    return [
+      { start: callStart, end: callStart, replacement: "await " },
+      { start: site.nameNode.getStart(sf), end: site.nameNode.end, replacement: "dispatchOnce" },
+    ];
+  }
+  return [];
+}
+
+// --------------------------------------------------------------------------------------------------
+// driver
+// --------------------------------------------------------------------------------------------------
+
+/**
+ * Plans (and materializes the new text for) the migration over the whole corpus. Returns
+ * `{ entries, fileTexts }`; `fileTexts` holds only the files whose text changed.
+ */
+export function planProgram({ checker, corpus, sourceFileFor, only = null }) {
+  const files = only ? corpus.filter((f) => only.has(f)) : corpus;
+  const entries = [];
+  const fileTexts = new Map();
+
+  for (const relPath of files) {
+    const sf = sourceFileFor(relPath);
+    if (!sf) continue;
+    // Cheap pre-filter; the AST walk below is the authority. `.dispatch(` cannot appear as a call
+    // without these bytes appearing first.
+    if (!sf.text.includes(".dispatch")) continue;
+    const { parseError, sites } = collectSites(sf, checker, relPath);
+    if (parseError) {
+      entries.push(reportEntry({ file: relPath, line: 1, before: "", after: "", classification: "skipped-parse-error" }));
+      continue;
+    }
+    if (sites.length === 0) continue;
+
+    const legacyReason = LEGACY_DISPATCH_TEST_SUBJECTS.get(relPath);
+    const edits = [];
+    for (const site of sites) {
+      const plan = planSite(site, checker);
+      const entry = reportEntry({
+        file: relPath,
+        line: site.line,
+        before: sf.text.slice(site.call.getStart(sf), site.call.end),
+        after: sf.text.slice(site.call.getStart(sf), site.call.end),
+        classification: plan.classification,
+      });
+      if (plan.reason) entry.reason = plan.reason;
+      if (plan.note) entry.note = plan.note;
+      if (plan.context) entry.context = plan.context;
+
+      if (legacyReason) {
+        // Excluded, but never silent: the context the site WOULD have been given is still on the
+        // record, so "this exclusion is hiding an easy migration" stays a checkable claim.
+        entry.contextWouldBe = plan.classification;
+        entry.classification = "excluded-test-subject";
+        entries.push(entry);
+        continue;
+      }
+
+      const siteEdits = emitEdits(site, plan);
+      if (siteEdits.length > 0) {
+        const spanStart = Math.min(site.call.getStart(sf), ...siteEdits.map((e) => e.start));
+        const spanEnd = Math.max(site.call.end, ...siteEdits.map((e) => e.end));
+        entry.before = sf.text.slice(spanStart, spanEnd);
+        entry.after = applyEdits(entry.before, siteEdits.map((e) => ({ ...e, start: e.start - spanStart, end: e.end - spanStart })));
+        edits.push(...siteEdits);
+      }
+      entries.push(entry);
+    }
+    if (edits.length > 0) {
+      const next = applyEdits(sf.text, edits);
+      if (next !== sf.text) fileTexts.set(relPath, next);
+    }
+  }
+
+  entries.sort((a, b) => (a.file === b.file ? a.line - b.line : (a.file < b.file ? -1 : 1)));
+  return { entries, fileTexts };
+}
+
+function main() {
+  const dryRun = isDryRun();
+  const only = new Set(positionalArgs());
+  const repoRoot = process.cwd();
+
+  const corpus = getCorpusFiles(repoRoot);
+  if (only.size > 0) {
+    const unknown = [...only].filter((f) => !corpus.includes(f));
+    if (unknown.length > 0) throw new Error(`dispatch-migration: not in the codemod corpus: ${unknown.join(", ")}`);
+  }
+  const ctx = createCorpusProgram(repoRoot, { corpus });
+  assertCorpusProgram(ctx);
+
+  const { entries, fileTexts } = planProgram({ ...ctx, only: only.size > 0 ? only : null });
+
+  for (const [relPath, text] of fileTexts) {
+    writeUnlessDryRun({ dryRun, file: path.join(repoRoot, relPath), text });
+  }
+
+  if (only.size === 0) {
+    const stale = [...LEGACY_DISPATCH_TEST_SUBJECTS.keys()].filter((f) => !entries.some((e) => e.file === f));
+    if (stale.length > 0) {
+      throw new Error(
+        `dispatch-migration: LEGACY_DISPATCH_TEST_SUBJECTS is stale — no \`.dispatch()\` site found in `
+          + `${stale.join(", ")}. Drop the entry instead of carrying a dead exclusion.`,
+      );
+    }
+  }
+
+  printReport(entries);
+
+  const tally = new Map();
+  for (const e of entries) tally.set(e.classification, (tally.get(e.classification) ?? 0) + 1);
+  const migrated = [...tally].filter(([k]) => k.startsWith("auto-")).reduce((n, [, v]) => n + v, 0);
+  process.stderr.write(
+    `\n${dryRun ? "[dry-run] " : ""}dispatch-migration: ${entries.length} \`.dispatch()\` sites examined in `
+      + `${new Set(entries.map((e) => e.file)).size} files; ${migrated} migrated across ${fileTexts.size} files.\n`
+      + [...tally].sort(([a], [b]) => (a < b ? -1 : 1)).map(([k, v]) => `  ${String(v).padStart(4)}  ${k}\n`).join("")
+      + (dryRun ? "  (no files written)\n" : ""),
+  );
+  for (const [file, reason] of LEGACY_DISPATCH_TEST_SUBJECTS) {
+    process.stderr.write(`  excluded on purpose: ${file}\n    ${reason}\n`);
+  }
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) main();

--- a/scripts/codemods/dispatch-migration.test.ts
+++ b/scripts/codemods/dispatch-migration.test.ts
@@ -1,0 +1,378 @@
+// Unit + contract suite for T04-18's codemod (`dispatch-migration.mjs`).
+//
+// Like T04-17's, the unit under test is `planProgram()` driven over an IN-MEMORY program, because
+// every decision this codemod makes needs a real `TypeChecker`: "is this receiver a `Compute` or
+// somebody else's object that also owns a `.dispatch()`", "is this the counts overload or the
+// indirect one", "is this callback parameter a `Frame`". A fixture-string test would be testing a
+// different function than the one that ships.
+//
+// The suite is organised around the ONE property that makes this codemod dangerous: `dispatchOnce()`
+// is async and `dispatch()` is not, so the `await`-insertion arm is pinned from both sides — the
+// contexts where the `await` is free (already-async function, module top level) and the contexts
+// where it would change a published signature and must therefore be reported instead.
+import { describe, expect, it } from "vitest";
+import path from "node:path";
+import ts from "typescript";
+import {
+  planProgram, classifyReceiver, classifyOverload, enclosingFunction, frameCallbackParam,
+} from "./dispatch-migration.mjs";
+
+const REPO_ROOT = path.resolve(import.meta.dirname, "../..");
+
+/**
+ * Structural stand-ins for the real surface. `Compute` carries BOTH `dispatch` and `dispatchOnce`
+ * (that pair is how the codemod recognises one), `Frame` carries `compute`/`pass`/`copyBuffer`, and
+ * `Scheduler` is the adversarial neighbour: a foreign object that also owns a `.dispatch()` and must
+ * never be touched.
+ */
+const AMBIENT = `
+export interface Gpu { readonly __gpu: unique symbol }
+export interface StorageBuffer { readonly gpu: unknown; readonly size: number }
+export interface DispatchOptions { readonly indirect: StorageBuffer | { readonly buffer: StorageBuffer; readonly offset?: number } }
+export interface Compute {
+  set(values: Record<string, unknown>): this;
+  bind(binding: string, resource: unknown): this;
+  dispatch(x: number, y?: number, z?: number): void;
+  dispatch(opts: DispatchOptions): void;
+  dispatchOnce(x: number, y?: number, z?: number): Promise<void>;
+  dispatchOnce(opts: DispatchOptions): Promise<void>;
+}
+export interface Pass { draw(d: unknown): void }
+export interface Frame {
+  compute(compute: Compute, x: number, y?: number, z?: number): void;
+  pass(target: unknown, body: (p: Pass) => void): void;
+  copyBuffer(opts: unknown): void;
+  raw(body: (encoder: unknown) => void): void;
+}
+/** A foreign API that also has a \`.dispatch()\` — the reason receivers are typed, not name-matched. */
+export interface Scheduler { dispatch(action: number): void }
+export declare function compute(gpu: Gpu, opts: Record<string, unknown>): Compute;
+export declare function storage(gpu: Gpu, n: number, opts?: Record<string, unknown>): StorageBuffer;
+export declare function frame(gpu: Gpu, cb: (f: Frame) => void): void;
+export declare function frameLoop(gpu: Gpu, cb: (f: Frame) => void): { stop(): void };
+export declare const gpu: Gpu;
+export declare const scheduler: Scheduler;
+export declare const anything: any;
+`;
+
+const COMPILER_OPTIONS: ts.CompilerOptions = {
+  target: ts.ScriptTarget.ESNext,
+  module: ts.ModuleKind.ESNext,
+  moduleResolution: ts.ModuleResolutionKind.Bundler,
+  strict: true,
+  skipLibCheck: true,
+  noEmit: true,
+  lib: ["lib.esnext.d.ts", "lib.dom.d.ts"],
+  types: [],
+};
+
+function build(files: Record<string, string>) {
+  const all: Record<string, string> = { "api.ts": AMBIENT, ...files };
+  const host = ts.createCompilerHost(COMPILER_OPTIONS, true);
+  const originalGetSourceFile = host.getSourceFile.bind(host);
+  const originalReadFile = host.readFile.bind(host);
+  const originalFileExists = host.fileExists.bind(host);
+  const keyOf = (fileName: string) => fileName.replace(`${REPO_ROOT}/`, "");
+  host.getSourceFile = (fileName, languageVersion, onError, shouldCreate) => {
+    const key = keyOf(fileName);
+    if (all[key] !== undefined) return ts.createSourceFile(fileName, all[key], languageVersion, true, ts.ScriptKind.TS);
+    return originalGetSourceFile(fileName, languageVersion, onError, shouldCreate);
+  };
+  host.readFile = (fileName) => (all[keyOf(fileName)] !== undefined ? all[keyOf(fileName)] : originalReadFile(fileName));
+  host.fileExists = (fileName) => (all[keyOf(fileName)] !== undefined ? true : originalFileExists(fileName));
+
+  const corpus = Object.keys(all);
+  const program = ts.createProgram(corpus.map((f) => path.join(REPO_ROOT, f)), COMPILER_OPTIONS, host);
+  const checker = program.getTypeChecker();
+  const sourceFileFor = (rel: string) => program.getSourceFile(path.join(REPO_ROOT, rel));
+  return { all, corpus, program, checker, sourceFileFor };
+}
+
+/** Builds the program and runs the planner over it. */
+function run(files: Record<string, string>) {
+  const ctx = build(files);
+  const { entries, fileTexts } = planProgram({ checker: ctx.checker, corpus: ctx.corpus, sourceFileFor: ctx.sourceFileFor });
+  return { ...ctx, entries, fileTexts };
+}
+
+const IMPORTS = `import { compute, storage, frame, frameLoop, gpu, scheduler, anything, type Compute } from "./api";\n`;
+const at = (entries: any[], line: number) => entries.find((e) => e.line === line);
+
+// ---------------------------------------------------------------------------------------------
+describe("f.compute() — the in-frame path", () => {
+  it("rewrites a dispatch in a frame callback onto the frame's own encoder", () => {
+    const { entries, fileTexts } = run({
+      "a.ts": `${IMPORTS}const sim = compute(gpu, {});\nframe(gpu, (f) => {\n  sim.dispatch(2);\n});\n`,
+    });
+    expect(at(entries, 4).classification).toBe("auto-f-compute");
+    expect(fileTexts.get("a.ts")).toContain("f.compute(sim,2);");
+  });
+
+  it("keeps every workgroup-count argument, in order", () => {
+    const { fileTexts } = run({
+      "a.ts": `${IMPORTS}const sim = compute(gpu, {});\nframe(gpu, (f) => {\n  sim.dispatch(2, 3, 4);\n});\n`,
+    });
+    expect(fileTexts.get("a.ts")).toContain("f.compute(sim,2, 3, 4);");
+  });
+
+  it("uses the callback's OWN parameter name, whatever it is called", () => {
+    const { fileTexts } = run({
+      "a.ts": `${IMPORTS}const sim = compute(gpu, {});\nframeLoop(gpu, (currentFrame) => {\n  sim.dispatch(1);\n});\n`,
+    });
+    expect(fileTexts.get("a.ts")).toContain("currentFrame.compute(sim,1);");
+  });
+
+  it("recognises the frame callback through an ALIASED import (typed, never name-matched)", () => {
+    const { entries } = run({
+      "a.ts": `import { compute, frame as runFrame, gpu } from "./api";\nconst sim = compute(gpu, {});\nrunFrame(gpu, (f) => {\n  sim.dispatch(1);\n});\n`,
+    });
+    expect(at(entries, 4).classification).toBe("auto-f-compute");
+  });
+
+  it("preserves a chained, multi-line receiver byte-for-byte", () => {
+    const src = `${IMPORTS}const sim = compute(gpu, {});\nframe(gpu, (f) => {\n  sim.set({\n    a: 1,\n    b: 2,\n  }).dispatch(16, 9);\n});\n`;
+    const { fileTexts } = run({ "a.ts": src });
+    expect(fileTexts.get("a.ts")).toContain(`f.compute(sim.set({\n    a: 1,\n    b: 2,\n  }),16, 9);`);
+  });
+
+  it("refuses a dispatch nested inside f.pass() — f.compute() there throws VGPU-FRAME-ENCODER-LOCKED", () => {
+    const { entries, fileTexts } = run({
+      "a.ts": `${IMPORTS}const sim = compute(gpu, {});\nframe(gpu, (f) => {\n  f.pass(null, (p) => {\n    sim.dispatch(1);\n  });\n});\n`,
+    });
+    // The nearest enclosing function is the PASS callback, not the frame callback: a sync context
+    // with no `f.compute()` available, so it is reported rather than moved onto a locked encoder.
+    expect(at(entries, 5).classification).toBe("ambiguous-sync-context");
+    expect(at(entries, 5).reason).toBe("sync-callback-argument");
+    expect(fileTexts.has("a.ts")).toBe(false);
+  });
+
+  it("refuses the indirect overload in a frame callback — f.compute() has no indirect twin", () => {
+    const { entries, fileTexts } = run({
+      "a.ts": `${IMPORTS}const sim = compute(gpu, {});\nconst args = storage(gpu, 12, { indirect: true });\nframe(gpu, (f) => {\n  sim.dispatch({ indirect: args });\n});\n`,
+    });
+    expect(at(entries, 5).classification).toBe("ambiguous-indirect-options");
+    expect(fileTexts.has("a.ts")).toBe(false);
+  });
+
+  it("refuses a frame callback that destructures its Frame — there is no `f` to write", () => {
+    const { entries } = run({
+      "a.ts": `${IMPORTS}const sim = compute(gpu, {});\nframe(gpu, ({ compute: c }) => {\n  sim.dispatch(1);\n});\n`,
+    });
+    expect(at(entries, 4).classification).toBe("ambiguous-sync-context");
+    expect(at(entries, 4).reason).toBe("frame-callback-without-named-parameter");
+  });
+});
+
+// ---------------------------------------------------------------------------------------------
+describe("await dispatchOnce() — the standalone path, and the async boundary", () => {
+  it("migrates inside a function that is ALREADY async (the await costs nothing observable)", () => {
+    const { entries, fileTexts } = run({
+      "a.ts": `${IMPORTS}const sim = compute(gpu, {});\nexport async function go() {\n  sim.dispatch(1);\n}\n`,
+    });
+    expect(at(entries, 4).classification).toBe("auto-dispatch-once");
+    expect(at(entries, 4).context).toBe("async-function");
+    expect(fileTexts.get("a.ts")).toContain("await sim.dispatchOnce(1);");
+  });
+
+  it("migrates at the top level of an ES module (top-level await)", () => {
+    const { entries, fileTexts } = run({
+      "a.ts": `${IMPORTS}const sim = compute(gpu, {});\nsim.dispatch(1);\n`,
+    });
+    expect(at(entries, 3).classification).toBe("auto-dispatch-once");
+    expect(at(entries, 3).context).toBe("top-level-module");
+    expect(fileTexts.get("a.ts")).toContain("await sim.dispatchOnce(1);");
+  });
+
+  it("keeps the indirect overload on the standalone path — dispatchOnce() DOES have that twin", () => {
+    const { entries, fileTexts } = run({
+      "a.ts": `${IMPORTS}const sim = compute(gpu, {});\nconst args = storage(gpu, 12, { indirect: true });\nexport async function go() {\n  sim.dispatch({ indirect: args });\n}\n`,
+    });
+    expect(at(entries, 5).classification).toBe("auto-dispatch-once");
+    expect(fileTexts.get("a.ts")).toContain("await sim.dispatchOnce({ indirect: args });");
+  });
+
+  it("migrates inside a loop body of an async function without reordering anything", () => {
+    const { fileTexts } = run({
+      "a.ts": `${IMPORTS}const sim = compute(gpu, {});\nexport async function go() {\n  for (let i = 0; i < 8; i++) { sim.dispatch(2, 2); }\n}\n`,
+    });
+    expect(fileTexts.get("a.ts")).toContain("for (let i = 0; i < 8; i++) { await sim.dispatchOnce(2, 2); }");
+  });
+
+  // --- the refusals: every one of these would change an observable contract ---
+
+  it("refuses a plain sync function (making it async is a caller-visible change)", () => {
+    const { entries, fileTexts } = run({
+      "a.ts": `${IMPORTS}const sim = compute(gpu, {});\nfunction step() {\n  sim.dispatch(1);\n}\nstep();\n`,
+    });
+    expect(at(entries, 4).classification).toBe("ambiguous-sync-context");
+    expect(at(entries, 4).reason).toBe("sync-local-function");
+    expect(fileTexts.has("a.ts")).toBe(false);
+  });
+
+  it("names an EXPORTED sync function as the published-signature case it is", () => {
+    const { entries } = run({
+      "a.ts": `${IMPORTS}const sim = compute(gpu, {});\nexport function step(): void {\n  sim.dispatch(1);\n}\n`,
+    });
+    expect(at(entries, 4).reason).toBe("sync-exported-function");
+    expect(at(entries, 4).note).toContain("exported-declaration");
+  });
+
+  it("names a member of a DECLARED interface, the shape every example in the corpus uses", () => {
+    const { entries } = run({
+      "a.ts": `${IMPORTS}const sim = compute(gpu, {});\nexport interface Scene { simulate(dt: number): void }\nexport function make(): Scene {\n  return {\n    simulate(dt: number) {\n      sim.dispatch(1);\n    },\n  };\n}\n`,
+    });
+    expect(at(entries, 7).classification).toBe("ambiguous-sync-context");
+    expect(at(entries, 7).reason).toBe("sync-member-of-a-declared-interface");
+    expect(at(entries, 7).note).toContain("Scene.simulate");
+  });
+
+  it("refuses a sync callback handed to a third party, even inside an async function", () => {
+    const { entries, fileTexts } = run({
+      "a.ts": `${IMPORTS}const sim = compute(gpu, {});\nexport async function go() {\n  [1, 2].forEach(() => {\n    sim.dispatch(1);\n  });\n}\n`,
+    });
+    // The ENCLOSING function is the sync arrow, not `go`: awaiting there would resolve into a
+    // callback whose return value `forEach` throws away, so the dispatch would escape the function.
+    expect(at(entries, 5).classification).toBe("ambiguous-sync-context");
+    expect(at(entries, 5).reason).toBe("sync-callback-argument");
+    expect(fileTexts.has("a.ts")).toBe(false);
+  });
+
+  it("refuses a generator, which cannot await", () => {
+    const { entries } = run({
+      "a.ts": `${IMPORTS}const sim = compute(gpu, {});\nexport function* steps() {\n  sim.dispatch(1);\n  yield 1;\n}\n`,
+    });
+    expect(at(entries, 4).reason).toBe("enclosing-generator-cannot-await");
+  });
+
+  it("refuses a call whose VALUE is consumed — `await` there needs parentheses and changes meaning", () => {
+    const { entries, fileTexts } = run({
+      "a.ts": `${IMPORTS}const sim = compute(gpu, {});\nexport async function go() {\n  const done = [sim.dispatch(1)];\n  return done;\n}\n`,
+    });
+    expect(at(entries, 4).classification).toBe("ambiguous-await-position");
+    expect(fileTexts.has("a.ts")).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------------------------
+describe("receiver and argument oracles", () => {
+  it("never touches a foreign `.dispatch()` (a Scheduler is not a Compute)", () => {
+    const { entries, fileTexts } = run({
+      "a.ts": `${IMPORTS}export async function go() {\n  scheduler.dispatch(1);\n}\n`,
+    });
+    expect(at(entries, 3).classification).toBe("not-a-compute");
+    expect(fileTexts.has("a.ts")).toBe(false);
+  });
+
+  it("reports an unresolved receiver as a bucket, never as a silent skip", () => {
+    const { entries, fileTexts } = run({
+      "a.ts": `${IMPORTS}export async function go() {\n  anything.dispatch(1);\n}\n`,
+    });
+    expect(at(entries, 3).classification).toBe("unresolved-receiver");
+    expect(fileTexts.has("a.ts")).toBe(false);
+  });
+
+  it("ignores `.dispatch(` inside a string, a template chunk and a comment", () => {
+    const { entries, fileTexts } = run({
+      "a.ts": `${IMPORTS}const doc = "sim.dispatch(1)";\nconst tpl = \`call sim.dispatch(2) here\`;\n// sim.dispatch(3)\n/* sim.dispatch(4) */\nexport const n = doc.length + tpl.length;\n`,
+    });
+    expect(entries).toEqual([]);
+    expect(fileTexts.size).toBe(0);
+  });
+
+  it("classifies the two overloads apart", () => {
+    const ctx = build({
+      "a.ts": `${IMPORTS}const sim = compute(gpu, {});\nconst args = storage(gpu, 12, { indirect: true });\nexport async function go() {\n  sim.dispatch(1, 2, 3);\n  sim.dispatch({ indirect: args });\n}\n`,
+    });
+    const sf = ctx.sourceFileFor("a.ts")!;
+    const calls: ts.CallExpression[] = [];
+    const visit = (n: ts.Node): void => {
+      if (ts.isCallExpression(n) && ts.isPropertyAccessExpression(n.expression) && n.expression.name.text === "dispatch") calls.push(n);
+      ts.forEachChild(n, visit);
+    };
+    visit(sf);
+    expect(calls).toHaveLength(2);
+    expect(classifyOverload(calls[0]!, ctx.checker)).toBe("counts");
+    expect(classifyOverload(calls[1]!, ctx.checker)).toBe("options");
+    expect(classifyReceiver(calls[0]!.expression.getChildAt(0), ctx.checker).kind).toBe("compute");
+  });
+});
+
+// ---------------------------------------------------------------------------------------------
+describe("harness contracts", () => {
+  it("is idempotent: a second run over migrated text finds nothing left to do", () => {
+    const first = run({
+      "a.ts": `${IMPORTS}const sim = compute(gpu, {});\nframe(gpu, (f) => {\n  sim.dispatch(2);\n});\nexport async function go() {\n  sim.dispatch(3);\n}\n`,
+    });
+    const migrated = first.fileTexts.get("a.ts")!;
+    expect(migrated).toContain("f.compute(sim,2);");
+    expect(migrated).toContain("await sim.dispatchOnce(3);");
+    const second = run({ "a.ts": migrated });
+    expect(second.entries).toEqual([]);
+    expect(second.fileTexts.size).toBe(0);
+  });
+
+  it("reports before/after spans that reproduce the real diff exactly (dry-run == apply)", () => {
+    const src = `${IMPORTS}const sim = compute(gpu, {});\nframe(gpu, (f) => {\n  sim.dispatch(2);\n});\nexport async function go() {\n  sim.dispatch(3);\n}\n`;
+    const { entries, fileTexts } = run({ "a.ts": src });
+    let replayed = src;
+    for (const entry of entries) {
+      if (entry.before === entry.after) continue;
+      expect(replayed).toContain(entry.before);
+      replayed = replayed.replace(entry.before, entry.after);
+    }
+    expect(replayed).toBe(fileTexts.get("a.ts"));
+  });
+
+  it("excludes a legacy-form test subject, but still records the context it WOULD have had", () => {
+    const rel = "packages/vgpu-api/tests/compute/aliasing.test.ts";
+    const { entries, fileTexts } = run({
+      [rel]: `${IMPORTS.replace("./api", "../../../../api")}const sim = compute(gpu, {});\nexport async function go() {\n  sim.dispatch(1);\n}\n`,
+    });
+    expect(at(entries, 4).classification).toBe("excluded-test-subject");
+    // The exclusion is a decision, not a blind spot: the site it hides is one that would otherwise
+    // have migrated cleanly, and the report says so.
+    expect(at(entries, 4).contextWouldBe).toBe("auto-dispatch-once");
+    expect(fileTexts.has(rel)).toBe(false);
+  });
+
+  it("gives every site a bucket — no site is ever dropped silently", () => {
+    const { entries } = run({
+      "a.ts": `${IMPORTS}const sim = compute(gpu, {});\nexport async function ok() { sim.dispatch(1); }\nexport function no() { sim.dispatch(2); }\nframe(gpu, (f) => { sim.dispatch(3); });\nexport async function foreign() { scheduler.dispatch(4); }\nexport async function un() { anything.dispatch(5); }\n`,
+    });
+    expect(entries.map((e) => e.classification)).toEqual([
+      "auto-dispatch-once", "ambiguous-sync-context", "auto-f-compute", "not-a-compute", "unresolved-receiver",
+    ]);
+    for (const entry of entries) expect(typeof entry.classification).toBe("string");
+  });
+});
+
+// ---------------------------------------------------------------------------------------------
+describe("scope helpers", () => {
+  it("enclosingFunction stops at the nearest function-like node, and returns null at top level", () => {
+    const ctx = build({
+      "a.ts": `${IMPORTS}const sim = compute(gpu, {});\nsim.dispatch(1);\nexport function outer() { function inner() { sim.dispatch(2); } inner(); }\n`,
+    });
+    const sf = ctx.sourceFileFor("a.ts")!;
+    const calls: ts.CallExpression[] = [];
+    const visit = (n: ts.Node): void => {
+      if (ts.isCallExpression(n) && ts.isPropertyAccessExpression(n.expression) && n.expression.name.text === "dispatch") calls.push(n);
+      ts.forEachChild(n, visit);
+    };
+    visit(sf);
+    expect(enclosingFunction(calls[0]!)).toBeNull();
+    const inner = enclosingFunction(calls[1]!) as ts.FunctionDeclaration;
+    expect(inner.name?.text).toBe("inner");
+  });
+
+  it("frameCallbackParam answers only for a real Frame callback", () => {
+    const ctx = build({
+      "a.ts": `${IMPORTS}const sim = compute(gpu, {});\nframe(gpu, (f) => { sim.dispatch(1); });\n[1].forEach((n) => { sim.dispatch(n); });\n`,
+    });
+    const sf = ctx.sourceFileFor("a.ts")!;
+    const arrows: ts.ArrowFunction[] = [];
+    const visit = (n: ts.Node): void => { if (ts.isArrowFunction(n)) arrows.push(n); ts.forEachChild(n, visit); };
+    visit(sf);
+    expect(frameCallbackParam(arrows[0]!, ctx.checker)).toEqual({ param: "f" });
+    expect(frameCallbackParam(arrows[1]!, ctx.checker)).toBeNull();
+  });
+});


### PR DESCRIPTION
## T04-18 — codemod 3 of the 0.4 cut: retire the legacy lazy-sync `dispatch()` at the call sites

Third codemod of the chain (after T04-16 unified-signature and T04-17 ownership-binding-scoped).
Migrates **application call sites** of the legacy lazy-sync `Compute.dispatch()` onto the two paths
the rev6.1 design defines. **Additive**: `compute.ts` is untouched — `dispatch()` the *method* stays
alive until T04-22; this PR only moves callers.

```
frame(gpu, (f) => { sim.dispatch(n) })   ->  frame(gpu, (f) => { f.compute(sim, n) })
sim.dispatch(n)            (standalone)  ->  await sim.dispatchOnce(n)
```

### Buckets — 74 sites / 21 files

| Bucket | Sites |
|---|---|
| `excluded-test-subject` | 53 |
| `ambiguous-sync-context` | 15 |
| `auto-dispatch-once` | **6 (migrated)** |
| `auto-f-compute` | **0** |

All 6 migrated sites are in functions that were **already `async`** — the strict rule, no async
propagation anywhere. Three files changed: `examples/by-example-s11-compute/src/example.ts`,
`examples/fluid-validation/src/fluid-gpu.test.ts` (×4), `experiments/ort-init-device/shared/pipeline.ts`.

The 53 exclusions are files whose *subject* is `dispatch()` itself; each carries a stated reason, and
each is checked against the live corpus on every run so a stale exemption fails rather than silently
covering nothing. Exclusions are never blind: every excluded site still records the `contextWouldBe`
it would have been given — **28** of the 53 would have migrated (25 `auto-dispatch-once` +
3 `auto-f-compute`).

### Two corrections to the ticket

1. **The corpus is 7 app-level files, not 6.** The ticket's verified count came from a grep over
   `apps/docs/examples`, `apps/docs/components` and `examples` only. Re-running that exact grep at
   base does return exactly its 6 files — but it never looked at `experiments/`, which
   `scripts/codemods/lib/glob-corpus.mjs` deliberately includes. `experiments/ort-init-device/shared/pipeline.ts`
   is a real 7th app-level site, and it is one of the 6 migrated.
2. **`auto-f-compute` is 0, and that is correct — the motivating case is dynamic, not lexical.** The
   ticket expected `fft-ocean-surface/scene.ts` to be the `f.compute()` case. Its 4 sites live in
   `simulate()` / `rebuildSpectrum()`, and `renderer.ts:143` calls `scene.simulate(dt)` from *inside*
   a `frameLoop((currentFrame) => …)` callback — dynamically within a frame, never lexically, so
   there is no `f` at the dispatch (and `renderer.ts:224` calls it outside any frame at all). The
   `auto-f-compute` path is implemented and unit-tested; it has **0 applications today** and is
   waiting on `Frame` being threaded through those example interfaces.

### Motivation #1, recorded rather than asserted

`packages/vgpu-api/tests/dispatch-order-motivation.test.ts` records both arms on one timeline off the
same mock device, so the claim is a *diff between two recordings*. It is deliberately honest about
where the legacy form is and is not a bug:

- **The fft-ocean shape** (computes, then the render that consumes them): program order **survives** —
  queue submits are ordered and the dispatch's own submit lands first. The cost is **3 submits instead
  of 1**, not a wrong result. This is why the corpus renders correctly today, and why this migration
  is not a bug fix in that shape.
- **The inverted shape** (a pass, *then* a dispatch): the dispatch opens its own encoder and submits
  mid-callback while the pass still sits unsubmitted in the frame's encoder. Execution order comes out
  the **reverse** of program order. `f.compute()` removes it.

### Debt: the 15 `ambiguous-sync-context` sites → **T04-18b**

Pinned per file in `dispatch-migration.corpus.test.ts` so the table cannot grow by accident.
**T04-22 cannot delete `dispatch()` until it is empty.** Each needs a design decision — thread a
`Frame` through (what the design actually wants) or make the function async and propagate — not a
mechanical rewrite, which is why they are deferred to **T04-18b** rather than forced here.

| File | Sites | Why it cannot be mechanical |
|---|---|---|
| `apps/docs/examples/fluid/simulation.ts` | 7 | `stepFluid()` is an exported `: void` driven by a 6,000-iteration loop in `validation.ts`; 7 awaits per step is a different program. Wants a `Frame`. |
| `apps/docs/examples/fft-ocean-surface/scene.ts` | 4 | `simulate()`/`rebuildSpectrum()` are `: void`; called from inside a `frameLoop` in `renderer.ts` but not lexically. Threading the `Frame` changes the example's published interface. |
| `apps/docs/examples/air-painting/visual-pipeline.ts` | 3 | `dispatchCrop` is module-local, but its callers `cropDetectorInput()`/`cropLandmarkInput()`/`consumeHandLandmarks()` are all `: void` on the exported `VisualPipeline`, called from sync paths in `ort-runtime.ts`. |
| `apps/docs/examples/depth-estimation/renderer.ts` | 1 | `SideBySidePipeline.draw()` is `: void`. There is a `runFrame()` later in the same method — the natural migration is code motion into that callback, which a codemod may not do. |

### Gates

- `pnpm typecheck` exit 0 · `pnpm test` **2283 passed / 141 skipped**, exit 0 (reproduced twice)
- `pnpm bundle-check` exit 0 — `full-root` 44019 B / 44032 B, **headroom 13 B**; no `packages/*/src/`
  file is touched, so the bundle delta is structurally zero
- Codemod suite: 28 unit tests + 4 corpus invariants. Idempotent: a second run reports 0 migrated.

<details>
<summary><b>Adversarial QA — PASS</b> (mutation testing; suite at <code>/tmp/debug/scripts/vgpu-t04-18-dispatch-codemod-qa</code>)</summary>

**The fine site was measured, not read.** `fluid-gpu.test.ts:34` is an 8-iteration ping-pong loop
where a `pressure.swap()` follows the dispatch, and `Compute` never snapshots bindings —
`setCore.bindGroups()` is a *pull* that runs **after** `dispatchOnce`'s `await`. Both arms were
replayed on the mock, observing `pass.setBindGroup` (not `createBindGroup`, which `bind-cache.ts`
dedupes by identity): base and migrated encode `ping→pong, pong→ping, …` **identically**, 8 encoders,
8 submits, each iteration's bind immediately followed by its own submit before the swap. The
counter-example arm is emphatic — with the `await` dropped, **all 8 iterations encode `pong→ping`**.
So emitting `await` (not a bare rename) is load-bearing, and the mutant that strips it is killed.

- **Motivation-#1 recording: 6/6 mutants killed**, including two library-level ones (defer
  `dispatch()`'s submit; give `f.compute()` its own encoder) — the recording is pinned against the
  behaviour it claims to record, not just against itself.
- **Corpus invariant + stale guard: 6/6 killed** (stale entry, entry off-corpus, exclusion removed,
  reason degraded, debt table off by one, silent-zero). Run **after `git add`** — corpus enumeration
  is `git ls-files` (T04-17's lesson).
- **Accounting exact**: an independent TS-AST walk over all tracked `.ts`/`.tsx` reconciles **per file
  with zero divergence** at the tree the codemod ran on — 74/21. Chain: 71/20 at base → +3 (the
  timeline test's own control arm) = 74/21 → −6 = 68/18 at HEAD.
- **Debt table exact**: 3/1/4/7 matches site-for-site, every `reason` code right, structural claims verified.

**Follow-ups (non-blocking, neither reaches the delivered diff):**
1. **6 of 16 oracle mutants survive** — real, killable coverage gaps in *defensive* branches (union
   receiver; mixed args; the arity cap; spread args; the structural `Frame` fallback; method-as-frame-callback).
   None changes the corpus outcome, so the shipped diff is robust, but six documented rules have no
   test. Distinguishing fixtures for each are in the QA suite (`probes/oracle-survivors.test.ts`),
   proving they are coverage gaps rather than equivalent mutants. The overload oracle is the weakest (1/4).
2. **`experiments/**` is in the codemod corpus but in no repo gate** — absent from `pnpm-workspace.yaml`,
   from the root `tsconfig.json` references and from `vitest.config.ts`'s `include`. A planted type
   error at the migrated site leaves both gates green. The site itself **is** correct (checked
   out-of-band with a path-mapped `tsc`; already `async`; lifecycle order preserved because
   `dispatchOnce` submits *before* it resolves). This is a property of the T04-15 harness, not of
   T04-18 — but T04-22 must not read a green gate as covering these files.
3. Two cosmetic prose slips in the `AMBIGUOUS_DEBT` reasons (counts/codes are exact; only narration
   drifts): depth-estimation's `runFrame()` is 17 lines below the dispatch, not "five"; fluid's loop
   is 6,000 iterations, with 5,000 the point the scripted pointer switches on.
</details>
