### PR TITLE
Improve agent resource discovery

### DIFF
--- a/apps/docs/agents.md
+++ b/apps/docs/agents.md
@@ -33,7 +33,7 @@ Use these instructions when an AI coding agent edits this project.
 | Configure the Fumadocs source adapter or versioned docs | `lib/geistdocs/source.ts` |
 | Configure Fumadocs collections and source-safe MDX processing | `source.config.ts` |
 | Configure the docs page renderer | `app/[lang]/docs/[[...slug]]/page.tsx` |
-| Configure AI-readable markdown output | `app/[lang]/agents.md/route.ts`, `app/[lang]/.well-known/mcp.json/route.ts`, `app/[lang]/llms.txt/route.ts`, `app/[lang]/llms.mdx/[[...slug]]/route.ts`, `app/[lang]/sitemap.md/route.ts` |
+| Configure AI-readable markdown output | `app/[lang]/agents.md/route.ts`, `app/[lang]/.well-known/mcp.json/route.ts`, `app/[lang]/llms.txt/route.ts`, `app/[lang]/llms-full.txt/route.ts`, `app/[lang]/llms.mdx/[[...slug]]/route.ts`, `app/[lang]/sitemap.md/route.ts` |
 | Configure chat or search APIs | `app/api/chat/route.ts`, `app/api/search/route.ts` |
 | Add request handling before or after Geistdocs routing | `proxy.ts` |
 | Edit the marketing home page | `app/[lang]/(home)/**` |
@@ -53,7 +53,7 @@ Use these instructions when an AI coding agent edits this project.
 - Keep App Router route files as thin adapters around package helpers such as `createDocsPage`, `createChatRoute`, `createLlmsRoute`, and `createProxy`.
 - Keep `export const config` in `proxy.ts` as a static object. Next.js must parse proxy matchers at build time.
 - Use proxy matcher exclusions that only match `/api` and `/api/...`, such as `api(?:/|$)`. Do not exclude broad prefixes like `api`, because that also excludes routes such as `/api-reference`.
-- Preserve markdown negotiation unless the task explicitly changes AI-readable output. Geistdocs serves `/agents.md`, `/llms.txt`, `/.well-known/mcp.json`, and per-page Markdown for `.md`, `.mdx`, `Accept: text/markdown`, and AI-agent requests.
+- Preserve markdown negotiation unless the task explicitly changes AI-readable output. The app serves a concise `/llms.txt` index, a `createLlmsRoute`-backed `/llms-full.txt` corpus, `/agents.md`, `/.well-known/mcp.json`, and per-page Markdown for `.md`, `.mdx`, `Accept: text/markdown`, and AI-agent requests.
 - When adding custom proxy behavior, prefer `before`, `after`, and `markdownRoutes` options on `createProxy` instead of replacing the proxy.
 - Use explicit `markdownRoutes` for root-mounted docs or any site where homepage/app routes coexist with docs routes.
 - Keep source URLs, navigation links, `getPageUrl`, and `markdownRoutes` app-local when `config.basePath` is set. Geistdocs derives public page-action and Markdown URLs separately.
@@ -77,7 +77,7 @@ Use these instructions when an AI coding agent edits this project.
 - Inventory direct app usage of `ai` and `@ai-sdk/react`. Package-owned Ask AI uses AI SDK v6; migrate local AI SDK code separately from Geistdocs route adapters.
 - Import source-config helpers from `@vercel/geistdocs/source-config` in `source.config.ts`. Do not import runtime component entry points from source config.
 - Move existing `middleware.ts` behavior into `createProxy({ before })` or `createProxy({ after })` hooks.
-- Delete `public/llms.txt` when using `createLlmsRoute`; otherwise the static file can mask the App Router route.
+- Delete `public/llms.txt` when an App Router llms route exists; otherwise the static file can mask the concise `/llms.txt` index or a `createLlmsRoute` adapter.
 - Set `openGraph.images` in `createDocsPage` only when the app includes the Geistdocs OG route, or override metadata to avoid broken `/og/...` URLs.
 - Add Tailwind CSS v4 `@source` entries for `@vercel/geistdocs` and related runtime dependencies when migrating styles.
 - Add local fallbacks for production-only environment variables so migration builds do not require production secrets.
@@ -101,5 +101,5 @@ Use these instructions when an AI coding agent edits this project.
 
 - Run `pnpm build` after changing routes, config, source setup, MDX components, or package versions.
 - Run `pnpm dev` and open the changed pages when visual layout, navigation, or MDX rendering changes.
-- Check both `/docs` and AI-readable routes such as `/agents.md`, `/.well-known/mcp.json`, `/llms.txt`, or a page-level `.md` URL when changing content routing or proxy behavior.
+- Check both `/docs` and AI-readable routes such as `/agents.md`, `/.well-known/mcp.json`, `/llms.txt`, `/llms-full.txt`, or a page-level `.md` URL when changing content routing or proxy behavior.
 - Confirm no secrets were added to source files. Use `.env.local` for local values and keep it out of Git.

--- a/apps/docs/app/.well-known/api-catalog/route.test.ts
+++ b/apps/docs/app/.well-known/api-catalog/route.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import { API_CATALOG_PROFILE } from "../../../lib/api-catalog";
+import { GET, HEAD } from "./route";
+
+describe("RFC 9727 API catalog", () => {
+  it("links the existing examples API to its machine and human descriptions", async () => {
+    const response = GET();
+    const document = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toBe(
+      `application/linkset+json; profile="${API_CATALOG_PROFILE}"`,
+    );
+    expect(response.headers.get("access-control-allow-origin")).toBe("*");
+    expect(
+      response.headers.get("access-control-expose-headers")?.toLowerCase().split(/\s*,\s*/u),
+    ).toContain("link");
+    expect(response.headers.get("cache-control")).toBe("public, max-age=300, must-revalidate");
+    expect(response.headers.get("x-content-type-options")).toBe("nosniff");
+    expect(response.headers.get("link")).toBe(
+      '<https://vgpu.sh/.well-known/api-catalog>; rel="api-catalog"',
+    );
+    expect(document).toEqual({
+      linkset: expect.arrayContaining([
+        expect.objectContaining({
+          anchor: "https://vgpu.sh/.well-known/api-catalog",
+          item: [{ href: "https://vgpu.sh/.well-known/vgpu-examples.json", type: "application/json" }],
+        }),
+        expect.objectContaining({
+          anchor: "https://vgpu.sh/.well-known/vgpu-examples.json",
+          "service-desc": [{ href: "https://vgpu.sh/openapi.json", type: "application/json" }],
+          "service-doc": [{ href: "https://vgpu.sh/docs/examples-api", type: "text/html" }],
+        }),
+      ]),
+    });
+  });
+
+  it("returns GET-equivalent headers without a HEAD body", async () => {
+    const get = GET();
+    const head = HEAD();
+
+    expect(head.status).toBe(get.status);
+    for (const header of [
+      "access-control-allow-origin",
+      "access-control-expose-headers",
+      "cache-control",
+      "content-length",
+      "content-type",
+      "link",
+      "x-content-type-options",
+    ]) {
+      expect(head.headers.get(header), header).toBe(get.headers.get(header));
+    }
+    expect(head.headers.get("link")).toContain('rel="api-catalog"');
+    expect(await head.text()).toBe("");
+  });
+});

--- a/apps/docs/app/.well-known/api-catalog/route.ts
+++ b/apps/docs/app/.well-known/api-catalog/route.ts
@@ -1,0 +1,32 @@
+import {
+  API_CATALOG_CONTENT_TYPE,
+  apiCatalogDocument,
+} from "../../../lib/api-catalog";
+import { siteUrl } from "../../../lib/site";
+
+export const revalidate = false;
+
+const body = JSON.stringify(apiCatalogDocument);
+const contentLength = new TextEncoder().encode(body).byteLength.toString();
+
+function createApiCatalogResponse(includeBody: boolean): Response {
+  return new Response(includeBody ? body : null, {
+    headers: {
+      "Access-Control-Allow-Origin": "*",
+      "Access-Control-Expose-Headers": "Link",
+      "Cache-Control": "public, max-age=300, must-revalidate",
+      "Content-Length": contentLength,
+      "Content-Type": API_CATALOG_CONTENT_TYPE,
+      "Link": `<${siteUrl("/.well-known/api-catalog")}>; rel="api-catalog"`,
+      "X-Content-Type-Options": "nosniff",
+    },
+  });
+}
+
+export function GET(): Response {
+  return createApiCatalogResponse(true);
+}
+
+export function HEAD(): Response {
+  return createApiCatalogResponse(false);
+}

--- a/apps/docs/app/[lang]/(home)/components/docs-links-section.tsx
+++ b/apps/docs/app/[lang]/(home)/components/docs-links-section.tsx
@@ -44,6 +44,17 @@ export function DocsLinksSection() {
           </DynamicLink>
         ))}
       </div>
+      <p className="mt-6 text-pretty text-sm text-gray-900">
+        Building agent tooling? Read the{" "}
+        <DynamicLink className="underline" href="/[lang]/docs/examples-api">
+          vgpu Examples API reference
+        </DynamicLink>{" "}
+        or inspect its{" "}
+        <a className="underline" href="/openapi.json">
+          OpenAPI 3.1 description
+        </a>
+        .
+      </p>
     </section>
   );
 }

--- a/apps/docs/app/[lang]/(home)/page.tsx
+++ b/apps/docs/app/[lang]/(home)/page.tsx
@@ -6,7 +6,7 @@ import { Hero } from "./components/hero";
 import { OneShaderEverySurfaceSection } from "./components/one-shader-every-surface-section";
 import { ShaderCodeScalesSection } from "./components/shader-code-scales-section";
 import "./hero-solo.css";
-import { SITE_DESCRIPTION, SITE_NAME, siteUrl } from "@/lib/site";
+import { SITE_DESCRIPTION, SITE_IDENTITY_URLS, SITE_NAME, siteUrl } from "@/lib/site";
 
 // Landing metadata + body copy carried over unchanged from the old
 // `apps/docs/app/page.tsx` (this ticket rebuilds the chrome, not the text —
@@ -45,6 +45,7 @@ const structuredData = {
       url: siteUrl("/"),
       description,
       publisher: { "@id": "https://vercel.com/#organization" },
+      sameAs: SITE_IDENTITY_URLS,
     },
     {
       "@type": "SoftwareSourceCode",
@@ -57,6 +58,7 @@ const structuredData = {
       license: "https://github.com/vercel-labs/vgpu/blob/main/LICENSE",
       programmingLanguage: ["TypeScript", "WGSL"],
       runtimePlatform: ["Web browsers", "Node.js", "Serverless runtimes"],
+      sameAs: SITE_IDENTITY_URLS,
       publisher: {
         "@type": "Organization",
         "@id": "https://vercel.com/#organization",

--- a/apps/docs/app/[lang]/docs/[[...slug]]/page.tsx
+++ b/apps/docs/app/[lang]/docs/[[...slug]]/page.tsx
@@ -25,6 +25,10 @@ const docsPage = createDocsPage({
       alternates: {
         ...metadata.alternates,
         canonical,
+        types: {
+          ...metadata.alternates?.types,
+          "text/markdown": siteUrl(`${page.url}.md`),
+        },
       },
       openGraph: {
         type: "article",

--- a/apps/docs/app/[lang]/index.md/route.test.ts
+++ b/apps/docs/app/[lang]/index.md/route.test.ts
@@ -9,7 +9,12 @@ describe("homepage Markdown", () => {
     expect(response.status).toBe(200);
     expect(response.headers.get("content-type")).toContain("text/markdown");
     expect(response.headers.get("vary")).toMatch(/\bAccept\b/iu);
-    expect(response.headers.get("link")).toBe('<https://vgpu.sh/>; rel="canonical"');
+    const link = response.headers.get("link");
+    expect(link).toContain('<https://vgpu.sh/>; rel="canonical"');
+    expect(link).toContain('<https://vgpu.sh/index.md>; rel="alternate"; type="text/markdown"');
+    expect(link).toContain('<https://vgpu.sh/llms.txt>; rel="describedby"; type="text/markdown"');
+    expect(link).toContain('<https://vgpu.sh/openapi.json>; rel="service-desc"; type="application/json"');
+    expect(link).toContain('<https://vgpu.sh/.well-known/api-catalog>; rel="api-catalog"; type="application/linkset+json"');
     for (const expected of [
       "pnpm add vgpu",
       "npx vgpu",
@@ -18,6 +23,7 @@ describe("homepage Markdown", () => {
       "/openapi.json",
       "/agents.md",
       "/llms.txt",
+      "/llms-full.txt",
       "/sitemap.md",
     ]) {
       expect(body).toContain(expected);

--- a/apps/docs/app/[lang]/index.md/route.ts
+++ b/apps/docs/app/[lang]/index.md/route.ts
@@ -1,5 +1,5 @@
 import { applyMarkdownHeaders } from "@vercel/agent-readability";
-import { siteUrl } from "../../../lib/site";
+import { homepageDiscoveryLinkHeader, siteUrl } from "../../../lib/site";
 
 export const revalidate = false;
 
@@ -32,7 +32,8 @@ The preferred way to discover and copy examples is \`npx vgpu examples\`. The ex
 ## Agent resources
 
 - [Agent readiness manifest](/agents.md)
-- [Complete documentation export](/llms.txt)
+- [Agent documentation index](/llms.txt)
+- [Complete documentation export](/llms-full.txt)
 - [Markdown sitemap](/sitemap.md)
 - [XML sitemap](/sitemap.xml)
 
@@ -44,5 +45,6 @@ export function GET(): Response {
     new Headers({ "Content-Type": "text/markdown; charset=utf-8" }),
     { canonicalUrl: siteUrl("/") },
   );
+  headers.append("Link", homepageDiscoveryLinkHeader);
   return new Response(homepageMarkdown, { headers });
 }

--- a/apps/docs/app/[lang]/layout.tsx
+++ b/apps/docs/app/[lang]/layout.tsx
@@ -1,12 +1,19 @@
 import "../global.css";
 import type { Metadata } from "next";
+import { getPublicPath } from "@vercel/geistdocs/config";
 import { Footer } from "@vercel/geistdocs/footer";
 import { Navbar } from "@vercel/geistdocs/navbar";
 import { GeistdocsProvider } from "@/components/geistdocs/provider";
 import { config } from "@/lib/geistdocs/config";
 import { mono, sans } from "@/lib/geistdocs/fonts";
 import { cn } from "@/lib/utils";
-import { SITE_DESCRIPTION, SITE_NAME, SITE_ORIGIN, siteUrl } from "@/lib/site";
+import {
+  SITE_DESCRIPTION,
+  SITE_NAME,
+  SITE_ORIGIN,
+  localizedSitePath,
+  siteUrl,
+} from "@/lib/site";
 
 export const metadata: Metadata = {
   metadataBase: new URL(SITE_ORIGIN),
@@ -46,6 +53,23 @@ const Layout = async ({ children, params }: LayoutProps<"/[lang]">) => {
           <Navbar config={config} />
           {children}
           <Footer />
+          <nav
+            aria-label="vgpu project links"
+            className="mx-auto flex max-w-[1448px] items-center gap-4 px-6 pb-8 text-sm text-gray-900"
+          >
+            <a
+              className="transition-colors hover:text-gray-1000"
+              href={getPublicPath(localizedSitePath("/about", lang), config.basePath)}
+            >
+              About
+            </a>
+            <a
+              className="transition-colors hover:text-gray-1000"
+              href={getPublicPath(localizedSitePath("/contact", lang), config.basePath)}
+            >
+              Contact
+            </a>
+          </nav>
         </GeistdocsProvider>
       </body>
     </html>

--- a/apps/docs/app/[lang]/llms-full.txt/route.ts
+++ b/apps/docs/app/[lang]/llms-full.txt/route.ts
@@ -1,0 +1,24 @@
+import { applyMarkdownHeaders } from "@vercel/agent-readability";
+import { createLlmsRoute } from "@vercel/geistdocs/routes/llms";
+import { geistdocsSource } from "@/lib/geistdocs/source";
+import { localizedSiteUrl } from "@/lib/site";
+
+const route = createLlmsRoute({
+  sources: [geistdocsSource],
+});
+
+export const { revalidate } = route;
+
+export const GET: typeof route.GET = async (request, context) => {
+  const { lang } = await context.params;
+  const response = await route.GET(request, context);
+  const headers = applyMarkdownHeaders(response.headers, {
+    canonicalUrl: localizedSiteUrl("/llms-full.txt", lang),
+  });
+
+  return new Response(response.body, {
+    headers,
+    status: response.status,
+    statusText: response.statusText,
+  });
+};

--- a/apps/docs/app/[lang]/llms.mdx/[[...slug]]/route.ts
+++ b/apps/docs/app/[lang]/llms.mdx/[[...slug]]/route.ts
@@ -1,7 +1,7 @@
 import { createDocsMarkdownRoute } from "@vercel/geistdocs/routes/llms";
 import { config } from "@/lib/geistdocs/config";
 import { geistdocsSource } from "@/lib/geistdocs/source";
-import { siteUrl } from "@/lib/site";
+import { localizedSiteUrl, siteUrl } from "@/lib/site";
 
 const route = createDocsMarkdownRoute({
   config,
@@ -12,12 +12,19 @@ const route = createDocsMarkdownRoute({
 export const { generateStaticParams, revalidate } = route;
 
 export const GET: typeof route.GET = async (request, context) => {
+  const { lang } = await context.params;
   const response = await route.GET(request, context);
   const canonical = response.headers.get("link")?.match(/<([^>]+)>;\s*rel="canonical"/iu)?.[1];
 
   if (canonical) {
     const url = new URL(canonical);
-    response.headers.set("Link", `<${siteUrl(`${url.pathname}${url.search}`)}>; rel="canonical"`);
+    response.headers.set(
+      "Link",
+      [
+        `<${siteUrl(`${url.pathname}${url.search}`)}>; rel="canonical"`,
+        `<${localizedSiteUrl("/llms.txt", lang)}>; rel="describedby"; type="text/markdown"`,
+      ].join(", "),
+    );
   }
 
   return response;

--- a/apps/docs/app/[lang]/llms.txt/route.test.ts
+++ b/apps/docs/app/[lang]/llms.txt/route.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import { GET } from "./route";
+
+describe("llms.txt index", () => {
+  it("publishes a concise v2 index of canonical agent resources", async () => {
+    const response = await GET(new Request("https://vgpu.sh/llms.txt"), {
+      params: Promise.resolve({ lang: "en" }),
+    });
+    const body = await response.text();
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toContain("text/markdown");
+    expect(response.headers.get("link")).toContain('<https://vgpu.sh/llms.txt>; rel="canonical"');
+    expect(body.startsWith("# vgpu\n\n> ")).toBe(true);
+    expect(body.length).toBeLessThan(30_000);
+    for (const expected of [
+      "/docs/get-started/agents.md",
+      "/docs/get-started/web.md",
+      "/docs/get-started/node.md",
+      "/docs/cli.md",
+      "/docs/examples-api.md",
+      "/agents.md",
+      "/openapi.json",
+      "/.well-known/api-catalog",
+      "/sitemap.md",
+      "/llms-full.txt",
+    ]) {
+      expect(body).toContain(expected);
+    }
+    expect(body).not.toContain("```\n");
+    expect(body).not.toContain("That's the whole instruction");
+  });
+
+  it("localizes documentation links for non-default languages", async () => {
+    const response = await GET(new Request("https://vgpu.sh/cn/llms.txt"), {
+      params: Promise.resolve({ lang: "cn" }),
+    });
+    const body = await response.text();
+
+    expect(response.headers.get("link")).toContain('<https://vgpu.sh/cn/llms.txt>; rel="canonical"');
+    expect(body).toContain("https://vgpu.sh/cn/docs/get-started/agents.md");
+    expect(body).toContain("https://vgpu.sh/cn/llms-full.txt");
+    expect(body).toContain("https://vgpu.sh/openapi.json");
+  });
+});

--- a/apps/docs/app/[lang]/llms.txt/route.ts
+++ b/apps/docs/app/[lang]/llms.txt/route.ts
@@ -1,6 +1,22 @@
-import { createLlmsRoute } from "@vercel/geistdocs/routes/llms";
-import { geistdocsSource } from "@/lib/geistdocs/source";
+import { applyMarkdownHeaders } from "@vercel/agent-readability";
+import { buildLlmsIndexMarkdown } from "../../../lib/llms";
+import { siteUrl } from "../../../lib/site";
 
-export const { GET, revalidate } = createLlmsRoute({
-  sources: [geistdocsSource],
-});
+export const revalidate = false;
+
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ lang: string }> },
+): Promise<Response> {
+  const { lang } = await params;
+  const localePrefix = lang === "en" ? "" : `/${lang}`;
+  const headers = applyMarkdownHeaders(
+    new Headers({
+      "Cache-Control": "public, max-age=300, must-revalidate",
+      "Content-Type": "text/markdown; charset=utf-8",
+    }),
+    { canonicalUrl: siteUrl(`${localePrefix}/llms.txt`) },
+  );
+
+  return new Response(buildLlmsIndexMarkdown(lang), { headers });
+}

--- a/apps/docs/app/[lang]/not-found.tsx
+++ b/apps/docs/app/[lang]/not-found.tsx
@@ -5,7 +5,7 @@ const recoveryLinks = [
   ["Browse examples", "/examples"],
   ["Search the docs", "/docs?search="],
   ["Markdown sitemap", "/sitemap.md"],
-  ["Complete Markdown export", "/llms.txt"],
+  ["Agent documentation index", "/llms.txt"],
 ] as const;
 
 export default function NotFoundPage() {

--- a/apps/docs/app/openapi.json/route.ts
+++ b/apps/docs/app/openapi.json/route.ts
@@ -1,4 +1,5 @@
 import { openApiDocument } from "@/lib/examples-api/openapi";
+import { siteUrl } from "@/lib/site";
 
 export const revalidate = false;
 
@@ -7,6 +8,11 @@ export function GET(): Response {
     headers: {
       "Cache-Control": "public, max-age=300, must-revalidate",
       "Access-Control-Allow-Origin": "*",
+      "Access-Control-Expose-Headers": "Link",
+      "Link": [
+        `<${siteUrl("/.well-known/api-catalog")}>; rel="api-catalog"`,
+        `<${siteUrl("/docs/examples-api")}>; rel="service-doc"; type="text/html"`,
+      ].join(", "),
       "X-Content-Type-Options": "nosniff",
     },
   });

--- a/apps/docs/content/docs/examples-api.mdx
+++ b/apps/docs/content/docs/examples-api.mdx
@@ -1,5 +1,5 @@
 ---
-title: Examples API
+title: vgpu Examples API
 description: Read-only, tokenless discovery for versioned vgpu example manifests and source artifacts.
 ---
 

--- a/apps/docs/geistdocs.test.ts
+++ b/apps/docs/geistdocs.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, it } from "vitest";
-import { agent } from "./geistdocs";
+import { agent, nav } from "./geistdocs";
 
 describe("agent readiness metadata", () => {
+  it("keeps project trust links out of the primary navigation", () => {
+    expect(nav.map((item) => item.label)).toEqual(["Docs", "Examples"]);
+  });
+
   it("advertises the real developer resources without claiming MCP support", () => {
     expect(agent.product.category).toBe("Developer tools");
     expect(agent.api?.openApiUrl).toBe("https://vgpu.sh/openapi.json");

--- a/apps/docs/geistdocs.tsx
+++ b/apps/docs/geistdocs.tsx
@@ -33,14 +33,6 @@ export const nav = [
     label: "Examples",
     href: "/examples",
   },
-  {
-    label: "About",
-    href: "/about",
-  },
-  {
-    label: "Contact",
-    href: "/contact",
-  },
 ];
 
 export const suggestions = [

--- a/apps/docs/lib/api-catalog.ts
+++ b/apps/docs/lib/api-catalog.ts
@@ -1,0 +1,34 @@
+import { siteUrl } from "./site";
+
+export const API_CATALOG_PROFILE = "https://www.rfc-editor.org/info/rfc9727" as const;
+export const API_CATALOG_CONTENT_TYPE =
+  `application/linkset+json; profile="${API_CATALOG_PROFILE}"` as const;
+
+export const apiCatalogDocument = {
+  linkset: [
+    {
+      anchor: siteUrl("/.well-known/api-catalog"),
+      item: [
+        {
+          href: siteUrl("/.well-known/vgpu-examples.json"),
+          type: "application/json",
+        },
+      ],
+    },
+    {
+      anchor: siteUrl("/.well-known/vgpu-examples.json"),
+      "service-desc": [
+        {
+          href: siteUrl("/openapi.json"),
+          type: "application/json",
+        },
+      ],
+      "service-doc": [
+        {
+          href: siteUrl("/docs/examples-api"),
+          type: "text/html",
+        },
+      ],
+    },
+  ],
+} as const;

--- a/apps/docs/lib/llms.ts
+++ b/apps/docs/lib/llms.ts
@@ -1,0 +1,39 @@
+import { localizedSiteUrl, siteUrl } from "./site";
+
+export function buildLlmsIndexMarkdown(lang = "en"): string {
+  const markdownUrl = (path: string) => localizedSiteUrl(path, lang);
+
+  return `# vgpu
+
+> vgpu is a small, composable WebGPU library for browser canvases, headless Node.js, and serverless runtimes, with documentation and tooling designed for coding agents.
+
+Use the focused Markdown pages below first. Fetch the full export only when a task requires broad repository context.
+
+## Start here
+
+- [Agent quickstart](${markdownUrl("/docs/get-started/agents.md")}): Discover the versioned docs and tools available through the vgpu CLI.
+- [Web quickstart](${markdownUrl("/docs/get-started/web.md")}): Render to a browser canvas and configure WGSL imports.
+- [Node.js quickstart](${markdownUrl("/docs/get-started/node.md")}): Render headlessly through Dawn for scripts, servers, and tests.
+
+## Reference
+
+- [CLI reference](${markdownUrl("/docs/cli.md")}): Commands for docs, examples, validation, diagnostics, and snapshots.
+- [Library API reference](${markdownUrl("/docs/reference.md")}): Package map and generated API topic pages.
+- [Interactive examples](${markdownUrl("/examples")}): Live WebGPU examples with read-only source views.
+- [vgpu Examples API](${markdownUrl("/docs/examples-api.md")}): Tokenless, read-only discovery for immutable example artifacts.
+
+## Machine interfaces
+
+- [Agent readiness manifest](${markdownUrl("/agents.md")}): Product identity, CLI, package, and API discovery metadata.
+- [OpenAPI 3.1 description](${siteUrl("/openapi.json")}): Typed examples API operations and response schemas.
+- [API catalog](${siteUrl("/.well-known/api-catalog")}): RFC 9727 discovery for the examples API.
+- [Markdown sitemap](${markdownUrl("/sitemap.md")}): Complete page index.
+
+## Optional
+
+- [Complete documentation export](${markdownUrl("/llms-full.txt")}): All documentation concatenated as Markdown for bulk ingestion.
+- [XML sitemap](${siteUrl("/sitemap.xml")}): Canonical indexable URLs.
+- [Source repository](https://github.com/vercel-labs/vgpu): Source, issues, releases, and contribution history.
+- [vgpu on npm](https://www.npmjs.com/package/vgpu): Published package and CLI.
+`;
+}

--- a/apps/docs/lib/site.test.ts
+++ b/apps/docs/lib/site.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, it } from "vitest";
-import { SITE_ORIGIN, siteUrl } from "./site";
+import {
+  homepageDiscoveryLinkHeader,
+  homepageLinkHeader,
+  SITE_IDENTITY_URLS,
+  SITE_ORIGIN,
+  localizedSiteUrl,
+  siteUrl,
+} from "./site";
 
 describe("canonical site URLs", () => {
   it("always resolves against the permanent apex origin", () => {
@@ -7,5 +14,24 @@ describe("canonical site URLs", () => {
     expect(siteUrl()).toBe("https://vgpu.sh/");
     expect(siteUrl("/docs/get-started")).toBe("https://vgpu.sh/docs/get-started");
     expect(siteUrl("docs/cli")).toBe("https://vgpu.sh/docs/cli");
+    expect(localizedSiteUrl("/llms.txt", "en")).toBe("https://vgpu.sh/llms.txt");
+    expect(localizedSiteUrl("/llms.txt", "cn")).toBe("https://vgpu.sh/cn/llms.txt");
+  });
+
+  it("advertises canonical agent discovery resources", () => {
+    expect(homepageLinkHeader).toContain('<https://vgpu.sh/>; rel="canonical"');
+    for (const expected of [
+      '<https://vgpu.sh/index.md>; rel="alternate"; type="text/markdown"',
+      '<https://vgpu.sh/llms.txt>; rel="describedby"; type="text/markdown"',
+      '<https://vgpu.sh/sitemap.xml>; rel="sitemap"; type="application/xml"',
+      '<https://vgpu.sh/openapi.json>; rel="service-desc"; type="application/json"',
+      '<https://vgpu.sh/.well-known/api-catalog>; rel="api-catalog"; type="application/linkset+json"',
+    ]) {
+      expect(homepageDiscoveryLinkHeader).toContain(expected);
+    }
+    expect(SITE_IDENTITY_URLS).toEqual([
+      "https://github.com/vercel-labs/vgpu",
+      "https://www.npmjs.com/package/vgpu",
+    ]);
   });
 });

--- a/apps/docs/lib/site.test.ts
+++ b/apps/docs/lib/site.test.ts
@@ -4,6 +4,7 @@ import {
   homepageLinkHeader,
   SITE_IDENTITY_URLS,
   SITE_ORIGIN,
+  localizedSitePath,
   localizedSiteUrl,
   siteUrl,
 } from "./site";
@@ -14,6 +15,8 @@ describe("canonical site URLs", () => {
     expect(siteUrl()).toBe("https://vgpu.sh/");
     expect(siteUrl("/docs/get-started")).toBe("https://vgpu.sh/docs/get-started");
     expect(siteUrl("docs/cli")).toBe("https://vgpu.sh/docs/cli");
+    expect(localizedSitePath("/about", "en")).toBe("/about");
+    expect(localizedSitePath("/about", "cn")).toBe("/cn/about");
     expect(localizedSiteUrl("/llms.txt", "en")).toBe("https://vgpu.sh/llms.txt");
     expect(localizedSiteUrl("/llms.txt", "cn")).toBe("https://vgpu.sh/cn/llms.txt");
   });

--- a/apps/docs/lib/site.ts
+++ b/apps/docs/lib/site.ts
@@ -10,8 +10,12 @@ export function siteUrl(path = "/"): string {
   return new URL(path, SITE_ORIGIN).toString();
 }
 
+export function localizedSitePath(path: string, lang: string): string {
+  return lang === "en" ? path : `/${lang}${path}`;
+}
+
 export function localizedSiteUrl(path: string, lang: string): string {
-  return siteUrl(lang === "en" ? path : `/${lang}${path}`);
+  return siteUrl(localizedSitePath(path, lang));
 }
 
 export const homepageDiscoveryLinkHeader = [

--- a/apps/docs/lib/site.ts
+++ b/apps/docs/lib/site.ts
@@ -1,7 +1,25 @@
 export const SITE_ORIGIN = "https://vgpu.sh" as const;
 export const SITE_NAME = "vgpu" as const;
 export const SITE_DESCRIPTION = "The WebGPU library, designed for agents." as const;
+export const SITE_IDENTITY_URLS = [
+  "https://github.com/vercel-labs/vgpu",
+  "https://www.npmjs.com/package/vgpu",
+] as const;
 
 export function siteUrl(path = "/"): string {
   return new URL(path, SITE_ORIGIN).toString();
 }
+
+export function localizedSiteUrl(path: string, lang: string): string {
+  return siteUrl(lang === "en" ? path : `/${lang}${path}`);
+}
+
+export const homepageDiscoveryLinkHeader = [
+  `<${siteUrl("/index.md")}>; rel="alternate"; type="text/markdown"`,
+  `<${siteUrl("/llms.txt")}>; rel="describedby"; type="text/markdown"`,
+  `<${siteUrl("/sitemap.xml")}>; rel="sitemap"; type="application/xml"`,
+  `<${siteUrl("/openapi.json")}>; rel="service-desc"; type="application/json"`,
+  `<${siteUrl("/.well-known/api-catalog")}>; rel="api-catalog"; type="application/linkset+json"`,
+].join(", ");
+
+export const homepageLinkHeader = `<${siteUrl("/")}>; rel="canonical", ${homepageDiscoveryLinkHeader}`;

--- a/apps/docs/next.config.ts
+++ b/apps/docs/next.config.ts
@@ -5,6 +5,7 @@ import type { NextConfig } from "next";
 // run on bare node, with no TS toolchain), so the gate and the app can never
 // disagree about what the redirect table is.
 import { loadDocsRedirects } from "./lib/docs-redirects.mjs";
+import { homepageLinkHeader } from "./lib/site";
 
 const withMDX = createMDX();
 const require = createRequire(import.meta.url);
@@ -63,6 +64,20 @@ const config: NextConfig = {
   // ship without any of them; `scripts/check-url-anchor-parity.mjs` will not.
   async redirects() {
     return loadDocsRedirects();
+  },
+
+  async headers() {
+    return [
+      {
+        source: "/",
+        headers: [
+          {
+            key: "Link",
+            value: homepageLinkHeader,
+          },
+        ],
+      },
+    ];
   },
 
   images: {

--- a/apps/docs/proxy.ts
+++ b/apps/docs/proxy.ts
@@ -82,7 +82,7 @@ const proxy = createProxy({
 // of the geistdocs rewrite just like `/models/**` and `/ort/**` above.
 export const config = {
   matcher: [
-    "/((?!api(?:/|$)|openapi.json$|opengraph-image(?:/|$)|.well-known/vgpu-examples.json(?:/|$)|preview/|models/|ort/|hero/|examples/.+\\.(?:png|jpe?g|webp|avif|gif|svg|ico|mp4|webm|mesh)$|_next/static|_next/image|favicon.ico|sitemap.xml|robots.txt).*)",
+    "/((?!api(?:/|$)|openapi.json$|opengraph-image(?:/|$)|\\.well-known/api-catalog(?:/|$)|.well-known/vgpu-examples.json(?:/|$)|preview/|models/|ort/|hero/|examples/.+\\.(?:png|jpe?g|webp|avif|gif|svg|ico|mp4|webm|mesh)$|_next/static|_next/image|favicon.ico|sitemap.xml|robots.txt).*)",
   ],
 };
 

--- a/apps/docs/scripts/check-doc-links.mjs
+++ b/apps/docs/scripts/check-doc-links.mjs
@@ -63,7 +63,18 @@ const MARKDOWN = /\.mdx?$/u;
  * `/examples/<slug>` and `/preview/<slug>` are validated against the real
  * example directories, not accepted blindly.
  */
-const APP_ROUTES = new Set(["/", "/examples", "/llms.txt", "/agents.md", "/sitemap.xml", "/robots.txt"]);
+const APP_ROUTES = new Set([
+  "/",
+  "/.well-known/api-catalog",
+  "/agents.md",
+  "/examples",
+  "/llms-full.txt",
+  "/llms.txt",
+  "/openapi.json",
+  "/robots.txt",
+  "/sitemap.md",
+  "/sitemap.xml",
+]);
 
 function parseArgs(argv) {
   const options = { anchorsFrom: null };

--- a/apps/docs/scripts/check-production-readiness.mjs
+++ b/apps/docs/scripts/check-production-readiness.mjs
@@ -10,6 +10,13 @@ const APP_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const READY_TIMEOUT_MS = 120_000;
 const CANONICAL_ORIGIN = "https://vgpu.sh";
 const DEPLOYMENT_ALIAS = "vgpu.labs.vercel.dev";
+const HOMEPAGE_DISCOVERY_LINKS = [
+  '<https://vgpu.sh/index.md>; rel="alternate"; type="text/markdown"',
+  '<https://vgpu.sh/llms.txt>; rel="describedby"; type="text/markdown"',
+  '<https://vgpu.sh/sitemap.xml>; rel="sitemap"; type="application/xml"',
+  '<https://vgpu.sh/openapi.json>; rel="service-desc"; type="application/json"',
+  '<https://vgpu.sh/.well-known/api-catalog>; rel="api-catalog"; type="application/linkset+json"',
+];
 
 function fail(message) {
   throw new Error(message);
@@ -110,12 +117,23 @@ async function checkHomepage(baseUrl) {
     assert(html.includes(`property="${property}"`), `homepage: ${property} is missing`);
   }
   assert(html.includes("https://vgpu.sh/opengraph-image"), "homepage: canonical OG image URL is missing");
+  assert(html.includes("/docs/examples-api"), "homepage: examples API reference is not discoverable");
+  assert(html.includes("/openapi.json"), "homepage: OpenAPI description is not discoverable");
+
+  const linkHeader = response.headers.get("link") ?? "";
+  for (const expected of HOMEPAGE_DISCOVERY_LINKS) {
+    assert(linkHeader.includes(expected), `homepage: Link header is missing ${expected}`);
+  }
 
   const jsonLdMatch = html.match(/<script[^>]*type="application\/ld\+json"[^>]*>([\s\S]*?)<\/script>/iu);
   assert(jsonLdMatch, "homepage: JSON-LD is missing from server HTML");
   const jsonLd = JSON.parse(jsonLdMatch[1]);
   const types = jsonLd["@graph"].map((entry) => entry["@type"]);
   assert(types.includes("WebSite") && types.includes("SoftwareSourceCode"), "homepage: JSON-LD entities are incomplete");
+  const jsonLdText = JSON.stringify(jsonLd);
+  for (const identity of ["https://github.com/vercel-labs/vgpu", "https://www.npmjs.com/package/vgpu"]) {
+    assert(jsonLdText.includes(identity), `homepage: JSON-LD sameAs is missing ${identity}`);
+  }
   assert(!html.includes(DEPLOYMENT_ALIAS), "homepage: deployment alias leaked into metadata");
   console.log("  ok  homepage SSR, canonical, Open Graph, and JSON-LD");
 }
@@ -124,7 +142,11 @@ async function checkMarkdown(baseUrl) {
   const negotiated = await request(baseUrl, "/", { headers: { Accept: "text/markdown" } });
   const negotiatedBody = await negotiated.text();
   assertMarkdownResponse(negotiated, "negotiated homepage");
-  assert(negotiated.headers.get("link") === '<https://vgpu.sh/>; rel="canonical"', "negotiated homepage: canonical Link is wrong");
+  const negotiatedLinks = negotiated.headers.get("link") ?? "";
+  assert(negotiatedLinks.includes('<https://vgpu.sh/>; rel="canonical"'), "negotiated homepage: canonical Link is wrong");
+  for (const expected of HOMEPAGE_DISCOVERY_LINKS) {
+    assert(negotiatedLinks.includes(expected), `negotiated homepage: Link header is missing ${expected}`);
+  }
 
   const index = await request(baseUrl, "/index.md");
   const indexBody = await index.text();
@@ -141,7 +163,14 @@ async function checkMarkdown(baseUrl) {
   const missingBody = await missing.text();
   assertMarkdownResponse(missing, "missing docs Markdown", 404);
   assert(/Page Not Found|suggest/iu.test(missingBody), "missing docs Markdown: useful recovery body is missing");
-  assert(missingBody.includes("/llms.txt"), "missing docs Markdown: full index link is missing");
+  assert(missingBody.includes("/llms.txt"), "missing docs Markdown: agent index link is missing");
+
+  const localizedDocs = await request(baseUrl, "/cn/docs/get-started/agents.md");
+  assertMarkdownResponse(localizedDocs, "localized docs Markdown");
+  assert(
+    localizedDocs.headers.get("link")?.includes('<https://vgpu.sh/cn/llms.txt>; rel="describedby"'),
+    "localized docs Markdown: describedby Link is not localized",
+  );
   console.log("  ok  homepage/docs Markdown negotiation and useful 404 recovery");
 }
 
@@ -161,6 +190,51 @@ async function checkApi(baseUrl) {
   assert(openApi.status === 200, `OpenAPI: status ${openApi.status}`);
   assert(openApi.headers.get("content-type")?.includes("application/json"), "OpenAPI: wrong content type");
   assert(document.openapi === "3.1.0", "OpenAPI: version is not 3.1.0");
+  assert(openApi.headers.get("link")?.includes('rel="api-catalog"'), "OpenAPI: API catalog Link is missing");
+  assert(
+    openApi.headers.get("access-control-expose-headers")?.toLowerCase().split(/\s*,\s*/u).includes("link"),
+    "OpenAPI: Link is not CORS-exposed",
+  );
+
+  const catalog = await request(baseUrl, "/.well-known/api-catalog");
+  const catalogBody = await catalog.json();
+  assert(catalog.status === 200, `API catalog: status ${catalog.status}`);
+  assert(catalog.headers.get("access-control-allow-origin") === "*", "API catalog: CORS is missing");
+  assert(
+    catalog.headers.get("access-control-expose-headers")?.toLowerCase().split(/\s*,\s*/u).includes("link"),
+    "API catalog: Link is not CORS-exposed",
+  );
+  assert(
+    catalog.headers.get("cache-control") === "public, max-age=300, must-revalidate",
+    "API catalog: cache policy changed",
+  );
+  assert(
+    catalog.headers.get("content-type") ===
+      'application/linkset+json; profile="https://www.rfc-editor.org/info/rfc9727"',
+    `API catalog: wrong content type ${catalog.headers.get("content-type")}`,
+  );
+  const catalogText = JSON.stringify(catalogBody);
+  for (const expected of ["/.well-known/vgpu-examples.json", "/openapi.json", "/docs/examples-api"]) {
+    assert(catalogText.includes(expected), `API catalog: missing ${expected}`);
+  }
+  const catalogHead = await request(baseUrl, "/.well-known/api-catalog", { method: "HEAD" });
+  assert(catalogHead.status === 200, `API catalog HEAD: status ${catalogHead.status}`);
+  assert((await catalogHead.text()) === "", "API catalog HEAD: body must be empty");
+  for (const header of [
+    "access-control-allow-origin",
+    "access-control-expose-headers",
+    "cache-control",
+    "content-length",
+    "content-type",
+    "link",
+    "x-content-type-options",
+  ]) {
+    assert(
+      catalogHead.headers.get(header) === catalog.headers.get(header),
+      `API catalog HEAD: ${header} differs from GET`,
+    );
+  }
+  assert(catalogHead.headers.get("link")?.includes('rel="api-catalog"'), "API catalog HEAD: Link is missing");
 
   const discovery = await request(baseUrl, "/.well-known/vgpu-examples.json");
   const discoveryBody = await discovery.json();
@@ -187,7 +261,7 @@ async function checkApi(baseUrl) {
   assert(method.status === 405, `examples JSON 405: status ${method.status}`);
   assert(method.headers.get("allow") === "GET, HEAD, OPTIONS", "examples JSON 405: Allow header changed");
   assert(methodJson.error?.code === "VGPU-EXAMPLES-METHOD-NOT-ALLOWED", "examples JSON 405: frozen code changed");
-  console.log("  ok  OpenAPI, discovery, and frozen examples JSON errors");
+  console.log("  ok  OpenAPI, RFC 9727 catalog, discovery, and frozen examples JSON errors");
 }
 
 async function checkAgentResources(baseUrl) {
@@ -199,9 +273,36 @@ async function checkAgentResources(baseUrl) {
   }
   assert(!body.toLowerCase().includes("mcp server"), "agents.md: undeclared MCP support leaked in");
 
+  const llms = await request(baseUrl, "/llms.txt");
+  const llmsBody = await llms.text();
+  assert(llms.status === 200 && llmsBody.startsWith("# vgpu\n\n> "), "llms.txt: v2 index header is missing");
+  assert(llmsBody.length < 30_000, `llms.txt: index is too large at ${llmsBody.length} characters`);
+  for (const expected of ["/docs/get-started/agents.md", "/openapi.json", "/llms-full.txt"]) {
+    assert(llmsBody.includes(expected), `llms.txt: missing ${expected}`);
+  }
+
+  const llmsFull = await request(baseUrl, "/llms-full.txt");
+  const llmsFullBody = await llmsFull.text();
+  assert(llmsFull.status === 200, `llms-full.txt: status ${llmsFull.status}`);
+  assert(llmsFull.headers.get("content-type")?.includes("text/markdown"), "llms-full.txt: wrong content type");
+  assert(
+    llmsFull.headers.get("link")?.includes('<https://vgpu.sh/llms-full.txt>; rel="canonical"'),
+    "llms-full.txt: canonical Link is missing",
+  );
+  assert(llmsFullBody.length > 30_000, "llms-full.txt: complete corpus is unexpectedly short");
+  for (const heading of ["# CLI", "# vgpu Examples API", "# API Reference"]) {
+    assert(llmsFullBody.includes(heading), `llms-full.txt: representative page is missing ${heading}`);
+  }
+
+  const localizedLlmsFull = await request(baseUrl, "/cn/llms-full.txt");
+  assert(
+    localizedLlmsFull.headers.get("link")?.includes('<https://vgpu.sh/cn/llms-full.txt>; rel="canonical"'),
+    "localized llms-full.txt: canonical Link is missing",
+  );
+
   const mcp = await request(baseUrl, "/.well-known/mcp.json");
   assert(mcp.status === 404, `MCP manifest must remain 404, received ${mcp.status}`);
-  console.log("  ok  agent metadata advertises API/CLI/npm and leaves MCP undeclared");
+  console.log("  ok  agent metadata and concise/full llms surfaces leave MCP undeclared");
 }
 
 async function checkCanonicalMachineFiles(baseUrl) {

--- a/apps/docs/scripts/check-production-readiness.mjs
+++ b/apps/docs/scripts/check-production-readiness.mjs
@@ -119,6 +119,9 @@ async function checkHomepage(baseUrl) {
   assert(html.includes("https://vgpu.sh/opengraph-image"), "homepage: canonical OG image URL is missing");
   assert(html.includes("/docs/examples-api"), "homepage: examples API reference is not discoverable");
   assert(html.includes("/openapi.json"), "homepage: OpenAPI description is not discoverable");
+  for (const trustPath of ["/about", "/contact"]) {
+    assert(html.includes(`href="${trustPath}"`), `homepage footer: ${trustPath} is not discoverable`);
+  }
 
   const linkHeader = response.headers.get("link") ?? "";
   for (const expected of HOMEPAGE_DISCOVERY_LINKS) {

--- a/packages/vgpu-api/package.json
+++ b/packages/vgpu-api/package.json
@@ -8,7 +8,7 @@
     "rendering",
     "vgpu"
   ],
-  "homepage": "https://github.com/vercel-labs/vgpu#readme",
+  "homepage": "https://vgpu.sh",
   "bugs": {
     "url": "https://github.com/vercel-labs/vgpu/issues"
   },

--- a/packages/vgpu/package.json
+++ b/packages/vgpu/package.json
@@ -10,7 +10,7 @@
     "wgsl",
     "vgpu"
   ],
-  "homepage": "https://github.com/vercel-labs/vgpu#readme",
+  "homepage": "https://vgpu.sh",
   "bugs": {
     "url": "https://github.com/vercel-labs/vgpu/issues"
   },


### PR DESCRIPTION
Adds a concise, localized `/llms.txt` index while preserving the complete Geistdocs corpus at `/llms-full.txt` with canonical Markdown headers.

Publishes an RFC 9727 API catalog and advertises Markdown, sitemap, OpenAPI, and catalog resources through discoverable HTTP `Link` headers with CORS-safe metadata.

Strengthens JSON-LD identity, docs Markdown alternates, homepage API visibility, localized recovery guidance, and npm package homepage metadata without changing existing CLI or examples API contracts.

Verification includes focused Vitest coverage, TypeScript, documentation gates, a production Next.js build, and the expanded production-readiness smoke test.