### PR TITLE
chore(release): v0.3.1

### DIFF
--- a/packages/adapter-mock/package.json
+++ b/packages/adapter-mock/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vgpu/adapter-mock",
-  "version": "0.3.1-rc.0",
+  "version": "0.3.1",
   "description": "Mock GPU adapter for testing vgpu code without real WebGPU hardware.",
   "keywords": [
     "webgpu",

--- a/packages/adapter-node/package.json
+++ b/packages/adapter-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vgpu/adapter-node",
-  "version": "0.3.1-rc.0",
+  "version": "0.3.1",
   "description": "Node.js GPU adapter for vgpu, using Dawn-based WebGPU bindings.",
   "keywords": [
     "webgpu",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vgpu/core",
-  "version": "0.3.1-rc.0",
+  "version": "0.3.1",
   "description": "Core WebGPU runtime primitives (device, buffer, texture, shader, queue) for vgpu.",
   "keywords": [
     "webgpu",

--- a/packages/render/package.json
+++ b/packages/render/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vgpu/render",
-  "version": "0.3.1-rc.0",
+  "version": "0.3.1",
   "description": "Render pipeline + render pass abstractions for vgpu.",
   "keywords": [
     "webgpu",

--- a/packages/vgpu-api/package.json
+++ b/packages/vgpu-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vgpu",
-  "version": "0.3.1-rc.0",
+  "version": "0.3.1",
   "description": "Public VGPU API entrypoint scaffold for browser, Node, mock, scene, and client typing surfaces.",
   "keywords": [
     "webgpu",

--- a/packages/wgsl-std/package.json
+++ b/packages/wgsl-std/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vgpu/wgsl-std",
-  "version": "0.3.1-rc.0",
+  "version": "0.3.1",
   "description": "Pure WGSL utility snippets for vgpu shaders.",
   "keywords": [
     "webgpu",

--- a/packages/wgsl/package.json
+++ b/packages/wgsl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vgpu/wgsl",
-  "version": "0.3.1-rc.0",
+  "version": "0.3.1",
   "description": "WGSL shader compilation, runtime resolution, and webpack/vite loaders for vgpu.",
   "keywords": [
     "webgpu",

--- a/skills/vgpu/SKILL.md
+++ b/skills/vgpu/SKILL.md
@@ -5,9 +5,9 @@ description: >-
   vgpu/mock, vgpu/scene, and vgpu/client. Use @vgpu/render/inspect, /utils, /edit,
   and /perf only as slim tooling subpaths. Bundles performance guides and the API
   reference; load one doc at a time.
-vgpuVersion: 0.3.1-rc.0
-gitSha: 678dfaf3b9ca7acee5dc369219b5ef8c941ce477
-generatedAt: 2026-08-26T04:52:06.569Z
+vgpuVersion: 0.3.1
+gitSha: ebc67f0072134e505a2fc4a8254422feb559c681
+generatedAt: 2026-08-26T05:27:59.542Z
 ---
 
 # vgpu


### PR DESCRIPTION
Promotes the tested 0.3.1-rc.0 line to stable 0.3.1 without changing product code.

Removes the RC suffix from all seven publishable fixed-group packages and regenerates the vgpu skill version/provenance metadata.

Validation: build, workspace typecheck, generated-doc drift, bundle budgets, 27 focused MCP/isolated-tarball tests, and a recursive latest-tag publish dry run.

After merge, the v0.3.1 GitHub release will publish these packages to npm latest.