### PR TITLE
fix(wgsl): resolve tmpdir symlink before comparing webpack fileDependencies on macOS

### DIFF
--- a/packages/wgsl/tests/webpack-real.test.ts
+++ b/packages/wgsl/tests/webpack-real.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, mkdtemp, readFile, symlink, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, realpath, symlink, writeFile } from "node:fs/promises";
 import { createRequire } from "node:module";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
@@ -75,7 +75,7 @@ describe("wgslWebpackLoader (real webpack 5)", () => {
       optimization: { minimize: false },
     });
 
-    expect(stats.compilation.fileDependencies.has(helperWgsl)).toBe(true);
+    expect(stats.compilation.fileDependencies.has(await realpath(helperWgsl))).toBe(true);
   });
 
   it("emits fresh bundled WGSL when a transitive import changes between builds", async () => {


### PR DESCRIPTION

## Diagnosis

The "addDependency wiring" test in `webpack-real.test.ts` asserts that `stats.compilation.fileDependencies` contains the transitively-imported `helper.wgsl`. On macOS this assertion fails, even though the loader correctly registers the dependency.

This is because `os.tmpdir()` on macOS returns a path under `/var/folders/...`, but `/var` is itself a symlink to `/private/var`. Webpack's resolver  follows symlinks by default, so `fileDependencies` records the resolved `/private/var/folders/.../helper.wgsl` path, while the test compares against the un-resolved `/var/folders/.../helper.wgsl` it wrote the fixture to. So the string comparison fails even though the file is tracked properly.

## Fix

Resolve the expected path with `fs.realpath` before comparing.

## Evidence (before / after)

**Before** (macOS, `node v22.22.2`):
```
AssertionError: expected false to be true
 ❯ packages/wgsl/tests/webpack-real.test.ts:78:64
```

**After:** all 5 tests in `webpack-real.test.ts` pass.

## Gates run (macOS, Node 22.22.2)

| Gate | Result |
| --- | --- |
| `pnpm typecheck` | ✅ |
| `pnpm test:fast` | ✅ 766 passed / 76 skipped |

## Notes

No changeset included since this is a test-only change, no published package behavior affected.
