### PR TITLE
cli: point the top-level help at the pre-PR checklist

### DIFF
--- a/packages/vgpu/bin/vgpu.js
+++ b/packages/vgpu/bin/vgpu.js
@@ -47,6 +47,9 @@ the same code running in the browser, headless Node, and your test suite.
   npx vgpu docs find "<topic | symbol | VGPU-error-code>"
   npx vgpu docs cat <path>
 
+## Before you ship
+  npx vgpu docs cat shipping-to-production   Pre-PR checklist: correctness gates, measure, free defaults, propose the rest
+
 ## Validate shader code
   npx vgpu check <file.wgsl>              Validate and reflect a WGSL file as JSON
   npx vgpu check <file.wgsl> --require-validation

--- a/packages/vgpu/tests/cli.test.ts
+++ b/packages/vgpu/tests/cli.test.ts
@@ -28,6 +28,9 @@ the same code running in the browser, headless Node, and your test suite.
   npx vgpu docs find "<topic | symbol | VGPU-error-code>"
   npx vgpu docs cat <path>
 
+## Before you ship
+  npx vgpu docs cat shipping-to-production   Pre-PR checklist: correctness gates, measure, free defaults, propose the rest
+
 ## Validate shader code
   npx vgpu check <file.wgsl>              Validate and reflect a WGSL file as JSON
   npx vgpu check <file.wgsl> --require-validation


### PR DESCRIPTION
## Summary

Follow-up to #405, driven by the multi-model n2-ship-hero runs.

**Finding.** With claude-sonnet-5 the getting-started / `vgpu docs` pointers from #405 work (3/3 runs opened the guide, measured, pre-warmed, proposed with numbers). gpt-5 and gemini-2.5-pro never ran a single `vgpu docs` command: they read `npx vgpu` with no arguments, ran `vgpu check` on the shaders (gpt-5 also `next build` and `doctor`), wrote a descriptive PR.md, and finished in 17-18 tool calls. Every pointer added so far sat one command deeper than those agents ever went.

**Change.** A `## Before you ship` section in the top-level `npx vgpu` help, the one surface every CLI-driven agent reads:

```
## Before you ship
  npx vgpu docs cat shipping-to-production   Pre-PR checklist: correctness gates, measure, free defaults, propose the rest
```

`packages/vgpu/tests/cli.test.ts` pins the help text and is updated to match.

## Test plan
- [x] `vitest run packages/vgpu/tests/cli.test.ts` (29 passed)
- [x] n2-ship-hero with `openai/gpt-5` against this build: **behavior flipped**. Before: 17 tool calls, zero `vgpu docs`, no measurement, no pre-warm. After: read the guide (PR.md opens with "Ran through `npx vgpu docs cat guides/shipping-to-production.docs.md` end to end"), applied `compile()` pre-warm (and caught a real `VGPU-SURFACE-NOT-IN-FRAME` while doing it), wrote a headless snapshot script, installed a browser to check the page, PR.md with measurements. It then exceeded the eval's shared 20-minute budget, so eve recorded the run as failed on timeout, not on a gate. Follow-up PR gives n2/n3 the 30-minute budget n1 already has.
- [x] n2-ship-hero with `google/gemini-2.5-pro` against this build: 4/4 gates, **opened the guide** and applied `compile()` pre-warm (before: zero `vgpu docs`, no pre-warm). Still no measurement and a PR.md without numbers, so the guide's section 2 is the part this model skips. 17 tool calls.

One run per model per condition; read as the mechanism working, not as rates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)