### PR TITLE
fix(docs): remove prism reflection seams

### DIFF
--- a/apps/docs/app/[lang]/(home)/components/prism-background/pipelines/shared/glass/fixtures/ray-footprint-probe.wgsl
+++ b/apps/docs/app/[lang]/(home)/components/prism-background/pipelines/shared/glass/fixtures/ray-footprint-probe.wgsl
@@ -1,0 +1,22 @@
+import { RayDirection, reflectRay, refractRay } from "../ray-footprint.wgsl";
+struct Inputs {
+  incident: vec3f,
+  incidentDx: vec3f,
+  incidentDy: vec3f,
+  normal: vec3f,
+  normalDx: vec3f,
+  normalDy: vec3f,
+  eta: f32,
+}
+@group(0) @binding(0) var<uniform> inputs: Inputs;
+@fragment fn fs_main(@builtin(position) p: vec4f) -> @location(0) vec4f {
+  let ray = RayDirection(inputs.incident, inputs.incidentDx, inputs.incidentDy);
+  let normal = RayDirection(inputs.normal, inputs.normalDx, inputs.normalDy);
+  let reflected = reflectRay(ray, normal);
+  let transmitted = refractRay(ray, normal, inputs.eta);
+  let fields = array<vec3f, 6>(
+    reflected.value, reflected.dx, reflected.dy,
+    transmitted.value, transmitted.dx, transmitted.dy,
+  );
+  return vec4f(fields[u32(p.x)], 1.0);
+}

--- a/apps/docs/app/[lang]/(home)/components/prism-background/pipelines/shared/glass/glass-back.wgsl
+++ b/apps/docs/app/[lang]/(home)/components/prism-background/pipelines/shared/glass/glass-back.wgsl
@@ -9,8 +9,9 @@ import {
   Glass,
   dielectricFresnel,
   glassEnvironment,
-  glassEnvironmentLod,
 } from "./glass-common.wgsl";
+import { env_lod } from "../../../environment/environment-map-common.wgsl";
+import { RayDirection, reflectRay, refractRay } from "./ray-footprint.wgsl";
 
 @group(0) @binding(0) var<uniform> params: Glass;
 @group(0) @binding(1) var studioEnvironment: texture_2d<f32>;
@@ -26,28 +27,31 @@ struct VertexOut {
 struct SurfaceHit {
   distance: f32,
   outwardNormal: vec3f,
+  planeIndex: u32,
 };
 
 struct ExitPath {
   position: vec3f,
-  direction: vec3f,
-  incidentDirection: vec3f,
-  inwardNormal: vec3f,
+  direction: RayDirection,
+  incidentDirection: RayDirection,
+  inwardNormal: RayDirection,
   escaped: u32,
+  planeIndex: u32,
 };
 
 const NO_HIT: f32 = 100000.0;
-const SURFACE_EPSILON: f32 = 0.0002;
+// The rasterized bevel need not lie on any of the five ideal planes.
+const NO_PLANE: u32 = 5u;
 const MAX_INTERNAL_BOUNCES: u32 = 3u;
 
-fn sampleEnvironment(direction: vec3f) -> vec3f {
+fn sampleEnvironment(direction: RayDirection) -> vec3f {
   return glassEnvironment(
-    direction,
+    direction.value,
     params,
     studioEnvironment,
     debugEnvironment,
     environmentSampler,
-    glassEnvironmentLod(direction, params),
+    env_lod(0.0, direction.dx, direction.dy, params.environmentTexelAngle),
   );
 }
 
@@ -60,36 +64,48 @@ fn vs_main(@location(0) position: vec3f, @location(1) normal: vec3f) -> VertexOu
   return out;
 }
 
-fn planeHitDistance(origin: vec3f, direction: vec3f, plane: vec4f) -> f32 {
+fn planeHitDistance(
+  origin: vec3f,
+  direction: vec3f,
+  plane: vec4f,
+  planeIndex: u32,
+  departedPlane: u32,
+) -> f32 {
+  if (planeIndex == departedPlane) { return NO_HIT; }
   let denominator = dot(plane.xyz, direction);
   if (denominator <= 0.00001) { return NO_HIT; }
   let distance = (plane.w - dot(plane.xyz, origin)) / denominator;
-  return select(NO_HIT, distance, distance > SURFACE_EPSILON);
+  return select(NO_HIT, distance, distance >= 0.0);
 }
 
 /** Nearest ideal prism plane reached by a ray already inside the glass. */
-fn nextSurface(origin: vec3f, direction: vec3f) -> SurfaceHit {
+fn nextSurface(origin: vec3f, direction: vec3f, departedPlane: u32) -> SurfaceHit {
+  // Exclude the interface we just left by identity. Nudging the origin or
+  // rejecting short positive distances can skip a different face near a corner.
   // Keep the old front -> back -> side comparison order for exact tie parity.
   let frontPlane = params.prismPlanes[3];
   let backPlane = params.prismPlanes[4];
-  var nearest = planeHitDistance(origin, direction, frontPlane);
+  var nearest = planeHitDistance(origin, direction, frontPlane, 3u, departedPlane);
+  var planeIndex = 3u;
   var normal = frontPlane.xyz;
 
-  let backDistance = planeHitDistance(origin, direction, backPlane);
+  let backDistance = planeHitDistance(origin, direction, backPlane, 4u, departedPlane);
   if (backDistance < nearest) {
     nearest = backDistance;
     normal = backPlane.xyz;
+    planeIndex = 4u;
   }
 
   for (var index = 0u; index < 3u; index = index + 1u) {
     let plane = params.prismPlanes[index];
-    let distance = planeHitDistance(origin, direction, plane);
+    let distance = planeHitDistance(origin, direction, plane, index, departedPlane);
     if (distance < nearest) {
       nearest = distance;
       normal = plane.xyz;
+      planeIndex = index;
     }
   }
-  return SurfaceHit(nearest, normal);
+  return SurfaceHit(nearest, normal, planeIndex);
 }
 
 /**
@@ -101,27 +117,31 @@ fn nextSurface(origin: vec3f, direction: vec3f) -> SurfaceHit {
  */
 fn traceExit(
   firstPosition: vec3f,
-  firstDirection: vec3f,
-  firstInwardNormal: vec3f,
+  firstDirection: RayDirection,
+  firstInwardNormal: RayDirection,
+  firstPlane: u32,
 ) -> ExitPath {
   var position = firstPosition;
   var direction = firstDirection;
   var inwardNormal = firstInwardNormal;
+  var planeIndex = firstPlane;
 
   for (var bounce = 0u; bounce <= MAX_INTERNAL_BOUNCES; bounce = bounce + 1u) {
-    let transmitted = refract(direction, inwardNormal, params.ior);
-    if (length(transmitted) > 0.00001) {
-      return ExitPath(position, normalize(transmitted), direction, inwardNormal, 1u);
+    let transmitted = refractRay(direction, inwardNormal, params.ior);
+    if (length(transmitted.value) > 0.00001) {
+      return ExitPath(position, transmitted, direction, inwardNormal, 1u, planeIndex);
     }
 
-    direction = normalize(reflect(direction, inwardNormal));
-    let hit = nextSurface(position + direction * SURFACE_EPSILON, direction);
+    direction = reflectRay(direction, inwardNormal);
+    let hit = nextSurface(position, direction.value, planeIndex);
     if (hit.distance >= 10.0) { break; }
-    position = position + direction * (hit.distance + SURFACE_EPSILON);
-    inwardNormal = -hit.outwardNormal;
+    position = position + direction.value * hit.distance;
+    planeIndex = hit.planeIndex;
+    // Subsequent interfaces are ideal planes with constant local normals.
+    inwardNormal = RayDirection(-hit.outwardNormal, vec3f(0.0), vec3f(0.0));
   }
 
-  return ExitPath(position, direction, direction, inwardNormal, 0u);
+  return ExitPath(position, direction, direction, inwardNormal, 0u, planeIndex);
 }
 
 /**
@@ -131,17 +151,22 @@ fn traceExit(
  */
 fn traceReflectedEnvironmentExit(
   surfacePosition: vec3f,
-  incidentDirection: vec3f,
-  inwardNormal: vec3f,
+  incidentDirection: RayDirection,
+  inwardNormal: RayDirection,
+  departedPlane: u32,
 ) -> ExitPath {
-  let direction = normalize(reflect(incidentDirection, inwardNormal));
-  let shiftedPosition = surfacePosition + direction * SURFACE_EPSILON;
-  let hit = nextSurface(shiftedPosition, direction);
+  let direction = reflectRay(incidentDirection, inwardNormal);
+  let hit = nextSurface(surfacePosition, direction.value, departedPlane);
   if (hit.distance >= 10.0) {
-    return ExitPath(surfacePosition, direction, direction, inwardNormal, 0u);
+    return ExitPath(surfacePosition, direction, direction, inwardNormal, 0u, departedPlane);
   }
-  let position = shiftedPosition + direction * hit.distance;
-  return traceExit(position, direction, -hit.outwardNormal);
+  let position = surfacePosition + direction.value * hit.distance;
+  return traceExit(
+    position,
+    direction,
+    RayDirection(-hit.outwardNormal, vec3f(0.0), vec3f(0.0)),
+    hit.planeIndex,
+  );
 }
 
 @fragment
@@ -150,15 +175,24 @@ fn fs_main(in: VertexOut) -> @location(0) vec4f {
   let incident = -view;
   // Back-facing triangles expose their inward normal to the camera ray.
   let inwardNormal = -normalize(in.worldNormal);
-  let exit = traceExit(in.worldPosition, incident, inwardNormal);
+  // Capture derivatives before tracing. Adjacent pixels can hit different faces
+  // or take different TIR paths; differentiating their final directions would
+  // mistake that jump for a broad footprint and paint blurred mip seams.
+  let exit = traceExit(
+    in.worldPosition,
+    RayDirection(incident, dpdx(incident), dpdy(incident)),
+    RayDirection(inwardNormal, dpdx(inwardNormal), dpdy(inwardNormal)),
+    NO_PLANE,
+  );
 
   let reflectedExit = traceReflectedEnvironmentExit(
     exit.position,
     exit.incidentDirection,
     exit.inwardNormal,
+    exit.planeIndex,
   );
   let reflectedFacing = clamp(
-    -dot(reflectedExit.incidentDirection, reflectedExit.inwardNormal),
+    -dot(reflectedExit.incidentDirection.value, reflectedExit.inwardNormal.value),
     0.0,
     1.0,
   );
@@ -170,7 +204,7 @@ fn fs_main(in: VertexOut) -> @location(0) vec4f {
   let reflectedEnvironment = sampleEnvironment(reflectedExit.direction)
     * params.reflectionStrength
     * reflectedExitTransmission;
-  let facing = clamp(-dot(exit.incidentDirection, exit.inwardNormal), 0.0, 1.0);
+  let facing = clamp(-dot(exit.incidentDirection.value, exit.inwardNormal.value), 0.0, 1.0);
   let fresnel = dielectricFresnel(params.fresnelF0, facing);
   let reflectionWeight = select(
     1.0,

--- a/apps/docs/app/[lang]/(home)/components/prism-background/pipelines/shared/glass/ray-footprint.test.ts
+++ b/apps/docs/app/[lang]/(home)/components/prism-background/pipelines/shared/glass/ray-footprint.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, test } from "vitest";
+import { effect, frame, init, target } from "vgpu/node";
+
+import shader from "./fixtures/ray-footprint-probe.wgsl";
+
+type Vec3 = [number, number, number];
+
+
+describe.skipIf(process.env.VGPU_DOCKER_TEST !== "1")("glass ray footprint GPU", () => {
+  test("matches finite differences through reflection, refraction, bevel normals and TIR", async () => {
+    const gpu = await init();
+    try {
+      const output = target(gpu, { size: [6, 1], format: "rgba32float" });
+      const probe = effect(gpu, shader);
+      await probe.compile(output);
+      for (const eta of [1 / 1.645, 1.645]) {
+        // Include normal incidence, near-critical transmission and TIR.
+        for (const angle of [0, 0.35, Math.asin(1 / 1.645) - 0.01, 0.9]) {
+          for (const bevel of [false, true]) {
+            const incident: Vec3 = [Math.sin(angle), -Math.cos(angle), 0];
+            const normal: Vec3 = [0, 1, 0];
+            const incidentDx: Vec3 = [Math.cos(angle) * 0.002, Math.sin(angle) * 0.002, 0];
+            const incidentDy: Vec3 = [0, 0, 0.003];
+            const normalDx: Vec3 = bevel ? [0.004, 0, 0] : [0, 0, 0];
+            const normalDy: Vec3 = bevel ? [0, 0, 0.005] : [0, 0, 0];
+            probe.set({ inputs: { incident, incidentDx, incidentDy, normal, normalDx, normalDy, eta } });
+            frame(gpu, (current) => current.pass({ target: output }, (pass) => pass.draw(probe)));
+            const pixels = await output.readFloats();
+            for (const [operation, offset] of [[reflect, 0], [refract, 3]] as const) {
+              const reference = operation(incident, normal, eta);
+              const derivatives = [[incidentDx, normalDx], [incidentDy, normalDy]].map(([dd, dn]) => {
+                const step = 0.001;
+                const plus = operation(perturb(incident, dd!, step), perturb(normal, dn!, step), eta);
+                const minus = operation(perturb(incident, dd!, -step), perturb(normal, dn!, -step), eta);
+                return plus.map((value, channel) => (value - minus[channel]!) / (2 * step));
+              });
+              [reference, ...derivatives].forEach((expected, field) => {
+                expected.forEach((value, channel) => {
+                  const actual = pixels[(offset + field) * 4 + channel]!;
+                  expect(Number.isFinite(actual)).toBe(true);
+                  expect(actual, `eta=${eta}, angle=${angle}, bevel=${bevel}, field=${offset + field}`).toBeCloseTo(value, 5);
+                });
+              });
+            }
+          }
+        }
+      }
+    } finally {
+      gpu.dispose();
+    }
+  });
+});
+
+function dot(a: Vec3, b: Vec3): number {
+  return a.reduce((sum, value, channel) => sum + value * b[channel]!, 0);
+}
+
+function normalize(value: Vec3): Vec3 {
+  const length = Math.hypot(...value);
+  return value.map((component) => component / length) as Vec3;
+}
+
+function perturb(value: Vec3, delta: Vec3, step: number): Vec3 {
+  return normalize(value.map((component, channel) => component + delta[channel]! * step) as Vec3);
+}
+
+function reflect(incident: Vec3, normal: Vec3, _eta: number): Vec3 {
+  const facing = dot(incident, normal);
+  return normalize(incident.map((value, channel) => value - 2 * facing * normal[channel]!) as Vec3);
+}
+
+function refract(incident: Vec3, normal: Vec3, eta: number): Vec3 {
+  const facing = dot(incident, normal);
+  const k = 1 - eta * eta * (1 - facing * facing);
+  if (k < 0) return [0, 0, 0];
+  return normalize(incident.map((value, channel) => eta * value - (eta * facing + Math.sqrt(k)) * normal[channel]!) as Vec3);
+}

--- a/apps/docs/app/[lang]/(home)/components/prism-background/pipelines/shared/glass/ray-footprint.wgsl
+++ b/apps/docs/app/[lang]/(home)/components/prism-background/pipelines/shared/glass/ray-footprint.wgsl
@@ -1,0 +1,49 @@
+/** A unit direction and its local change over one screen pixel. */
+export struct RayDirection {
+  value: vec3f,
+  dx: vec3f,
+  dy: vec3f,
+}
+
+fn normalizedRay(value: vec3f, dx: vec3f, dy: vec3f) -> RayDirection {
+  let magnitude = length(value);
+  let unit = value / magnitude;
+  return RayDirection(
+    unit,
+    (dx - unit * dot(unit, dx)) / magnitude,
+    (dy - unit * dot(unit, dy)) / magnitude,
+  );
+}
+
+/** Differentiate reflection along this ray's interface, never across hit faces. */
+export fn reflectRay(ray: RayDirection, normal: RayDirection) -> RayDirection {
+  let facing = dot(ray.value, normal.value);
+  let facingDx = dot(ray.dx, normal.value) + dot(ray.value, normal.dx);
+  let facingDy = dot(ray.dy, normal.value) + dot(ray.value, normal.dy);
+  return normalizedRay(
+    reflect(ray.value, normal.value),
+    ray.dx - 2.0 * (facingDx * normal.value + facing * normal.dx),
+    ray.dy - 2.0 * (facingDy * normal.value + facing * normal.dy),
+  );
+}
+
+/** Snell's law and its differential; a zero value marks total internal reflection. */
+export fn refractRay(ray: RayDirection, normal: RayDirection, eta: f32) -> RayDirection {
+  let facing = dot(ray.value, normal.value);
+  let k = 1.0 - eta * eta * (1.0 - facing * facing);
+  if (k < 0.0) {
+    return RayDirection(vec3f(0.0), vec3f(0.0), vec3f(0.0));
+  }
+  let root = sqrt(k);
+  let scale = eta * facing + root;
+  // At the critical angle the footprint tends to infinity. Bound the divisor
+  // for finite arithmetic; the environment sampler clamps the resulting LOD.
+  let slope = eta + eta * eta * facing / max(root, 0.00001);
+  let facingDx = dot(ray.dx, normal.value) + dot(ray.value, normal.dx);
+  let facingDy = dot(ray.dy, normal.value) + dot(ray.value, normal.dy);
+  return normalizedRay(
+    eta * ray.value - scale * normal.value,
+    eta * ray.dx - slope * facingDx * normal.value - scale * normal.dx,
+    eta * ray.dy - slope * facingDy * normal.value - scale * normal.dy,
+  );
+}

--- a/apps/docs/app/[lang]/(home)/components/prism-background/prism-gpu.test.ts
+++ b/apps/docs/app/[lang]/(home)/components/prism-background/prism-gpu.test.ts
@@ -60,6 +60,46 @@ const ISOLATED_GLASS: PrismControls = {
 const ISOLATED_GLASS_WALL: PrismControls = { ...ISOLATED_GLASS, view: 'wall' };
 
 describe.skipIf(gpuOnly)('prism-rainbow picture', () => {
+  test('reflected studio panels stay continuous near internal face transitions', async () => {
+    const gpu = await init();
+    try {
+      const output = target(gpu, {
+        size: [1600, 900],
+        format: 'rgba8unorm',
+        label: 'prism-reflection-continuity',
+      });
+      await renderComposite(gpu, output, { controls: ISOLATED_GLASS });
+      const pixels = await output.read();
+      const red = (x: number, y: number) => pixels[(y * 1600 + x) * 4]!;
+      // Three smooth interiors of the bottom-left studio reflection. The old
+      // ray-origin bias skipped neighboring faces near edges, leaving isolated
+      // dark pixels here even with environment mip selection corrected.
+      const patches = [
+        [538, 568, 544, 583],
+        [560, 580, 574, 589],
+        [545, 606, 568, 615],
+      ] as const;
+      for (const [x0, y0, x1, y1] of patches) {
+        let deepestDip = 0;
+        let brightness = 0;
+        for (let y = y0; y < y1; y++) {
+          for (let x = x0; x < x1; x++) {
+            brightness += red(x, y);
+            const neighbors = Math.max(
+              Math.min(red(x - 1, y), red(x + 1, y)),
+              Math.min(red(x, y - 1), red(x, y + 1)),
+            );
+            deepestDip = Math.max(deepestDip, neighbors - red(x, y));
+          }
+        }
+        expect(brightness / ((x1 - x0) * (y1 - y0))).toBeGreaterThan(110);
+        expect(deepestDip, `reflection patch at ${x0},${y0}`).toBeLessThanOrEqual(8);
+      }
+    } finally {
+      gpu.dispose();
+    }
+  });
+
   test('the rainbow lands in the prism’s shadow, and the wall stays dark', async () => {
     const gpu = await init();
     try {


### PR DESCRIPTION
The homepage prism showed dark streaks and dotted lines inside bright glass reflections. This fixes both causes in the shared back-glass shader:

- Propagate each ray's local direction footprint through reflection and refraction. Mip selection now preserves filtering without treating jumps between neighboring internal ray paths as a large sampling footprint.
- Keep intersections at the actual surface and exclude the departed plane by identity. This replaces the origin offset and minimum hit distance that could skip an adjacent face near an edge.

Adds GPU checks against finite-difference references for reflection, refraction, bevel normals, and total internal reflection, plus a render regression checking continuity in three reflected studio-panel patches.

Validation: 41 focused optics and GPU tests passed. The existing “the glass covers its own projected area, and only that” test still fails with 118 changed pixels outside its region; the same failure was reproduced on the original shader. The new continuity regression fails on the previous implementation and passes with this change. Deterministic 1600×900 GPU renders were visually compared before and after both fixes.
