### PR TITLE
chore: add shared Conductor Portless dev setup

### DIFF
--- a/.conductor/settings.toml
+++ b/.conductor/settings.toml
@@ -1,0 +1,12 @@
+"$schema" = "https://conductor.build/schemas/settings.repo.schema.json"
+
+[scripts]
+setup = ". scripts/use-project-node.sh && pnpm install --frozen-lockfile && { [ \"${CONDUCTOR_IS_LOCAL:-0}\" != \"1\" ] || pnpm exec portless trust; } && pnpm build"
+archive = "true"
+run_mode = "concurrent"
+
+[scripts.run.docs]
+available_in = [ "local" ]
+command = ". scripts/use-project-node.sh >/dev/null && PORTLESS_PORT=1355 PORTLESS_HTTPS=1 PORTLESS_SYNC_HOSTS=0 pnpm exec portless --name \"vgpu-$CONDUCTOR_WORKSPACE_NAME\" --app-port \"$CONDUCTOR_PORT\" -- pnpm --dir apps/docs dev"
+default = true
+icon = "globe"

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "onnxruntime-web": "1.27.0",
     "pixelmatch": "^7.2.0",
     "pngjs": "^7.0.0",
+    "portless": "0.13.0",
     "typescript": "^5.7.3",
     "vgpu": "workspace:*",
     "vitest": "^3.2.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,6 +41,9 @@ importers:
       pngjs:
         specifier: ^7.0.0
         version: 7.0.0
+      portless:
+        specifier: 0.13.0
+        version: 0.13.0
       typescript:
         specifier: ^5.7.3
         version: 5.9.3
@@ -4698,6 +4701,12 @@ packages:
 
   points-on-path@0.2.1:
     resolution: {integrity: sha512-25ClnWWuw7JbWZcgqY/gJ4FQWadKxGWk+3kR/7kD0tCaDtPPMj7oHu2ToLaVhfpnHrZzYby2w6tUA0eOIuUg8g==}
+
+  portless@0.13.0:
+    resolution: {integrity: sha512-PxMZ5BHH+ZZi9rTq4T8m003aZxh56qI0aBdNsxLn7jrTtvNJYBWYD3lc5PuQrom/aVh6z8iLb+tKUI6b7QNYQw==}
+    engines: {node: '>=20'}
+    os: [darwin, linux, win32]
+    hasBin: true
 
   postcss-selector-parser@7.1.4:
     resolution: {integrity: sha512-HeP7D2wyhkR+XaK6v4W8oRF62Dsz4flyuczALJp61GckGm42u1saSSJ/0auvcBqxs3jMRFEcPK34At/0JBKdOg==}
@@ -9924,6 +9933,8 @@ snapshots:
     dependencies:
       path-data-parser: 0.1.0
       points-on-curve: 0.2.0
+
+  portless@0.13.0: {}
 
   postcss-selector-parser@7.1.4:
     dependencies:

--- a/scripts/use-project-node.sh
+++ b/scripts/use-project-node.sh
@@ -1,0 +1,26 @@
+# Source this file before project commands so the active shell can switch Node.
+# If no supported version manager is installed, keep the caller's current Node.
+if command -v fnm >/dev/null 2>&1; then
+  fnm use
+elif command -v nvm >/dev/null 2>&1; then
+  nvm use
+else
+  vgpu_nvm_script=""
+
+  if [ -n "${NVM_DIR:-}" ] && [ -s "$NVM_DIR/nvm.sh" ]; then
+    vgpu_nvm_script="$NVM_DIR/nvm.sh"
+  elif [ -s "$HOME/.nvm/nvm.sh" ]; then
+    vgpu_nvm_script="$HOME/.nvm/nvm.sh"
+  elif [ -s "/opt/homebrew/opt/nvm/nvm.sh" ]; then
+    vgpu_nvm_script="/opt/homebrew/opt/nvm/nvm.sh"
+  elif [ -s "/usr/local/opt/nvm/nvm.sh" ]; then
+    vgpu_nvm_script="/usr/local/opt/nvm/nvm.sh"
+  fi
+
+  if [ -n "$vgpu_nvm_script" ]; then
+    . "$vgpu_nvm_script"
+    nvm use
+  fi
+
+  unset vgpu_nvm_script
+fi


### PR DESCRIPTION
Adds shared Conductor setup and a concurrent docs run command backed by stable workspace-specific Portless HTTPS URLs. Pins the Node 22-compatible Portless release and adds a portable helper that uses fnm or nvm when available while gracefully falling back to the current Node. Validated the Conductor schema, sh/zsh syntax, version-manager paths, frozen install, workspace build, and Portless HTTPS routing.