### PR TITLE
fix(wgsl): report compute and non-ASCII entry points from compile()

### DIFF
--- a/.changeset/wgsl-compile-entry-points.md
+++ b/.changeset/wgsl-compile-entry-points.md
@@ -1,0 +1,9 @@
+---
+"@vgpu/wgsl": patch
+---
+
+`compile()` now reports the entry points it was previously missing or mangling in runtime WGSL strings. The extractor required the stage attribute to sit directly before `fn`, but WGSL requires `@workgroup_size` on every compute entry point, so that attribute always sits in between and no compute entry point was ever reported: `compile("@compute @workgroup_size(1) fn main() {}").entryPoints` returned `[]`.
+
+Entry point names are also no longer truncated at the first non-ASCII character (`maín` was reported as `"ma"`, `Ωmain` was dropped), and `@vertex` / `@fragment` / `@compute` functions written inside line or block comments are no longer reported as real entry points.
+
+`compile()` remains a byte-for-byte passthrough; the scanner is still not pulled into the browser-facing `@vgpu/wgsl` entry.

--- a/packages/wgsl/src/compile.ts
+++ b/packages/wgsl/src/compile.ts
@@ -33,15 +33,25 @@ function cacheKey(wgsl: string): Record<string, string> {
   return { default: `vgpu-wgsl-1:${(hash >>> 0).toString(16).padStart(8, "0")}` };
 }
 
+// Scanned with a regex rather than the scanner on purpose: `compile()` is the browser-facing
+// entry, and reflecting here pulls the scanner into it (688 B -> 4062 B gzip against a 1024 B
+// budget). The stage attribute is not required to sit next to `fn` — `@workgroup_size` always
+// separates them on compute entries — so anything between the two is skipped. `;{}` are excluded
+// from that gap because none of them can appear inside an attribute list, which keeps the match
+// from running past its own function into the next declaration.
 function entryPoints(wgsl: string): string[] {
   const names: string[] = [];
-  const pattern = /@(vertex|fragment|compute)\s+fn\s+([A-Za-z_][A-Za-z0-9_]*)/g;
-  for (const match of wgsl.matchAll(pattern)) names.push(match[2]!);
+  const pattern = /@(?:vertex|fragment|compute)[^;{}]*?\bfn\s+([\p{XID_Start}_]\p{XID_Continue}*)/gu;
+  for (const match of stripComments(wgsl).matchAll(pattern)) names.push(match[1]!);
   return names;
 }
 
+function stripComments(wgsl: string): string {
+  return wgsl.replace(/\/\*[\s\S]*?\*\//g, "").replace(/\/\/.*$/gm, "");
+}
+
 function hasTopLevelImport(wgsl: string): boolean {
-  const stripped = wgsl.replace(/\/\*[\s\S]*?\*\//g, "").replace(/\/\/.*$/gm, "").trimStart();
+  const stripped = stripComments(wgsl).trimStart();
   return stripped.startsWith("import ") || stripped.startsWith("import{");
 }
 

--- a/packages/wgsl/tests/passthrough.test.ts
+++ b/packages/wgsl/tests/passthrough.test.ts
@@ -12,3 +12,32 @@ test("compile rejects runtime imports", () => {
   expect(act).toThrow(/Runtime WGSL/);
   expect(act).toThrow(expect.objectContaining({ code: "VGPU-WGSL-RUNTIME-IMPORT" }));
 });
+
+test("compile reports compute entry points behind their required attributes", () => {
+  expect(compile("@compute @workgroup_size(1) fn main() {}").entryPoints).toEqual(["main"]);
+  expect(compile("@compute\n@workgroup_size(8, 8)\nfn cs() {}").entryPoints).toEqual(["cs"]);
+  expect(compile("@workgroup_size(1) @compute fn cs() {}").entryPoints).toEqual(["cs"]);
+  expect(compile("@compute @workgroup_size(WG * ((N + 1))) fn cs() {}").entryPoints).toEqual(["cs"]);
+});
+
+test("compile does not run an entry point match into the next declaration", () => {
+  expect(compile("@compute\nstruct S { x: f32 };\n@fragment fn fs() {}").entryPoints).toEqual(["fs"]);
+  expect(compile("@compute @workgroup_size(1)").entryPoints).toEqual([]);
+});
+
+test("compile reports every stage of a multi-entry shader in source order", () => {
+  const source = "@compute @workgroup_size(64) fn simulate() {}\n@vertex fn vs() -> @builtin(position) vec4f { return vec4f(0); }\n@fragment fn fs() -> @location(0) vec4f { return vec4f(1); }";
+
+  expect(compile(source).entryPoints).toEqual(["simulate", "vs", "fs"]);
+});
+
+test("compile does not truncate non-ASCII entry point names", () => {
+  expect(compile("@fragment fn maín() -> @location(0) vec4f { return vec4f(1); }").entryPoints).toEqual(["maín"]);
+  expect(compile("@fragment fn Ωmain() -> @location(0) vec4f { return vec4f(1); }").entryPoints).toEqual(["Ωmain"]);
+});
+
+test("compile ignores entry points inside comments", () => {
+  const source = "// @vertex fn lineGhost() {}\n/* @compute @workgroup_size(1) fn blockGhost() {} */\n@fragment fn fs() -> @location(0) vec4f { return vec4f(1); }";
+
+  expect(compile(source).entryPoints).toEqual(["fs"]);
+});


### PR DESCRIPTION
Closes #296.

## Diagnosis

`compile()` — the runtime pass-through for WGSL strings — extracts entry points with a regex over the raw source:

```ts
/@(vertex|fragment|compute)\s+fn\s+([A-Za-z_][A-Za-z0-9_]*)/g
```

That pattern requires the stage attribute to sit directly before `fn`. WGSL requires `@workgroup_size` on every compute entry point, so on a compute entry the two are *never* adjacent, and **no compute entry point has ever been reported**:

```ts
compile("@compute @workgroup_size(1) fn main() {}").entryPoints  // []
```

Two more defects come from the same line. The name class is ASCII-only, so a non-ASCII identifier is truncated at the first non-ASCII character rather than reported or skipped — `maín` is reported as `"ma"`, a different, plausible-looking name — and `Ωmain` is dropped. And because the regex runs over raw text, a stage function inside a comment is reported as a real entry point.

This reaches users through `Device.createShader(string)`, whose `Shader.entryPoints` is this array (`packages/core/src/device.ts:66`, `packages/core/src/shader.ts:23`).

The existing coverage misses it because every other entry point test goes through `reflectSource`, which is correct; `passthrough.test.ts` used the exact broken form as its fixture but only asserted `wgsl` and `diagnostics`, never `entryPoints`.

## Fix

Match the gap between the stage attribute and `fn` rather than assuming they are adjacent, and take the name with the `XID_Start`/`XID_Continue` classes WGSL itself defines identifiers with:

```ts
/@(?:vertex|fragment|compute)[^;{}]*?\bfn\s+([\p{XID_Start}_]\p{XID_Continue}*)/gu
```

`;`, `{` and `}` cannot occur inside an attribute list, so excluding them bounds the gap to a single declaration and the match cannot run past its own function into the next one. Parentheses are not special to the pattern, so attribute arguments nest to any depth (`@workgroup_size(WG * ((N + 1)))`) without a balanced-paren match. Comments are stripped first, reusing the strip `hasTopLevelImport` already performed.

`compile()` stays a byte-for-byte passthrough. I deliberately did **not** route it through `reflectSource`: per the note in `loader-reserved-identifiers.test.ts`, reflecting here pulls the scanner into the browser-facing `@vgpu/wgsl` entry (688 B → 4062 B gzip against a 1024 B client budget). The regex stays, correctly bounded.

## Evidence (before / after)

Against the built `@vgpu/wgsl` entry:

| source | before | after |
| --- | --- | --- |
| `@compute @workgroup_size(1) fn main() {}` | `[]` | `["main"]` |
| `@compute\n@workgroup_size(8, 8)\nfn cs() {}` | `[]` | `["cs"]` |
| `@compute @workgroup_size(WG * ((N + 1))) fn cs() {}` | `[]` | `["cs"]` |
| `@fragment fn maín() {…}` | `["ma"]` | `["maín"]` |
| `@fragment fn Ωmain() {…}` | `[]` | `["Ωmain"]` |
| `// @vertex fn ghost() {}` + a real `@fragment fn fs` | `["ghost","fs"]` | `["fs"]` |
| `@compute @workgroup_size(64) fn simulate()` + `vs` + `fs` | `["vs","fs"]` | `["simulate","vs","fs"]` |

The five new tests in `passthrough.test.ts` fail on `main` and pass here. Two of them pin the bound rather than the fix, so a later loosening of the gap is caught: a stage attribute followed by an unrelated declaration must not leak forward, and a trailing `@compute @workgroup_size(1)` with no `fn` must report nothing.

## Gates run (macOS, Node v22.14.0)

| Gate | Result |
| --- | --- |
| `pnpm typecheck` | ✅ (two clean runs) |
| `pnpm test:fast` | ✅ 771 passed / 76 skipped (two clean runs) |
| `pnpm vitest run packages/vgpu-api` | ✅ 603 passed / 45 skipped |
| `pnpm bundle-check` | ✅ `@vgpu/wgsl` 708 B gzip / 1024 B budget (was 688 B) |
| `pnpm check:skill-drift` | ✅ no drift |

## Notes

Changeset included (`patch` for `@vgpu/wgsl`) since this changes published package behavior.

Non-ASCII names are now reported intact instead of truncated, which is the passthrough-level half of #294. `compile()` still does not *validate* them the way the scanner does — that stays with #294, and closing it would subsume this path.

Unrelated to this change, but worth flagging: `pnpm build` fails with `TS5055: Cannot write file .../dist/index.d.ts because it would overwrite input file` on every second run in a warm tree. It reproduces on a clean `main` checkout with no changes applied; `rm -rf packages/*/dist` clears it.
