### PR TITLE
docs: improve documentation onboarding

### DIFF
--- a/apps/docs/content/docs/get-started/agents.mdx
+++ b/apps/docs/content/docs/get-started/agents.mdx
@@ -25,13 +25,13 @@ For agents that support skills, this installs the vgpu skill: the same reference
 
 ## Connect the hosted MCP server
 
-Add this remote MCP URL to your agent or editor:
+Use `add-mcp` to detect installed MCP clients and add the hosted VGPU server globally:
 
-```text
-https://vgpu.sh/api/mcp
+```bash
+npx -y add-mcp https://vgpu.sh/api/mcp -g
 ```
 
-It requires no authentication and gives the agent two read-only tools: `docs` for searching and resolving the VGPU documentation, and `examples` for finding and reading verified example source. Use automatic protocol negotiation when your client offers it.
+The installer lets you review its detected clients before writing their configuration. The server requires no authentication and gives the agent two read-only tools: `docs` for searching and resolving the VGPU documentation, and `examples` for finding and reading verified example source.
 
 If the agent needs to download an example, run `npx -y vgpu mcp --project-from-cwd` locally on Linux or macOS. Filesystem writes remain disabled until you explicitly select an output boundary. See the [MCP reference](/docs/mcp) for hosted HTTP details, local stdio setup, safe download destinations, and editor-specific guidance.
 

--- a/apps/docs/content/docs/get-started/index.mdx
+++ b/apps/docs/content/docs/get-started/index.mdx
@@ -1,26 +1,25 @@
 ---
 title: Get started
-description: vgpu runs in the browser and in Node.js with the same API. Pick your platform, then learn the core ideas.
+description: Set up your coding agent and render your first frame with vgpu.
 ---
 
-vgpu runs in two places with the same API: the browser, where WebGPU renders straight to a canvas,
-and Node.js, where Dawn renders headless for scripts, servers, and tests.
+vgpu is designed to be used with coding agents. Give your agent access to version-matched docs, verified examples, and diagnostics, then choose where to render.
 
 <Cards>
   <Card
     title="Agents"
-    description="vgpu is agent-first — the full documentation ships inside the package. Point your agent at `npx vgpu`."
+    description="Start here. Run `npx vgpu`, install the vgpu skill, or connect through MCP."
     href="/docs/get-started/agents"
     className="col-span-2"
   />
   <Card
     title="Web"
-    description="Render to a canvas with WebGPU, and set up the .wgsl loader for Next.js or Vite."
+    description="Render a shader to an interactive canvas with Next.js or Vite."
     href="/docs/get-started/web"
   />
   <Card
     title="Node.js"
-    description="Render headless through Dawn — save a PNG or assert on pixels in a test."
+    description="Render headlessly, save an image, or run GPU tests without a browser."
     href="/docs/get-started/node"
   />
 </Cards>

--- a/apps/docs/content/docs/index.mdx
+++ b/apps/docs/content/docs/index.mdx
@@ -1,17 +1,22 @@
 ---
-title: Documentation
-description: Documentation for vgpu, the WebGPU library designed for agents.
+title: vgpu Docs
+description: Build WebGPU applications for browsers, Node.js, and automated workflows.
 ---
 
-Documentation for vgpu, the WebGPU library designed for agents.
+vgpu is a TypeScript library for building WebGPU applications with one composable API. Write modular WGSL once, then use the same shaders for interactive canvases, headless rendering, images, video, and automated tests.
 
-vgpu runs in two places with the same API: the browser, where WebGPU renders straight to a canvas, and Node.js, where Dawn renders headless for scripts, servers, and tests.
+## How to use these docs
 
-- [Get started](/docs/get-started) — install `vgpu` and render with `init()`.
-- [Concepts](/docs/concepts) — learn `Gpu`, `set()`, targets, frames, bundles, and adapters.
-- [Guides](/docs/guides) — performance, testing, and shader authoring.
-- [API Reference](/docs/reference) — package map and generated topic pages.
-- [CLI](/docs/cli) — the `vgpu` command line.
-- [MCP](/docs/mcp) — connect agents to VGPU docs and verified examples over HTTP or local stdio.
-- [ML](/docs/ml) — running ONNX models alongside vgpu on a shared `GPUDevice`.
-- [Examples](/examples) — live WebGPU demos with read-only source views.
+- [Get started](/docs/get-started) — install vgpu and render your first frame.
+- [Learn the concepts](/docs/concepts) — understand GPUs, targets, frames, effects, and adapters.
+- [Explore the examples](/examples) — see live WebGPU demos and inspect their source.
+- [Explore the guides](/docs/guides) — solve specific problems involving performance, testing, and shader authoring.
+- [Browse the API reference](/docs/reference) — look up packages, types, and functions.
+
+Using a coding agent? Run `npx vgpu` to give it access to the docs, verified examples, validation tools, and runtime diagnostics.
+
+## Tools and workflows
+
+- [CLI](/docs/cli) — explore documentation, inspect examples, validate WGSL, and diagnose the runtime.
+- [MCP](/docs/mcp) — connect agents to VGPU documentation and verified examples.
+- [ML](/docs/ml) — run ONNX models alongside vgpu on a shared `GPUDevice`.

--- a/apps/docs/content/docs/meta.json
+++ b/apps/docs/content/docs/meta.json
@@ -1,7 +1,7 @@
 {
   "root": true,
   "title": "Documentation",
-  "description": "Documentation for vgpu, the WebGPU library designed for agents.",
+  "description": "Build WebGPU applications for browsers, Node.js, and automated workflows.",
   "pages": [
     "get-started",
     "concepts",

--- a/docs/nav.json
+++ b/docs/nav.json
@@ -1,7 +1,7 @@
 {
   "root": {
     "title": "Documentation",
-    "description": "Documentation for vgpu, the WebGPU library designed for agents."
+    "description": "Build WebGPU applications for browsers, Node.js, and automated workflows."
   },
   "packageOrder": [
     "vgpu",


### PR DESCRIPTION
## Summary

- rewrite the docs landing page around learning paths, examples, and tools
- foreground the agent-first workflow in Getting Started while preserving Web and Node.js paths
- align the Agents guide with the homepage global MCP installer command

## Verification

- `pnpm exec vitest run apps/docs/geistdocs.test.ts`
- `pnpm docs:verify-snippets`
- `pnpm check:skill-drift`
- browser checks for `/docs`, `/docs/get-started`, and `/docs/get-started/agents`