### PR TITLE
chore(release): prepare v0.4.0

### DIFF
--- a/packages/adapter-mock/package.json
+++ b/packages/adapter-mock/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vgpu/adapter-mock",
-  "version": "0.4.0-rc.0",
+  "version": "0.4.0",
   "description": "Mock GPU adapter for testing vgpu code without real WebGPU hardware.",
   "keywords": [
     "webgpu",

--- a/packages/adapter-node/package.json
+++ b/packages/adapter-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vgpu/adapter-node",
-  "version": "0.4.0-rc.0",
+  "version": "0.4.0",
   "description": "Node.js GPU adapter for vgpu, using Dawn-based WebGPU bindings.",
   "keywords": [
     "webgpu",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vgpu/core",
-  "version": "0.4.0-rc.0",
+  "version": "0.4.0",
   "description": "Core WebGPU runtime primitives (device, buffer, texture, shader, queue) for vgpu.",
   "keywords": [
     "webgpu",

--- a/packages/render/package.json
+++ b/packages/render/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vgpu/render",
-  "version": "0.4.0-rc.0",
+  "version": "0.4.0",
   "description": "Render pipeline + render pass abstractions for vgpu.",
   "keywords": [
     "webgpu",

--- a/packages/vgpu-api/package.json
+++ b/packages/vgpu-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vgpu",
-  "version": "0.4.0-rc.0",
+  "version": "0.4.0",
   "description": "Public VGPU API entrypoint scaffold for browser, Node, mock, scene, and client typing surfaces.",
   "keywords": [
     "webgpu",

--- a/packages/wgsl-std/package.json
+++ b/packages/wgsl-std/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vgpu/wgsl-std",
-  "version": "0.4.0-rc.0",
+  "version": "0.4.0",
   "description": "Pure WGSL utility snippets for vgpu shaders.",
   "keywords": [
     "webgpu",

--- a/packages/wgsl/package.json
+++ b/packages/wgsl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vgpu/wgsl",
-  "version": "0.4.0-rc.0",
+  "version": "0.4.0",
   "description": "WGSL shader compilation, runtime resolution, and webpack/vite loaders for vgpu.",
   "keywords": [
     "webgpu",

--- a/skills/vgpu/SKILL.md
+++ b/skills/vgpu/SKILL.md
@@ -5,9 +5,9 @@ description: >-
   vgpu/mock, vgpu/scene, vgpu/client, and vgpu/three. Use @vgpu/render/inspect, /utils, /edit,
   and /perf only as slim tooling subpaths. Bundles task guides and the API
   reference; load one doc at a time.
-vgpuVersion: 0.4.0-rc.0
-gitSha: 94517d52c4d873cb6a99f5d0cbf7263cd56fc8d2
-generatedAt: 2026-09-03T15:49:20.867Z
+vgpuVersion: 0.4.0
+gitSha: 5020b9b64246320c67cd8ffd9c678944e969c254
+generatedAt: 2026-09-03T16:36:02.432Z
 ---
 
 # vgpu


### PR DESCRIPTION
## Summary

- promote the seven public packages in the fixed release group from `0.4.0-rc.0` to `0.4.0`
- regenerate the vgpu skill stamp for the stable package version
- retain the existing `0.4.0` changelog entries produced for the RC

## Validation

- `pnpm build`
- `pnpm -w typecheck`
- `pnpm bundle-check`
- `pnpm check:skill-drift`
- 42 focused tests covering atomic frames, WGSL function exports, `vgpu/three`, types, and packed-package acceptance
- published `0.4.0-rc.0` smoke-tested in a disposable Vite app with real WebGPU pixel readback through both raw-source and minified-loader paths

## Local full-suite note

The macOS full-suite run completed with 2,618 passing tests and 13 platform-specific failures in the docs local filesystem publisher/routes and Linux glibc detection tests. The base commit’s Linux CI is green; none of these version-only changes touch those areas.