### PR TITLE
fix(release): accept canonical policy check URLs

### DIFF
--- a/scripts/check-production-authorization.mjs
+++ b/scripts/check-production-authorization.mjs
@@ -15,7 +15,7 @@ import {
   inspectExistingProductionAuthorization,
   latestCommitStatus,
   latestMainPolicyCheck,
-  mainPolicyRunIdFromDetailsUrl,
+  mainPolicyWorkflowRunId,
   normalizeGraphqlPullRequest,
   parseMainPolicyCheckExternalId,
   promotionVersionFromBranch,
@@ -596,7 +596,7 @@ async function main() {
   );
   const mainPolicyPolicySha = mainPolicyBinding?.policySha ?? null;
   const mainPolicyRunId = latestMainPolicy
-    ? mainPolicyRunIdFromDetailsUrl(latestMainPolicy.details_url, repository)
+    ? mainPolicyWorkflowRunId(latestMainPolicy, repository)
     : null;
   const mainPolicyWorkflowRun = mainPolicyRunId
     ? await github.get(

--- a/scripts/lib/production-authorization.mjs
+++ b/scripts/lib/production-authorization.mjs
@@ -306,6 +306,35 @@ export function mainPolicyRunIdFromDetailsUrl(detailsUrl, repository) {
   }
 }
 
+export function mainPolicyWorkflowRunId(checkRun, repository) {
+  const actionsRunId = mainPolicyRunIdFromDetailsUrl(
+    checkRun?.details_url,
+    repository
+  );
+  if (actionsRunId !== null) return actionsRunId;
+
+  const checkRunId = numericId(checkRun?.id);
+  const binding = parseMainPolicyCheckExternalId(checkRun?.external_id);
+  if (checkRunId === null || binding === null) return null;
+
+  try {
+    const url = new URL(checkRun.details_url);
+    const [owner, name] = repository.split("/");
+    const expectedPath = `/${owner}/${name}/runs/${checkRunId}`;
+    if (
+      url.origin !== "https://github.com" ||
+      url.pathname.replace(/\/$/, "") !== expectedPath ||
+      url.search !== "" ||
+      url.hash !== ""
+    ) {
+      return null;
+    }
+    return binding.runId;
+  } catch {
+    return null;
+  }
+}
+
 export function mainPolicyRunName(pullRequest) {
   return `Main policy PR #${pullRequest.number}: ${pullRequest.base.sha} -> ${pullRequest.head.sha}`;
 }
@@ -663,10 +692,10 @@ function validateMainPolicyCheck({
       latest.head_sha ?? "an unknown SHA"
     }, expected PR head ${pullRequest.head.sha}.`
   );
-  const runId = mainPolicyRunIdFromDetailsUrl(latest.details_url, repository);
+  const runId = mainPolicyWorkflowRunId(latest, repository);
   requireCondition(
     runId !== null,
-    `'${MAIN_POLICY_CHECK}' must link to an exact GitHub Actions run URL in ${repository}.`
+    `'${MAIN_POLICY_CHECK}' must link to its exact GitHub Actions workflow or check-run URL in ${repository}.`
   );
   requireCondition(
     String(mainPolicyWorkflowRun?.id) === runId,

--- a/scripts/production-authorization.test.ts
+++ b/scripts/production-authorization.test.ts
@@ -23,6 +23,7 @@ import {
   mainPolicyCheckExternalId,
   mainPolicyRunIdFromDetailsUrl,
   mainPolicyRunName,
+  mainPolicyWorkflowRunId,
   normalizeGraphqlPullRequest,
   parseMainPolicyCheckExternalId,
   releaseRunIdFromStatusTarget,
@@ -672,6 +673,16 @@ describe("web-only authorization", () => {
   });
 
   it("binds main-policy to its canonical workflow run and PR head", () => {
+    expect(
+      evaluateSite({
+        checkRuns: [
+          {
+            ...successfulMainPolicy,
+            details_url: `https://github.com/${repository}/runs/${successfulMainPolicy.id}`,
+          },
+        ],
+      })
+    ).toMatchObject({ kind: "site" });
     expectPolicyError(
       () =>
         evaluateSite({
@@ -683,7 +694,7 @@ describe("web-only authorization", () => {
             },
           ],
         }),
-      "exact GitHub Actions run URL"
+      "exact GitHub Actions workflow or check-run URL"
     );
     expectPolicyError(
       () =>
@@ -1128,6 +1139,37 @@ describe("status and release helpers", () => {
     expect(
       mainPolicyRunIdFromDetailsUrl(
         `https://github.com/${repository}/actions/runs/200/job/300`,
+        repository
+      )
+    ).toBeNull();
+  });
+
+  it("resolves GitHub's canonical check-run URL through the bound workflow metadata", () => {
+    expect(
+      mainPolicyWorkflowRunId(
+        {
+          ...successfulMainPolicy,
+          details_url: `https://github.com/${repository}/runs/${successfulMainPolicy.id}`,
+        },
+        repository
+      )
+    ).toBe("200");
+    expect(
+      mainPolicyWorkflowRunId(
+        {
+          ...successfulMainPolicy,
+          details_url: `https://github.com/${repository}/runs/999`,
+        },
+        repository
+      )
+    ).toBeNull();
+    expect(
+      mainPolicyWorkflowRunId(
+        {
+          ...successfulMainPolicy,
+          details_url: `https://github.com/${repository}/runs/${successfulMainPolicy.id}`,
+          external_id: "main-policy:invalid",
+        },
         repository
       )
     ).toBeNull();


### PR DESCRIPTION
## Summary

- accept the canonical check-run URL GitHub records for the trusted `main-policy` check
- recover the exact workflow-run ID from the check's bound `external_id` metadata
- continue requiring the URL to match the exact repository and check-run ID
- add helper and end-to-end policy coverage for the observed URL shape

## Why

The first canary → main promotion reached production authorization, but GitHub rewrote the `details_url` supplied when creating the custom check from `/actions/runs/<workflow-run-id>` to `/runs/<check-run-id>`. The gate rejected that canonical URL before it could validate the already-bound workflow metadata.

This is control-plane-only; it does not change or publish package code.

## Verification

- `pnpm exec vitest run scripts/production-authorization.test.ts scripts/main-pr-policy.test.ts`
- `pnpm -w typecheck`
- `git diff --check`