### PR TITLE
Add source actions to example pages

### DIFF
--- a/apps/docs/app/[lang]/examples/[slug]/download/route.test.ts
+++ b/apps/docs/app/[lang]/examples/[slug]/download/route.test.ts
@@ -1,0 +1,30 @@
+import { inflateRawSync } from "node:zlib";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+import { GET } from "./route";
+
+describe("example ZIP route", () => {
+  it("downloads the source under an example directory", async () => {
+    const response = await GET(new Request("https://vgpu.sh/examples/gradient/download"), {
+      params: Promise.resolve({ lang: "en", slug: "gradient" }),
+    });
+    const archive = new Uint8Array(await response.arrayBuffer());
+    const view = new DataView(archive.buffer);
+    const compressedSize = view.getUint32(18, true);
+    const nameLength = view.getUint16(26, true);
+    const name = new TextDecoder().decode(archive.slice(30, 30 + nameLength));
+    const content = inflateRawSync(
+      archive.slice(30 + nameLength, 30 + nameLength + compressedSize),
+    ).toString();
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toBe("application/zip");
+    expect(response.headers.get("content-disposition")).toBe(
+      'attachment; filename="gradient.zip"',
+    );
+    expect(name).toBe("gradient/index.tsx");
+    expect(content).toContain("export function Example()");
+  });
+});

--- a/apps/docs/app/[lang]/examples/[slug]/download/route.ts
+++ b/apps/docs/app/[lang]/examples/[slug]/download/route.ts
@@ -1,0 +1,45 @@
+import { translations } from "../../../../../geistdocs";
+import { examples, getExample } from "../../../../../lib/examples-registry";
+import { createZip } from "../../../../../lib/zip";
+
+interface ExampleDownloadRouteContext {
+  params: Promise<{ lang: string; slug: string }>;
+}
+
+export const revalidate = false;
+export const runtime = "nodejs";
+
+export function generateStaticParams() {
+  return Object.keys(translations).flatMap((lang) =>
+    examples.map((example) => ({ lang, slug: example.meta.slug })),
+  );
+}
+
+export async function GET(
+  _request: Request,
+  { params }: ExampleDownloadRouteContext,
+): Promise<Response> {
+  const { slug } = await params;
+  const example = getExample(slug);
+
+  if (!example) {
+    return Response.json({ error: "Example not found" }, { status: 404 });
+  }
+
+  const archive = createZip(
+    example.sources.map(({ code, name }) => ({
+      name: `${slug}/${name}`,
+      content: code,
+    })),
+  );
+
+  return new Response(archive, {
+    headers: {
+      "Cache-Control": "public, max-age=300, must-revalidate",
+      "Content-Disposition": `attachment; filename="${slug}.zip"`,
+      "Content-Length": archive.byteLength.toString(),
+      "Content-Type": "application/zip",
+      "X-Content-Type-Options": "nosniff",
+    },
+  });
+}

--- a/apps/docs/app/[lang]/examples/[slug]/page.tsx
+++ b/apps/docs/app/[lang]/examples/[slug]/page.tsx
@@ -2,12 +2,15 @@ import type { Metadata } from "next";
 import Link from "next/link";
 import { notFound } from "next/navigation";
 import { Button } from "@vercel/geistdocs/components/button";
+import { ExampleActions } from "@/components/example-actions";
 import { ExamplePreview } from "@/components/example-preview";
 import { ExampleSourceViewer } from "@/components/example-source-viewer";
 import { translations } from "@/geistdocs";
 // TGEIST-09: `examples`/`getExample` are the verbatim registry ported by
 // TGEIST-07 (`lib/examples-registry.ts`) -- unmodified by this ticket.
 import { examples, getExample } from "@/lib/examples-registry";
+import { buildExamplePrompt, buildV0OpenUrl } from "@/lib/example-actions";
+import { buildExampleSourceMarkdown } from "@/lib/example-readme";
 import { SITE_OG_IMAGE_PATH, siteUrl } from "@/lib/site";
 
 interface ExampleDetailPageProps {
@@ -53,20 +56,31 @@ const ExampleDetailPage = async ({ params }: ExampleDetailPageProps) => {
   const example = getExample(slug);
   if (!example) notFound();
 
+  const prompt = buildExamplePrompt(example);
+  const source = buildExampleSourceMarkdown(example);
+
   return (
     <main className="mx-auto w-full max-w-[880px] px-4 pt-12 pb-32 sm:px-6">
-      <div className="mb-6 flex flex-wrap items-end justify-between gap-4">
-        <div>
+      <div className="mb-6">
+        <div className="flex flex-col gap-4 md:flex-row md:items-end md:justify-between">
           <h1 className="font-medium! text-heading-32 text-gray-1000 tracking-tighter sm:text-heading-40">
             {example.meta.title}
           </h1>
-          <p className="mt-3 max-w-2xl text-copy-16 text-gray-900">
-            {example.meta.description}
-          </p>
+          <div className="flex shrink-0 items-center gap-2">
+            <Button asChild size="sm" variant="outline">
+              <Link href={`/preview/${example.meta.slug}`}>Open fullscreen</Link>
+            </Button>
+            <ExampleActions
+              downloadUrl={`/examples/${example.meta.slug}/download`}
+              prompt={prompt}
+              source={source}
+              v0Url={buildV0OpenUrl(example.meta.slug)}
+            />
+          </div>
         </div>
-        <Button asChild variant="outline">
-          <Link href={`/preview/${example.meta.slug}`}>Open fullscreen</Link>
-        </Button>
+        <p className="mt-3 max-w-2xl text-copy-16 text-gray-900">
+          {example.meta.description}
+        </p>
       </div>
 
       <div className="flex flex-col gap-6">

--- a/apps/docs/app/[lang]/examples/[slug]/v0.json/route.test.ts
+++ b/apps/docs/app/[lang]/examples/[slug]/v0.json/route.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+import { GET, generateStaticParams } from "./route";
+
+describe("example v0 registry route", () => {
+  it("serves a complete registry item", async () => {
+    const response = await GET(new Request("https://vgpu.sh/examples/gradient/v0.json"), {
+      params: Promise.resolve({ lang: "en", slug: "gradient" }),
+    });
+    const item = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toContain("application/json");
+    expect(item).toMatchObject({ name: "vgpu-gradient", type: "registry:block" });
+    expect(item.files.map((file: { path: string }) => file.path)).toContain(
+      "examples/gradient/shader.wgsl",
+    );
+  });
+
+  it("pre-renders every example in every language", () => {
+    expect(generateStaticParams()).toContainEqual({ lang: "cn", slug: "three-tsl" });
+  });
+
+  it("returns JSON for an unknown slug", async () => {
+    const response = await GET(new Request("https://vgpu.sh/examples/unknown/v0.json"), {
+      params: Promise.resolve({ lang: "en", slug: "unknown" }),
+    });
+
+    expect(response.status).toBe(404);
+    await expect(response.json()).resolves.toEqual({ error: "Example not found" });
+  });
+});

--- a/apps/docs/app/[lang]/examples/[slug]/v0.json/route.ts
+++ b/apps/docs/app/[lang]/examples/[slug]/v0.json/route.ts
@@ -1,0 +1,34 @@
+import { translations } from "../../../../../geistdocs";
+import { buildExampleV0RegistryItem } from "../../../../../lib/example-actions";
+import { examples, getExample } from "../../../../../lib/examples-registry";
+
+interface ExampleV0RouteContext {
+  params: Promise<{ lang: string; slug: string }>;
+}
+
+export const revalidate = false;
+
+export function generateStaticParams() {
+  return Object.keys(translations).flatMap((lang) =>
+    examples.map((example) => ({ lang, slug: example.meta.slug })),
+  );
+}
+
+export async function GET(
+  _request: Request,
+  { params }: ExampleV0RouteContext,
+): Promise<Response> {
+  const { slug } = await params;
+  const example = getExample(slug);
+
+  if (!example) {
+    return Response.json({ error: "Example not found" }, { status: 404 });
+  }
+
+  return Response.json(buildExampleV0RegistryItem(example), {
+    headers: {
+      "Cache-Control": "public, max-age=300, must-revalidate",
+      "X-Content-Type-Options": "nosniff",
+    },
+  });
+}

--- a/apps/docs/components/example-actions.tsx
+++ b/apps/docs/components/example-actions.tsx
@@ -1,0 +1,134 @@
+"use client";
+
+import { SiV0 } from "@icons-pack/react-simple-icons";
+import { Button } from "@vercel/geistdocs/components/button";
+import { ButtonGroup } from "@vercel/geistdocs/components/button-group";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@vercel/geistdocs/components/dropdown-menu";
+import {
+  CheckIcon,
+  ChevronDownIcon,
+  CopyIcon,
+  DownloadIcon,
+  FileTextIcon,
+} from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+
+interface ExampleActionsProps {
+  readonly downloadUrl: string;
+  readonly prompt: string;
+  readonly source: string;
+  readonly v0Url: string;
+}
+
+type CopiedAction = "prompt" | "source";
+
+interface MenuItemContentProps {
+  readonly description: string;
+  readonly icon: React.ReactNode;
+  readonly title: string;
+}
+
+function MenuItemContent({ description, icon, title }: MenuItemContentProps) {
+  return (
+    <span className="grid w-full grid-cols-[20px_minmax(0,1fr)] items-center gap-3 text-left">
+      <span className="flex size-5 items-center justify-center text-gray-900">{icon}</span>
+      <span className="flex min-w-0 flex-col items-start gap-0.5">
+        <span className="text-gray-1000 text-label-14">{title}</span>
+        <span className="text-copy-13 text-gray-900">{description}</span>
+      </span>
+    </span>
+  );
+}
+
+export function ExampleActions({ downloadUrl, prompt, source, v0Url }: ExampleActionsProps) {
+  const [copied, setCopied] = useState<CopiedAction | null>(null);
+  const resetTimer = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+
+  useEffect(() => () => clearTimeout(resetTimer.current), []);
+
+  const copy = async (action: CopiedAction, value: string) => {
+    await navigator.clipboard.writeText(value);
+    setCopied(action);
+    clearTimeout(resetTimer.current);
+    resetTimer.current = setTimeout(() => setCopied(null), 2000);
+  };
+
+  const promptCopied = copied === "prompt";
+
+  return (
+    <ButtonGroup>
+      <Button
+        aria-label={promptCopied ? "Prompt copied" : "Copy prompt"}
+        onClick={() => void copy("prompt", prompt)}
+        size="sm"
+        type="button"
+        variant="outline"
+      >
+        {promptCopied ? <CheckIcon className="size-4" /> : <CopyIcon className="size-4" />}
+        <span className="relative inline-block">
+          <span className="invisible">Copy prompt</span>
+          <span className="absolute inset-0">{promptCopied ? "Copied" : "Copy prompt"}</span>
+        </span>
+      </Button>
+
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button aria-label="Example actions" size="icon-sm" type="button" variant="outline">
+            <ChevronDownIcon className="size-4" />
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent
+          align="end"
+          className="w-[min(320px,calc(100vw-2rem))] rounded-xl bg-background-100 p-1 shadow-(--ds-shadow-menu)"
+          sideOffset={8}
+        >
+          <DropdownMenuItem asChild className="h-auto w-full p-2">
+            <button onClick={() => void copy("prompt", prompt)} type="button">
+              <MenuItemContent
+                description="Copy the pull command and agent instructions"
+                icon={copied === "prompt" ? <CheckIcon /> : <CopyIcon />}
+                title={copied === "prompt" ? "Prompt copied" : "Copy prompt"}
+              />
+            </button>
+          </DropdownMenuItem>
+          <DropdownMenuItem asChild className="h-auto w-full p-2">
+            <button onClick={() => void copy("source", source)} type="button">
+              <MenuItemContent
+                description="Copy every source file as Markdown"
+                icon={copied === "source" ? <CheckIcon /> : <FileTextIcon />}
+                title={copied === "source" ? "Source copied" : "Copy source"}
+              />
+            </button>
+          </DropdownMenuItem>
+          <DropdownMenuItem asChild className="h-auto w-full p-2">
+            <a href={v0Url} rel="noopener noreferrer" target="_blank">
+              <MenuItemContent
+                description="Start a v0 chat with the example files"
+                icon={<SiV0 aria-hidden="true" className="size-4" />}
+                title="Open in v0"
+              />
+            </a>
+          </DropdownMenuItem>
+          <DropdownMenuItem asChild className="h-auto w-full p-2">
+            <a download href={downloadUrl}>
+              <MenuItemContent
+                description="Download the complete source as a ZIP"
+                icon={<DownloadIcon />}
+                title="Download as ZIP"
+              />
+            </a>
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+
+      <span aria-live="polite" className="sr-only">
+        {copied === "prompt" ? "Prompt copied" : copied === "source" ? "Source copied" : ""}
+      </span>
+    </ButtonGroup>
+  );
+}

--- a/apps/docs/lib/example-actions.test.ts
+++ b/apps/docs/lib/example-actions.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { buildExamplePrompt, buildExampleV0RegistryItem, buildV0OpenUrl } from "./example-actions";
+import { getExample } from "./examples-registry";
+
+const gradient = getExample("gradient");
+if (!gradient) throw new Error("Missing gradient example fixture");
+
+describe("example actions", () => {
+  it("builds an agent prompt with the verified pull command and integration instructions", () => {
+    const prompt = buildExamplePrompt(gradient);
+
+    expect(prompt).toContain("npx vgpu examples pull gradient --out ./gradient");
+    expect(prompt).toContain("install any required dependencies");
+    expect(prompt).toContain("Preserve its WebGPU behavior and resource cleanup");
+  });
+
+  it("exposes every source file as a v0-fetchable registry item", () => {
+    const item = buildExampleV0RegistryItem(gradient);
+
+    expect(item.$schema).toBe("https://ui.shadcn.com/schema/registry-item.json");
+    expect(item.type).toBe("registry:block");
+    expect(item.dependencies).toEqual(expect.arrayContaining(["react", "vgpu"]));
+    expect(item.files).toHaveLength(gradient.sources.length);
+    expect(item.files[0]).toMatchObject({
+      path: "examples/gradient/index.tsx",
+      target: "~/examples/gradient/index.tsx",
+      type: "registry:file",
+      content: gradient.sources[0].code,
+    });
+  });
+
+  it("opens v0 with the public registry endpoint", () => {
+    const url = new URL(buildV0OpenUrl("gradient"));
+
+    expect(url.origin + url.pathname).toBe("https://v0.app/chat/api/open");
+    expect(url.searchParams.get("url")).toBe("https://vgpu.sh/examples/gradient/v0.json");
+  });
+});

--- a/apps/docs/lib/example-actions.ts
+++ b/apps/docs/lib/example-actions.ts
@@ -1,0 +1,80 @@
+import type { ExampleRecord } from "./examples-registry";
+import { siteUrl } from "./site";
+
+const IMPORT_SPECIFIER = /(?:\bfrom\s*|\bimport\s*(?:\(\s*)?)["']([^"']+)["']/gu;
+
+function packageName(specifier: string): string | undefined {
+  if (
+    specifier.startsWith(".") ||
+    specifier.startsWith("/") ||
+    specifier.startsWith("@/") ||
+    specifier.startsWith("node:")
+  ) {
+    return undefined;
+  }
+
+  if (specifier.startsWith("@")) {
+    const [scope, name] = specifier.split("/");
+    return scope && name ? `${scope}/${name}` : undefined;
+  }
+
+  return specifier.split("/")[0] || undefined;
+}
+
+function externalDependencies(example: ExampleRecord): string[] {
+  const dependencies = new Set<string>();
+
+  for (const { code } of example.sources) {
+    for (const match of code.matchAll(IMPORT_SPECIFIER)) {
+      const dependency = packageName(match[1]);
+      if (dependency) dependencies.add(dependency);
+    }
+  }
+
+  return [...dependencies].sort();
+}
+
+export function buildExamplePrompt(example: ExampleRecord): string {
+  const { slug, title } = example.meta;
+
+  return `Use the “${title}” vgpu example as a starting point for my project.
+
+Pull the complete, verified source into the current workspace with:
+
+\`\`\`bash
+npx vgpu examples pull ${slug} --out ./${slug}
+\`\`\`
+
+Then inspect the downloaded files, install any required dependencies, and integrate the example into the existing app. Preserve its WebGPU behavior and resource cleanup, adapt only what the project needs, and explain the changes you make.`;
+}
+
+export function buildExampleV0RegistryItem(example: ExampleRecord) {
+  const { description, slug, title } = example.meta;
+  const dependencies = externalDependencies(example);
+
+  return {
+    $schema: "https://ui.shadcn.com/schema/registry-item.json",
+    name: `vgpu-${slug}`,
+    type: "registry:block",
+    title,
+    description,
+    ...(dependencies.length > 0 ? { dependencies } : {}),
+    files: example.sources.map(({ code, name }) => ({
+      path: `examples/${slug}/${name}`,
+      content: code,
+      type: "registry:file",
+      target: `~/examples/${slug}/${name}`,
+    })),
+    meta: {
+      command: `npx vgpu examples pull ${slug} --out ./${slug}`,
+      source: siteUrl(`/examples/${slug}/source.md`),
+    },
+  } as const;
+}
+
+export function buildV0OpenUrl(slug: string): string {
+  const query = new URLSearchParams({
+    url: siteUrl(`/examples/${slug}/v0.json`),
+  });
+  return `https://v0.app/chat/api/open?${query.toString()}`;
+}

--- a/apps/docs/lib/geistdocs/markdown-not-found.test.ts
+++ b/apps/docs/lib/geistdocs/markdown-not-found.test.ts
@@ -61,6 +61,8 @@ describe("unmatched Markdown responses", () => {
     "/examples",
     "/cn/examples/",
     "/examples/triangle-led-front",
+    "/examples/triangle-led-front/download",
+    "/examples/triangle-led-front/v0.json",
     "/docs/get-started",
     "/llms.txt",
     "/cn/llms-full.txt",

--- a/apps/docs/lib/geistdocs/markdown-not-found.ts
+++ b/apps/docs/lib/geistdocs/markdown-not-found.ts
@@ -41,15 +41,15 @@ function localizedPathname(
 }
 
 function isKnownHtmlRoute(pathname: string): boolean {
-  const exampleSlug = pathname.startsWith("/examples/")
-    ? pathname.slice("/examples/".length)
-    : null;
+  const exampleRoute = pathname.match(
+    /^\/examples\/([^/]+)(?:\/(?:download|v0\.json))?$/u,
+  );
 
   return (
     HTML_ROUTE_PATHS.has(pathname) ||
     pathname === "/docs" ||
     pathname === "/examples" ||
-    (exampleSlug !== null && isExampleSlug(exampleSlug)) ||
+    (exampleRoute !== null && isExampleSlug(exampleRoute[1])) ||
     HTML_ROUTE_PREFIXES.some((prefix) => pathname.startsWith(prefix))
   );
 }

--- a/apps/docs/lib/zip.test.ts
+++ b/apps/docs/lib/zip.test.ts
@@ -1,0 +1,42 @@
+import { inflateRawSync } from "node:zlib";
+import { describe, expect, it } from "vitest";
+import { createZip } from "./zip";
+
+function readFirstEntry(archive: Uint8Array) {
+  const view = new DataView(archive.buffer, archive.byteOffset, archive.byteLength);
+  expect(view.getUint32(0, true)).toBe(0x04034b50);
+  const compressedSize = view.getUint32(18, true);
+  const nameLength = view.getUint16(26, true);
+  const extraLength = view.getUint16(28, true);
+  const nameStart = 30;
+  const contentStart = nameStart + nameLength + extraLength;
+
+  return {
+    name: new TextDecoder().decode(archive.slice(nameStart, contentStart)),
+    content: inflateRawSync(archive.slice(contentStart, contentStart + compressedSize)).toString(),
+  };
+}
+
+describe("createZip", () => {
+  it("creates a deterministic ZIP with readable source files", () => {
+    const files = [
+      { name: "gradient/index.tsx", content: "export const Example = () => null;\n" },
+      { name: "gradient/shader.wgsl", content: "@fragment fn main() {}\n" },
+    ] as const;
+    const first = createZip(files);
+    const second = createZip(files);
+
+    expect(first).toEqual(second);
+    expect(readFirstEntry(first)).toEqual({
+      name: "gradient/index.tsx",
+      content: files[0].content,
+    });
+    expect(new DataView(first.buffer).getUint32(first.byteLength - 22, true)).toBe(0x06054b50);
+  });
+
+  it("rejects paths that could escape the archive root", () => {
+    expect(() => createZip([{ name: "../secret", content: "nope" }])).toThrow(
+      "Unsafe ZIP entry name",
+    );
+  });
+});

--- a/apps/docs/lib/zip.ts
+++ b/apps/docs/lib/zip.ts
@@ -1,0 +1,126 @@
+import { deflateRawSync } from "node:zlib";
+
+export interface ZipFile {
+  readonly name: string;
+  readonly content: string | Uint8Array;
+}
+
+const encoder = new TextEncoder();
+const UTF8_FLAG = 0x0800;
+const DEFLATE_METHOD = 8;
+const DOS_DATE_1980_01_01 = 0x0021;
+
+const crcTable = Array.from({ length: 256 }, (_, initial) => {
+  let value = initial;
+  for (let bit = 0; bit < 8; bit += 1) {
+    value = (value & 1) === 1 ? 0xedb88320 ^ (value >>> 1) : value >>> 1;
+  }
+  return value >>> 0;
+});
+
+function crc32(bytes: Uint8Array): number {
+  let crc = 0xffffffff;
+  for (const byte of bytes) {
+    crc = crcTable[(crc ^ byte) & 0xff] ^ (crc >>> 8);
+  }
+  return (crc ^ 0xffffffff) >>> 0;
+}
+
+function assertSafeName(name: string): void {
+  const segments = name.split("/");
+  if (
+    name.length === 0 ||
+    name.startsWith("/") ||
+    name.includes("\\") ||
+    segments.some((segment) => segment === "" || segment === "." || segment === "..")
+  ) {
+    throw new Error(`Unsafe ZIP entry name: ${name}`);
+  }
+}
+
+function concatenate(chunks: readonly Uint8Array[], length: number): Uint8Array<ArrayBuffer> {
+  const output = new Uint8Array(length);
+  let offset = 0;
+  for (const chunk of chunks) {
+    output.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return output;
+}
+
+export function createZip(files: readonly ZipFile[]): Uint8Array<ArrayBuffer> {
+  if (files.length > 0xffff) throw new Error("ZIP contains too many files");
+
+  const localChunks: Uint8Array[] = [];
+  const centralChunks: Uint8Array[] = [];
+  let localLength = 0;
+  let centralLength = 0;
+
+  for (const file of files) {
+    assertSafeName(file.name);
+    const name = encoder.encode(file.name);
+    const content = typeof file.content === "string" ? encoder.encode(file.content) : file.content;
+    const compressed = deflateRawSync(content);
+    const checksum = crc32(content);
+
+    if (name.byteLength > 0xffff) throw new Error(`ZIP entry name is too long: ${file.name}`);
+    if (content.byteLength > 0xffffffff || compressed.byteLength > 0xffffffff) {
+      throw new Error(`ZIP entry is too large: ${file.name}`);
+    }
+
+    const localHeader = new Uint8Array(30);
+    const local = new DataView(localHeader.buffer);
+    local.setUint32(0, 0x04034b50, true);
+    local.setUint16(4, 20, true);
+    local.setUint16(6, UTF8_FLAG, true);
+    local.setUint16(8, DEFLATE_METHOD, true);
+    local.setUint16(10, 0, true);
+    local.setUint16(12, DOS_DATE_1980_01_01, true);
+    local.setUint32(14, checksum, true);
+    local.setUint32(18, compressed.byteLength, true);
+    local.setUint32(22, content.byteLength, true);
+    local.setUint16(26, name.byteLength, true);
+    local.setUint16(28, 0, true);
+    localChunks.push(localHeader, name, compressed);
+
+    const centralHeader = new Uint8Array(46);
+    const central = new DataView(centralHeader.buffer);
+    central.setUint32(0, 0x02014b50, true);
+    central.setUint16(4, 20, true);
+    central.setUint16(6, 20, true);
+    central.setUint16(8, UTF8_FLAG, true);
+    central.setUint16(10, DEFLATE_METHOD, true);
+    central.setUint16(12, 0, true);
+    central.setUint16(14, DOS_DATE_1980_01_01, true);
+    central.setUint32(16, checksum, true);
+    central.setUint32(20, compressed.byteLength, true);
+    central.setUint32(24, content.byteLength, true);
+    central.setUint16(28, name.byteLength, true);
+    central.setUint16(30, 0, true);
+    central.setUint16(32, 0, true);
+    central.setUint16(34, 0, true);
+    central.setUint16(36, 0, true);
+    central.setUint32(38, 0, true);
+    central.setUint32(42, localLength, true);
+    centralChunks.push(centralHeader, name);
+
+    localLength += localHeader.byteLength + name.byteLength + compressed.byteLength;
+    centralLength += centralHeader.byteLength + name.byteLength;
+  }
+
+  const end = new Uint8Array(22);
+  const endView = new DataView(end.buffer);
+  endView.setUint32(0, 0x06054b50, true);
+  endView.setUint16(4, 0, true);
+  endView.setUint16(6, 0, true);
+  endView.setUint16(8, files.length, true);
+  endView.setUint16(10, files.length, true);
+  endView.setUint32(12, centralLength, true);
+  endView.setUint32(16, localLength, true);
+  endView.setUint16(20, 0, true);
+
+  return concatenate(
+    [...localChunks, ...centralChunks, end],
+    localLength + centralLength + end.byteLength,
+  );
+}


### PR DESCRIPTION
Adds a Geistdocs-style split actions menu beside example titles for copying the pull prompt or aggregated source Markdown. Exposes every example as a v0-compatible shadcn registry item and adds deterministic ZIP downloads, including agent-routing allowlisting. Verified with 27 focused tests, a production docs build, and live HTTP checks for the rendered actions, registry JSON, download headers, and ZIP contents.