### PR TITLE
fix(docs): resolve API reference package 404s

### DIFF
--- a/apps/docs/content/docs/reference/vgpu-adapter-node/meta.json
+++ b/apps/docs/content/docs/reference/vgpu-adapter-node/meta.json
@@ -1,6 +1,7 @@
 {
   "title": "@vgpu/adapter-node",
   "pages": [
+    "create-node-adapter",
     "..."
   ]
 }

--- a/apps/docs/content/docs/reference/vgpu-mock/meta.json
+++ b/apps/docs/content/docs/reference/vgpu-mock/meta.json
@@ -1,6 +1,7 @@
 {
   "title": "vgpu/mock",
   "pages": [
+    "create-mock-adapter",
     "..."
   ]
 }

--- a/apps/docs/lib/docs-redirects.mjs
+++ b/apps/docs/lib/docs-redirects.mjs
@@ -15,21 +15,14 @@
  *     page). Without these 7 redirects the cutover breaks 7 live URLs — the
  *     single biggest handoff out of F1-F3.
  *
- *  2. `SECTION_ROOTS` — was `/docs/get-started`, `/docs/concepts`, `/docs/guides`
- *     and `/docs/reference` redirecting to the first page of the section,
- *     because the generated tree had no `index.md` in those directories and
- *     fumadocs had no page at the folder URL to answer with. That stopgap is
- *     gone: `content/docs/{get-started,concepts,guides,reference}/index.mdx`
- *     (hand-authored, TGEIST-11 follow-up) are real section-index pages now,
- *     ported verbatim from `apps/docs/app/docs/{get-started,concepts,guides,
- *     reference}/page.tsx`, so the four URLs answer 200 directly and a redirect
- *     here would only get in the way — Next.js resolves `redirects()` before
- *     it resolves a page, so a live entry would mask the very index it used to
- *     stand in for. Left as an empty array (not deleted) since the shape —
- *     "redirect a section root to its first page until it has a real
- *     `index.md`" — is still the correct stopgap for the next section that
- *     ships without one; `checkSectionRootTargets()` below stays wired to it
- *     for free.
+ *  2. `SECTION_ROOTS` — directories that are linked as landing pages but have
+ *     no `index.md`. The four top-level sections (`get-started`, `concepts`,
+ *     `guides`, and `reference`) now have hand-authored index pages and must not
+ *     appear here. Reference package directories are different: their cards on
+ *     `/docs/reference` link to the package root, while the generated corpus
+ *     contains topic pages only. Redirect each package root to the first topic
+ *     from its `meta.json`; `checkSectionRootTargets()` fails CI if navigation
+ *     ordering changes without updating this table.
  *
  *  3. `legacyTopLevelRedirects()` + the manifest-derived package/symbol
  *     redirects — ported from `apps/docs/next.config.mjs` (the app being
@@ -64,12 +57,39 @@ export const CONSOLIDATED_CONCEPT_GUIDES = [
 
 /**
  * Section directories with no `index.md` in `content/docs/**`, and the page
- * each one would redirect to (the first real page of the section's
- * `meta.json` — asserted by `check-url-anchor-parity.mjs`). Empty: all four
- * sections that ever needed this (get-started, concepts, guides, reference)
- * have a real `index.mdx` now. See the module comment above.
+ * each one redirects to (the first real page of the section's `meta.json` —
+ * asserted by `check-url-anchor-parity.mjs`).
  */
-export const SECTION_ROOTS = [];
+export const SECTION_ROOTS = [
+  { source: "/docs/reference/vgpu", destination: "/docs/reference/vgpu/init", dir: "reference/vgpu" },
+  {
+    source: "/docs/reference/vgpu-scene",
+    destination: "/docs/reference/vgpu-scene/camera",
+    dir: "reference/vgpu-scene",
+  },
+  { source: "/docs/reference/wgsl", destination: "/docs/reference/wgsl/compile", dir: "reference/wgsl" },
+  { source: "/docs/reference/wgsl-std", destination: "/docs/reference/wgsl-std/color", dir: "reference/wgsl-std" },
+  {
+    source: "/docs/reference/vgpu-core",
+    destination: "/docs/reference/vgpu-core/device",
+    dir: "reference/vgpu-core",
+  },
+  {
+    source: "/docs/reference/render",
+    destination: "/docs/reference/render/wireframe-material",
+    dir: "reference/render",
+  },
+  {
+    source: "/docs/reference/vgpu-adapter-node",
+    destination: "/docs/reference/vgpu-adapter-node/create-node-adapter",
+    dir: "reference/vgpu-adapter-node",
+  },
+  {
+    source: "/docs/reference/vgpu-mock",
+    destination: "/docs/reference/vgpu-mock/create-mock-adapter",
+    dir: "reference/vgpu-mock",
+  },
+];
 
 /**
  * `apps/docs/next.config.mjs`'s hand-written redirect list, ported verbatim

--- a/apps/docs/lib/docs-redirects.test.ts
+++ b/apps/docs/lib/docs-redirects.test.ts
@@ -1,0 +1,35 @@
+import { existsSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+import { buildDocsRedirects, SECTION_ROOTS } from "./docs-redirects.mjs";
+
+const CONTENT_ROOT = resolve(import.meta.dirname, "../content/docs");
+type Redirect = { source: string; destination: string };
+type SectionRoot = Redirect & { dir: string };
+
+describe("API reference package roots", () => {
+  it("redirects every package card to an existing topic page", () => {
+    const index = readFileSync(resolve(CONTENT_ROOT, "reference/index.mdx"), "utf8");
+    const packagesSection = index.slice(index.indexOf("## Packages"));
+    const cardHrefs = new Set(
+      [...packagesSection.matchAll(/\bhref="(\/docs\/reference\/[^"]+)"/gu)].map((match) => match[1]),
+    );
+    const redirects = new Map(
+      (buildDocsRedirects([]) as Redirect[]).map(({ source, destination }) => [source, destination]),
+    );
+
+    expect([...cardHrefs].sort()).toEqual(
+      (SECTION_ROOTS as SectionRoot[]).map(({ source }) => source).sort(),
+    );
+
+    for (const href of cardHrefs) {
+      const destination = redirects.get(href);
+      expect(destination, `${href} needs a redirect`).toBeDefined();
+      expect(
+        existsSync(resolve(CONTENT_ROOT, `${destination?.replace(/^\/docs\//u, "")}.md`)),
+        `${href} must redirect to an emitted page`,
+      ).toBe(true);
+    }
+  });
+});

--- a/docs/nav-curation.snapshot.json
+++ b/docs/nav-curation.snapshot.json
@@ -11,6 +11,10 @@
       "..."
     ],
     "topicOrder": {
+      "@vgpu/adapter-node": [
+        "create-node-adapter",
+        "..."
+      ],
       "@vgpu/render": [
         "wireframe-material",
         "normal-debug-material",
@@ -64,6 +68,10 @@
         "uniform",
         "structured-uniform",
         "uniform-pool",
+        "..."
+      ],
+      "vgpu/mock": [
+        "create-mock-adapter",
         "..."
       ],
       "vgpu/scene": [

--- a/docs/nav.json
+++ b/docs/nav.json
@@ -76,6 +76,14 @@
       "perf",
       "edit",
       "..."
+    ],
+    "@vgpu/adapter-node": [
+      "create-node-adapter",
+      "..."
+    ],
+    "vgpu/mock": [
+      "create-mock-adapter",
+      "..."
     ]
   },
   "guideGroups": [


### PR DESCRIPTION
Redirect all eight API reference package roots to their first generated topic so the package cards no longer land on missing directory pages. Make the adapter-node and mock first-topic ordering explicit in the generated navigation metadata, and add a regression test that requires every package card to resolve to an emitted page.

Verified with `pnpm exec vitest run apps/docs/lib/docs-redirects.test.ts`, `pnpm --filter docs build`, content schema/emission checks, runtime requests for all eight package URLs, and `pnpm --filter docs check:url-anchor-parity`.