### PR TITLE
fix(docs): contain MCP hero command

### DIFF
--- a/apps/docs/app/[lang]/(home)/components/hero-tabs.tsx
+++ b/apps/docs/app/[lang]/(home)/components/hero-tabs.tsx
@@ -7,15 +7,21 @@ import { InlineCode, stripBackticks } from "./inline-code";
 
 /** `mono` distinguishes terminal commands from the natural-language prompt. */
 const tabContent = {
-  Prompt: { text: "Setup vgpu on my project, run `npx vgpu`", mono: false },
-  CLI: { text: "`pnpm add vgpu`", mono: true },
+  Prompt: {
+    text: "Setup vgpu on my project, run `npx vgpu`",
+    mono: false,
+    wrap: false,
+  },
+  CLI: { text: "`pnpm add vgpu`", mono: true, wrap: false },
   Skill: {
     text: "`npx skills add vercel-labs/vgpu`",
     mono: true,
+    wrap: false,
   },
   MCP: {
     text: "`npx -y add-mcp https://vgpu.sh/api/mcp -g`",
     mono: true,
+    wrap: true,
   },
 } as const;
 
@@ -193,6 +199,7 @@ export function HeroTabs() {
                 <InlineCode
                   text={tabContent[tab].text}
                   mono={tabContent[tab].mono}
+                  wrap={tabContent[tab].wrap}
                 />
               </span>
             );

--- a/apps/docs/app/[lang]/(home)/components/hero.tsx
+++ b/apps/docs/app/[lang]/(home)/components/hero.tsx
@@ -60,7 +60,7 @@ export function Hero({ canvasEnabled }: HeroProps) {
             rest of the hero, but the content opts back IN. */}
           <div
             data-hero-overlay
-            className="pointer-events-none relative z-10 grid min-h-svh grid-cols-1 grid-rows-[auto_1fr] gap-8 px-6 pb-6 pt-24 min-[768px]:absolute min-[768px]:inset-0 min-[768px]:min-h-0 min-[768px]:grid-rows-1 min-[768px]:gap-0 min-[768px]:py-[clamp(3rem,8svh,6rem)] min-[768px]:justify-items-start min-[1100px]:grid-cols-[minmax(0,21em)_minmax(0,1fr)] min-[1100px]:gap-[clamp(2rem,5vw,5rem)]"
+            className="pointer-events-none relative z-10 grid min-h-svh grid-cols-1 grid-rows-[auto_1fr] gap-8 px-6 pb-6 pt-24 min-[768px]:absolute min-[768px]:inset-0 min-[768px]:min-h-0 min-[768px]:grid-rows-1 min-[768px]:gap-0 min-[768px]:py-[clamp(3rem,8svh,6rem)] min-[768px]:justify-items-start min-[1100px]:grid-cols-[minmax(0,26em)_minmax(0,1fr)] min-[1100px]:gap-[clamp(2rem,5vw,5rem)]"
           >
             <div className="pointer-events-auto relative z-10 col-start-1 row-start-2 flex h-full flex-col items-center self-start justify-self-center min-[768px]:row-start-1 min-[768px]:h-auto min-[768px]:items-start min-[768px]:self-center min-[768px]:justify-self-start min-[1100px]:col-start-1 min-[1100px]:row-start-1">
               <h1
@@ -80,7 +80,7 @@ export function Hero({ canvasEnabled }: HeroProps) {
               <p className="max-w-[10em] text-3xl text-balance text-center font-light leading-tight min-[768px]:text-left min-[768px]:text-4xl">
                 The WebGPU library, designed for agents.
               </p>
-              <div className="mt-auto w-full max-w-[21em] min-[768px]:mt-7">
+              <div className="mt-auto w-full max-w-[28em] min-[768px]:mt-7">
                 <HeroTabs />
               </div>
               <div

--- a/apps/docs/app/[lang]/(home)/components/inline-code.tsx
+++ b/apps/docs/app/[lang]/(home)/components/inline-code.tsx
@@ -11,7 +11,9 @@ export function stripBackticks(text: string): string {
  * For commands quoted mid-sentence ("install with `npx skills add vercel-labs/vgpu`"), where a
  * block would break the line but the text still has to read as literal — hence
  * a span swap. Geist Mono runs slightly wider and taller than Geist Sans at the
- * same px size, so code is nudged to 0.95em to keep the baseline row even.
+ * same px size, so code is nudged to 0.95em to keep the baseline row even. Long
+ * commands may opt into wrapping when the containing layout is intentionally
+ * narrow.
  *
  * Fence only what is genuinely literal. Mono is a signal that the reader should
  * type the characters exactly; using it for a command merely *named* inside a
@@ -21,7 +23,15 @@ export function stripBackticks(text: string): string {
  * — only the import path changed, since this landing owns its own copy of the
  * hero overlay components (see TGEIST-10).
  */
-export function InlineCode({ text, mono = true }: { text: string; mono?: boolean }) {
+export function InlineCode({
+  text,
+  mono = true,
+  wrap = false,
+}: {
+  text: string;
+  mono?: boolean;
+  wrap?: boolean;
+}) {
   // Odd indices are the fenced spans: "a `b` c" -> ["a ", "b", " c"].
   return (
     <>
@@ -32,14 +42,21 @@ export function InlineCode({ text, mono = true }: { text: string; mono?: boolean
         // *presented* as code. Those are separate concerns, and the Prompt tab
         // needs the first without the second.
         //
-        // Unbreakable either way: a command split across lines ("run npx vgpu"
-        // / "docs") reads as prose and strands an orphan word. Wrap before it.
+        // Atomic by default: a command split across lines ("run npx vgpu" /
+        // "docs") reads as prose and strands an orphan word. Exceptionally
+        // long standalone commands can wrap at their own spaces instead.
         return mono ? (
-          <code key={index} className="whitespace-nowrap font-mono text-[0.95em]">
+          <code
+            key={index}
+            className={`${wrap ? "whitespace-normal" : "whitespace-nowrap"} font-mono text-[0.95em]`}
+          >
             {part}
           </code>
         ) : (
-          <span key={index} className="whitespace-nowrap">
+          <span
+            key={index}
+            className={wrap ? "whitespace-normal" : "whitespace-nowrap"}
+          >
             {part}
           </span>
         );


### PR DESCRIPTION
## Summary

- widen the homepage hero setup column for the longer MCP command
- allow only the MCP snippet to wrap when the viewport is too narrow
- preserve the existing copy interaction and shorter command layout

## Verification

- pnpm --filter docs build
- browser checked at 1280px, 768px, and 375px with no horizontal overflow or Next.js error overlay