### PR TITLE
Add Markdown and source routes for examples

### DIFF
--- a/apps/docs/app/[lang]/examples.md/[slug]/route.test.ts
+++ b/apps/docs/app/[lang]/examples.md/[slug]/route.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+import { GET, generateStaticParams } from "./route";
+
+describe("example Markdown", () => {
+  it("serves a README with the verified download command", async () => {
+    const response = await GET(new Request("https://vgpu.sh/examples/gradient.md"), {
+      params: Promise.resolve({ lang: "en", slug: "gradient" }),
+    });
+    const body = await response.text();
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toContain("text/markdown");
+    expect(response.headers.get("vary")).toMatch(/\bAccept\b/iu);
+    expect(response.headers.get("link")).toContain(
+      '<https://vgpu.sh/examples/gradient>; rel="canonical"',
+    );
+    expect(body).toContain("# Simple Gradient");
+    expect(body).toContain(
+      "Map screen coordinates to color with a tiny fullscreen fragment shader.",
+    );
+    expect(body).toContain(
+      "npx vgpu examples pull gradient --out ./gradient",
+    );
+    expect(body).toContain("https://vgpu.sh/examples/gradient");
+    expect(body).toContain("- `shader.wgsl`");
+  });
+
+  it("pre-renders every example in every language", () => {
+    const params = generateStaticParams();
+
+    expect(params).toContainEqual({ lang: "en", slug: "gradient" });
+    expect(params).toContainEqual({ lang: "cn", slug: "three-tsl" });
+  });
+
+  it("returns a useful Markdown 404 for an unknown internal slug", async () => {
+    const response = await GET(new Request("https://vgpu.sh/examples/unknown.md"), {
+      params: Promise.resolve({ lang: "en", slug: "unknown" }),
+    });
+    const body = await response.text();
+
+    expect(response.status).toBe(404);
+    expect(response.headers.get("content-type")).toContain("text/markdown");
+    expect(body).toContain("# Page Not Found");
+    expect(body).toContain("/examples/gradient.md");
+  });
+});

--- a/apps/docs/app/[lang]/examples.md/[slug]/route.ts
+++ b/apps/docs/app/[lang]/examples.md/[slug]/route.ts
@@ -1,0 +1,44 @@
+import { applyMarkdownHeaders, createNotFoundResponse } from "@vercel/agent-readability";
+import { translations } from "../../../../geistdocs";
+import { buildExampleReadme } from "../../../../lib/example-readme";
+import { examples, getExample } from "../../../../lib/examples-registry";
+import { localizedSitePath, siteUrl } from "../../../../lib/site";
+
+interface ExampleMarkdownRouteContext {
+  params: Promise<{ lang: string; slug: string }>;
+}
+
+export const revalidate = false;
+
+export function generateStaticParams() {
+  return Object.keys(translations).flatMap((lang) =>
+    examples.map((example) => ({ lang, slug: example.meta.slug })),
+  );
+}
+
+export async function GET(
+  _request: Request,
+  { params }: ExampleMarkdownRouteContext,
+): Promise<Response> {
+  const { lang, slug } = await params;
+  const example = getExample(slug);
+
+  if (!example) {
+    return createNotFoundResponse(localizedSitePath(`/examples/${slug}.md`, lang), {
+      sitemapUrl: localizedSitePath("/sitemap.md", lang),
+      indexUrl: localizedSitePath("/llms.txt", lang),
+      fullContentUrl: localizedSitePath("/llms-full.txt", lang),
+      exampleUrl: localizedSitePath("/examples/gradient.md", lang),
+    });
+  }
+
+  const headers = applyMarkdownHeaders(
+    new Headers({
+      "Cache-Control": "public, max-age=300, must-revalidate",
+      "Content-Type": "text/markdown; charset=utf-8",
+    }),
+    { canonicalUrl: siteUrl(`/examples/${slug}`) },
+  );
+
+  return new Response(buildExampleReadme(example), { headers });
+}

--- a/apps/docs/app/[lang]/examples.md/[slug]/source/route.test.ts
+++ b/apps/docs/app/[lang]/examples.md/[slug]/source/route.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+import { exampleSources } from "../../../../../lib/examples-source.generated";
+import { GET, generateStaticParams } from "./route";
+
+describe("example source Markdown", () => {
+  it("serves every source file in canonical order", async () => {
+    const response = await GET(
+      new Request("https://vgpu.sh/examples/gradient/source.md"),
+      { params: Promise.resolve({ lang: "en", slug: "gradient" }) },
+    );
+    const body = await response.text();
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toContain("text/markdown");
+    expect(response.headers.get("vary")).toMatch(/\bAccept\b/iu);
+    expect(response.headers.get("link")).toContain(
+      '<https://vgpu.sh/examples/gradient>; rel="canonical"',
+    );
+    expect(body).toContain("# Simple Gradient source");
+
+    let previousFileIndex = -1;
+    for (const file of exampleSources.gradient.files) {
+      const heading = `## \`${file.path}\``;
+      const fileIndex = body.indexOf(heading);
+      expect(fileIndex, `${file.path} is missing`).toBeGreaterThan(
+        previousFileIndex,
+      );
+      expect(body).toContain(file.content);
+      previousFileIndex = fileIndex;
+    }
+  });
+
+  it("pre-renders every example in every language", () => {
+    const params = generateStaticParams();
+
+    expect(params).toContainEqual({ lang: "en", slug: "gradient" });
+    expect(params).toContainEqual({ lang: "cn", slug: "three-tsl" });
+  });
+
+  it("returns a useful Markdown 404 for an unknown internal slug", async () => {
+    const response = await GET(
+      new Request("https://vgpu.sh/examples/unknown/source.md"),
+      { params: Promise.resolve({ lang: "en", slug: "unknown" }) },
+    );
+    const body = await response.text();
+
+    expect(response.status).toBe(404);
+    expect(response.headers.get("content-type")).toContain("text/markdown");
+    expect(body).toContain("# Page Not Found");
+    expect(body).toContain("/examples/gradient/source.md");
+  });
+});

--- a/apps/docs/app/[lang]/examples.md/[slug]/source/route.ts
+++ b/apps/docs/app/[lang]/examples.md/[slug]/source/route.ts
@@ -1,0 +1,50 @@
+import { applyMarkdownHeaders, createNotFoundResponse } from "@vercel/agent-readability";
+import { translations } from "../../../../../geistdocs";
+import { buildExampleSourceMarkdown } from "../../../../../lib/example-readme";
+import { examples, getExample } from "../../../../../lib/examples-registry";
+import { localizedSitePath, siteUrl } from "../../../../../lib/site";
+
+interface ExampleSourceMarkdownRouteContext {
+  params: Promise<{ lang: string; slug: string }>;
+}
+
+export const revalidate = false;
+
+export function generateStaticParams() {
+  return Object.keys(translations).flatMap((lang) =>
+    examples.map((example) => ({ lang, slug: example.meta.slug })),
+  );
+}
+
+export async function GET(
+  _request: Request,
+  { params }: ExampleSourceMarkdownRouteContext,
+): Promise<Response> {
+  const { lang, slug } = await params;
+  const example = getExample(slug);
+
+  if (!example) {
+    return createNotFoundResponse(
+      localizedSitePath(`/examples/${slug}/source.md`, lang),
+      {
+        sitemapUrl: localizedSitePath("/sitemap.md", lang),
+        indexUrl: localizedSitePath("/llms.txt", lang),
+        fullContentUrl: localizedSitePath("/llms-full.txt", lang),
+        exampleUrl: localizedSitePath(
+          "/examples/gradient/source.md",
+          lang,
+        ),
+      },
+    );
+  }
+
+  const headers = applyMarkdownHeaders(
+    new Headers({
+      "Cache-Control": "public, max-age=300, must-revalidate",
+      "Content-Type": "text/markdown; charset=utf-8",
+    }),
+    { canonicalUrl: siteUrl(`/examples/${slug}`) },
+  );
+
+  return new Response(buildExampleSourceMarkdown(example), { headers });
+}

--- a/apps/docs/app/[lang]/examples/[slug]/page.tsx
+++ b/apps/docs/app/[lang]/examples/[slug]/page.tsx
@@ -30,7 +30,12 @@ export async function generateMetadata({
   return {
     title: example.meta.title,
     description: example.meta.description,
-    alternates: { canonical: siteUrl(`/examples/${example.meta.slug}`) },
+    alternates: {
+      canonical: siteUrl(`/examples/${example.meta.slug}`),
+      types: {
+        "text/markdown": siteUrl(`/examples/${example.meta.slug}.md`),
+      },
+    },
     openGraph: {
       type: "article",
       title: example.meta.title,

--- a/apps/docs/lib/example-readme.ts
+++ b/apps/docs/lib/example-readme.ts
@@ -1,0 +1,36 @@
+import type { ExampleRecord } from "./examples-registry";
+import { siteUrl } from "./site";
+
+function inlineCode(value: string): string {
+  const fence = value.includes("`") ? "``" : "`";
+  return `${fence}${value}${fence}`;
+}
+
+export function buildExampleReadme(example: ExampleRecord): string {
+  const { description, slug, title } = example.meta;
+  const files = example.sources
+    .map(({ name }) => `- ${inlineCode(name)}`)
+    .join("\n");
+
+  return `# ${title}
+
+${description}
+
+## Download
+
+Download the complete verified example source:
+
+\`\`\`bash
+npx vgpu examples pull ${slug} --out ./${slug}
+\`\`\`
+
+## Explore
+
+- [Interactive example](${siteUrl(`/examples/${slug}`)})
+- [Fullscreen preview](${siteUrl(`/preview/${slug}`)})
+
+## Included files
+
+${files}
+`;
+}

--- a/apps/docs/lib/example-readme.ts
+++ b/apps/docs/lib/example-readme.ts
@@ -1,9 +1,23 @@
 import type { ExampleRecord } from "./examples-registry";
 import { siteUrl } from "./site";
 
+function backtickFence(value: string, minimumLength: number): string {
+  let longestRun = 0;
+  for (const [run] of value.matchAll(/`+/gu)) {
+    longestRun = Math.max(longestRun, run.length);
+  }
+  return "`".repeat(Math.max(minimumLength, longestRun + 1));
+}
+
 function inlineCode(value: string): string {
-  const fence = value.includes("`") ? "``" : "`";
+  const fence = backtickFence(value, 1);
   return `${fence}${value}${fence}`;
+}
+
+function fencedSource(code: string, language: string): string {
+  const fence = backtickFence(code, 3);
+  const normalizedCode = code.endsWith("\n") ? code : `${code}\n`;
+  return `${fence}${language}\n${normalizedCode}${fence}`;
 }
 
 export function buildExampleReadme(example: ExampleRecord): string {
@@ -28,8 +42,23 @@ npx vgpu examples pull ${slug} --out ./${slug}
 
 - [Interactive example](${siteUrl(`/examples/${slug}`)})
 - [Fullscreen preview](${siteUrl(`/preview/${slug}`)})
+- [Complete source](${siteUrl(`/examples/${slug}/source.md`)})
 
 ## Included files
+
+${files}
+`;
+}
+
+export function buildExampleSourceMarkdown(example: ExampleRecord): string {
+  const files = example.sources
+    .map(
+      ({ code, lang, name }) =>
+        `## ${inlineCode(name)}\n\n${fencedSource(code, lang)}`,
+    )
+    .join("\n\n");
+
+  return `# ${example.meta.title} source
 
 ${files}
 `;

--- a/apps/docs/proxy.ts
+++ b/apps/docs/proxy.ts
@@ -5,6 +5,7 @@ import {
 import { precompute } from "flags/next";
 import { NextResponse } from "next/server";
 import { homepageFlags } from "@/flags";
+import { exampleSlugs } from "@/lib/example-slugs";
 import { config as geistdocsConfig } from "@/lib/geistdocs/config";
 import { trackMdRequest } from "@/lib/geistdocs/md-tracking";
 import { createUnmatchedMarkdownNotFoundResponse } from "@/lib/geistdocs/markdown-not-found";
@@ -53,6 +54,10 @@ const proxy = createProxy({
   markdownRoutes: [
     { from: "/", to: "/[lang]/index.md" },
     { from: "/docs/*path", to: "/[lang]/llms.mdx/*path" },
+    ...exampleSlugs.map((slug) => ({
+      from: `/examples/${slug}` as const,
+      to: `/[lang]/examples.md/${slug}` as const,
+    })),
   ],
 });
 

--- a/apps/docs/proxy.ts
+++ b/apps/docs/proxy.ts
@@ -54,10 +54,16 @@ const proxy = createProxy({
   markdownRoutes: [
     { from: "/", to: "/[lang]/index.md" },
     { from: "/docs/*path", to: "/[lang]/llms.mdx/*path" },
-    ...exampleSlugs.map((slug) => ({
-      from: `/examples/${slug}` as const,
-      to: `/[lang]/examples.md/${slug}` as const,
-    })),
+    ...exampleSlugs.flatMap((slug) => [
+      {
+        from: `/examples/${slug}` as const,
+        to: `/[lang]/examples.md/${slug}` as const,
+      },
+      {
+        from: `/examples/${slug}/source` as const,
+        to: `/[lang]/examples.md/${slug}/source` as const,
+      },
+    ]),
   ],
 });
 

--- a/apps/docs/scripts/check-production-readiness.mjs
+++ b/apps/docs/scripts/check-production-readiness.mjs
@@ -192,11 +192,33 @@ async function checkMarkdown(baseUrl) {
     "examples Markdown preference fallback: valid app page was replaced",
   );
 
-  const exampleHtml = await request(baseUrl, "/examples/gradient", { headers: { Accept: "text/markdown" } });
-  assert(exampleHtml.status === 200, `example Markdown preference fallback: status ${exampleHtml.status}`);
+  const examplePage = await request(baseUrl, "/examples/gradient", { headers: { Accept: "text/html" } });
+  const examplePageBody = await examplePage.text();
+  assert(examplePage.status === 200, `example HTML: status ${examplePage.status}`);
   assert(
-    exampleHtml.headers.get("content-type")?.includes("text/html"),
-    "example Markdown preference fallback: valid detail page was replaced",
+    examplePageBody.includes('<link rel="alternate" type="text/markdown" href="https://vgpu.sh/examples/gradient.md"'),
+    "example HTML: Markdown alternate is missing",
+  );
+
+  const negotiatedExample = await request(baseUrl, "/examples/gradient", { headers: { Accept: "text/markdown" } });
+  assertMarkdownResponse(negotiatedExample, "negotiated example Markdown");
+  const negotiatedExampleBody = await negotiatedExample.text();
+  assert(negotiatedExampleBody.includes("# Simple Gradient"), "negotiated example Markdown: README title is missing");
+  assert(
+    negotiatedExampleBody.includes("npx vgpu examples pull gradient --out ./gradient"),
+    "negotiated example Markdown: download command is missing",
+  );
+
+  const explicitExample = await request(baseUrl, "/examples/gradient.md");
+  assertMarkdownResponse(explicitExample, "explicit example Markdown");
+  const explicitExampleBody = await explicitExample.text();
+  assert(
+    explicitExampleBody === negotiatedExampleBody,
+    "explicit and negotiated example Markdown differ",
+  );
+  assert(
+    explicitExample.headers.get("link")?.includes("<https://vgpu.sh/examples/gradient>; rel=\"canonical\""),
+    "explicit example Markdown: canonical Link is missing",
   );
 
   const missingExample = await request(baseUrl, "/examples/not-a-real-example", {

--- a/apps/docs/scripts/check-production-readiness.mjs
+++ b/apps/docs/scripts/check-production-readiness.mjs
@@ -220,6 +220,29 @@ async function checkMarkdown(baseUrl) {
     explicitExample.headers.get("link")?.includes("<https://vgpu.sh/examples/gradient>; rel=\"canonical\""),
     "explicit example Markdown: canonical Link is missing",
   );
+  assert(
+    explicitExampleBody.includes("https://vgpu.sh/examples/gradient/source.md"),
+    "explicit example Markdown: complete source link is missing",
+  );
+
+  const explicitExampleSource = await request(baseUrl, "/examples/gradient/source.md");
+  assertMarkdownResponse(explicitExampleSource, "explicit example source Markdown");
+  const explicitExampleSourceBody = await explicitExampleSource.text();
+  for (const expected of ["# Simple Gradient source", "## `index.tsx`", "## `renderer.ts`", "## `shader.wgsl`"]) {
+    assert(
+      explicitExampleSourceBody.includes(expected),
+      `explicit example source Markdown: missing ${expected}`,
+    );
+  }
+
+  const negotiatedExampleSource = await request(baseUrl, "/examples/gradient/source", {
+    headers: { Accept: "text/markdown" },
+  });
+  assertMarkdownResponse(negotiatedExampleSource, "negotiated example source Markdown");
+  assert(
+    await negotiatedExampleSource.text() === explicitExampleSourceBody,
+    "explicit and negotiated example source Markdown differ",
+  );
 
   const missingExample = await request(baseUrl, "/examples/not-a-real-example", {
     headers: { Accept: "text/markdown" },


### PR DESCRIPTION
Adds README-style Markdown representations for every `/examples/:id` page through `.md` URLs and content negotiation. Each README includes canonical metadata, interactive links, the verified `npx vgpu examples pull` command, and a link to `/examples/:id/source.md`. The source route joins every canonical file in order under filename headings with copy-safe syntax-aware fences, while invalid slugs preserve agent-friendly Markdown 404s. HTML pages advertise their Markdown alternate, and route plus production-readiness tests cover explicit and negotiated responses.

Verified with focused Vitest tests, the docs production build, TypeScript, and the full production-readiness smoke test.