### PR TITLE
Return structured JSON for unknown API routes

### DIFF
--- a/apps/docs/agents.md
+++ b/apps/docs/agents.md
@@ -36,6 +36,7 @@ Use these instructions when an AI coding agent edits this project.
 | Configure the docs page renderer | `app/[lang]/docs/[[...slug]]/page.tsx` |
 | Configure AI-readable markdown output | `app/[lang]/agents.md/route.ts`, `app/[lang]/.well-known/mcp.json/route.ts`, `app/[lang]/llms.txt/route.ts`, `app/[lang]/llms-full.txt/route.ts`, `app/[lang]/llms.mdx/[[...slug]]/route.ts`, `app/[lang]/sitemap.md/route.ts` |
 | Configure chat or search APIs | `app/api/chat/route.ts`, `app/api/search/route.ts` |
+| Configure the structured JSON fallback for unknown `/api/*` paths | `lib/api-not-found.ts`, `app/api/[...notFound]/route.ts` |
 | Add request handling before or after Geistdocs routing | `proxy.ts` |
 | Edit the marketing home page | `app/[lang]/(home)/**` |
 | Edit shared styles | `app/global.css`, `app/styles/geistdocs.css` |
@@ -56,6 +57,7 @@ Use these instructions when an AI coding agent edits this project.
 - Use proxy matcher exclusions that only match `/api` and `/api/...`, such as `api(?:/|$)`. Do not exclude broad prefixes like `api`, because that also excludes routes such as `/api-reference`.
 - Preserve markdown negotiation unless the task explicitly changes AI-readable output. The app serves a concise `/llms.txt` index, a `createLlmsRoute`-backed `/llms-full.txt` corpus, `/agents.md`, `/.well-known/mcp.json`, and per-page Markdown for `.md`, `.mdx`, `Accept: text/markdown`, and AI-agent requests.
 - Preserve the proxy `after` hook that returns a recoverable Markdown 404 for unknown agent requests outside `/docs`. When adding a valid HTML app route, add it to `lib/geistdocs/markdown-not-found.ts` so Markdown-preferring clients still receive the real page rather than the fallback.
+- Preserve `app/api/[...notFound]/route.ts` as the lowest-precedence API route. Valid API routes must retain their own contracts, unknown `/api/*` paths return a stable JSON 404 instead of the framework HTML response, and the existing bare `/api` redirect continues to lead to `/docs/reference`.
 - When adding custom proxy behavior, prefer `before`, `after`, and `markdownRoutes` options on `createProxy` instead of replacing the proxy.
 - Use explicit `markdownRoutes` for root-mounted docs or any site where homepage/app routes coexist with docs routes.
 - Keep source URLs, navigation links, `getPageUrl`, and `markdownRoutes` app-local when `config.basePath` is set. Geistdocs derives public page-action and Markdown URLs separately.
@@ -103,5 +105,5 @@ Use these instructions when an AI coding agent edits this project.
 
 - Run `pnpm build` after changing routes, config, source setup, MDX components, or package versions.
 - Run `pnpm dev` and open the changed pages when visual layout, navigation, or MDX rendering changes.
-- Check both `/docs` and AI-readable routes such as `/agents.md`, `/.well-known/mcp.json`, `/llms.txt`, `/llms-full.txt`, a page-level `.md` URL, and an unknown URL with `Accept: text/markdown` when changing content routing or proxy behavior.
+- Check both `/docs` and AI-readable routes such as `/agents.md`, `/.well-known/mcp.json`, `/llms.txt`, `/llms-full.txt`, a page-level `.md` URL, an unknown URL with `Accept: text/markdown`, and an unknown `/api` path when changing content routing or proxy behavior.
 - Confirm no secrets were added to source files. Use `.env.local` for local values and keep it out of Git.

--- a/apps/docs/app/api/[...notFound]/route.test.ts
+++ b/apps/docs/app/api/[...notFound]/route.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import * as route from "./route";
+
+const expectedError = {
+  error: {
+    code: "VGPU-API-NOT-FOUND",
+    message: "API endpoint not found",
+    resolution: "Use the OpenAPI document to find a supported endpoint.",
+    documentationUrl: "https://vgpu.sh/openapi.json",
+  },
+};
+
+const request = (path: string, method = "GET") =>
+  new Request(`https://vgpu.sh${path}`, { method });
+
+describe("unmatched API route", () => {
+  it.each([
+    ["GET", route.GET],
+    ["POST", route.POST],
+    ["PUT", route.PUT],
+    ["PATCH", route.PATCH],
+    ["DELETE", route.DELETE],
+    ["OPTIONS", route.OPTIONS],
+  ] as const)("returns the same structured JSON 404 for %s", async (method, handler) => {
+    const response = handler(request("/api/definitely-missing", method));
+
+    expect(response.status).toBe(404);
+    expect(response.headers.get("content-type")).toBe("application/json; charset=utf-8");
+    expect(response.headers.get("cache-control")).toBe("no-store");
+    expect(response.headers.get("access-control-allow-origin")).toBe("*");
+    expect(response.headers.get("x-content-type-options")).toBe("nosniff");
+    expect(Number(response.headers.get("content-length"))).toBeGreaterThan(0);
+    expect(await response.json()).toEqual(expectedError);
+  });
+
+  it("preserves the JSON headers and content length for HEAD without a body", async () => {
+    const get = route.GET(request("/api/definitely-missing"));
+    const head = route.HEAD(request("/api/definitely-missing", "HEAD"));
+
+    expect(head.status).toBe(404);
+    expect(head.headers.get("content-type")).toBe("application/json; charset=utf-8");
+    expect(head.headers.get("content-length")).toBe(get.headers.get("content-length"));
+    expect(await head.text()).toBe("");
+  });
+});

--- a/apps/docs/app/api/[...notFound]/route.ts
+++ b/apps/docs/app/api/[...notFound]/route.ts
@@ -1,0 +1,12 @@
+import { apiNotFoundResponse } from "../../../lib/api-not-found";
+
+// Specific API routes take precedence over this catch-all. An unknown endpoint
+// does not support any method, so every method returns the same 404 contract
+// instead of a framework-generated HTML 404 or 405 response.
+export const GET = (_request: Request) => apiNotFoundResponse();
+export const POST = GET;
+export const PUT = GET;
+export const PATCH = GET;
+export const DELETE = GET;
+export const OPTIONS = GET;
+export const HEAD = (_request: Request) => apiNotFoundResponse(true);

--- a/apps/docs/lib/api-not-found.ts
+++ b/apps/docs/lib/api-not-found.ts
@@ -1,0 +1,23 @@
+import { siteUrl } from "./site";
+
+const body = `${JSON.stringify({
+  error: {
+    code: "VGPU-API-NOT-FOUND",
+    message: "API endpoint not found",
+    resolution: "Use the OpenAPI document to find a supported endpoint.",
+    documentationUrl: siteUrl("/openapi.json"),
+  },
+})}\n`;
+
+const headers = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Expose-Headers": "Content-Length",
+  "Cache-Control": "no-store",
+  "Content-Length": String(new TextEncoder().encode(body).byteLength),
+  "Content-Type": "application/json; charset=utf-8",
+  "X-Content-Type-Options": "nosniff",
+} as const;
+
+export function apiNotFoundResponse(head = false): Response {
+  return new Response(head ? null : body, { status: 404, headers });
+}

--- a/apps/docs/scripts/check-production-readiness.mjs
+++ b/apps/docs/scripts/check-production-readiness.mjs
@@ -327,7 +327,46 @@ async function checkApi(baseUrl) {
   assert(method.status === 405, `examples JSON 405: status ${method.status}`);
   assert(method.headers.get("allow") === "GET, HEAD, OPTIONS", "examples JSON 405: Allow header changed");
   assert(methodJson.error?.code === "VGPU-EXAMPLES-METHOD-NOT-ALLOWED", "examples JSON 405: frozen code changed");
-  console.log("  ok  OpenAPI, RFC 9727 catalog, discovery, and frozen examples JSON errors");
+
+  const unknownApiPath = "/api/definitely-missing-agent-readiness/nested";
+  const unknownApi = await request(baseUrl, unknownApiPath);
+  const unknownApiJson = await unknownApi.json();
+  assert(unknownApi.status === 404, `unknown API JSON 404: status ${unknownApi.status}`);
+  assert(unknownApi.headers.get("content-type")?.includes("application/json"), "unknown API JSON 404: wrong content type");
+  assert(unknownApi.headers.get("cache-control") === "no-store", "unknown API JSON 404: unsafe cache policy");
+  assert(unknownApi.headers.get("access-control-allow-origin") === "*", "unknown API JSON 404: CORS is missing");
+  assert(unknownApiJson.error?.code === "VGPU-API-NOT-FOUND", "unknown API JSON 404: code changed");
+  assert(unknownApiJson.error?.message === "API endpoint not found", "unknown API JSON 404: message changed");
+  assert(
+    unknownApiJson.error?.resolution === "Use the OpenAPI document to find a supported endpoint.",
+    "unknown API JSON 404: resolution guidance changed",
+  );
+  assert(
+    unknownApiJson.error?.documentationUrl === "https://vgpu.sh/openapi.json",
+    "unknown API JSON 404: OpenAPI recovery link changed",
+  );
+
+  const bareApi = await request(baseUrl, "/api");
+  assert(
+    [307, 308].includes(bareApi.status) && bareApi.headers.get("location")?.endsWith("/docs/reference"),
+    "bare API: existing reference redirect changed",
+  );
+
+  const unknownApiPost = await request(baseUrl, unknownApiPath, { method: "POST" });
+  assert(unknownApiPost.status === 404, `unknown API POST JSON 404: status ${unknownApiPost.status}`);
+  assert(
+    (await unknownApiPost.json()).error?.code === "VGPU-API-NOT-FOUND",
+    "unknown API POST JSON 404: code changed",
+  );
+
+  const unknownApiHead = await request(baseUrl, unknownApiPath, { method: "HEAD" });
+  assert(unknownApiHead.status === 404, `unknown API HEAD JSON 404: status ${unknownApiHead.status}`);
+  assert(
+    unknownApiHead.headers.get("content-length") === unknownApi.headers.get("content-length"),
+    "unknown API HEAD JSON 404: content length differs from GET",
+  );
+  assert((await unknownApiHead.text()) === "", "unknown API HEAD JSON 404: body must be empty");
+  console.log("  ok  OpenAPI, RFC 9727 catalog, discovery, and structured JSON API errors");
 }
 
 async function checkAgentResources(baseUrl) {


### PR DESCRIPTION
Unknown `/api/*` paths now return a stable JSON 404 with recovery guidance pointing to the OpenAPI document. The fallback covers all HTTP methods, preserves bodyless HEAD semantics, CORS, content length, and no-store headers while leaving valid APIs and the bare `/api` redirect unchanged. Unit coverage, production-readiness smoke coverage, and agent maintenance guidance are included.

Validated with focused Vitest coverage, docs typecheck, a production build, and the production-readiness smoke suite.