### PR TITLE
cli: make the top-level help an imperative 'start here' for getting-started

### DIFF
--- a/packages/vgpu/bin/vgpu.js
+++ b/packages/vgpu/bin/vgpu.js
@@ -42,8 +42,8 @@ const help = `vgpu ${VERSION}
 TypeScript library for WebGPU: typed shader imports, a tiny gpu-first API, and
 the same code running in the browser, headless Node, and your test suite.
 
-## Read the docs
-  npx vgpu docs cat getting-started.md    The guide for using the current API correctly
+## Start here — read this before touching the project
+  npx vgpu docs cat getting-started.md    The current API and defaults, plus the guide index (performance, testing, shipping)
   npx vgpu docs find "<topic | symbol | VGPU-error-code>"
   npx vgpu docs cat <path>
 

--- a/packages/vgpu/tests/cli.test.ts
+++ b/packages/vgpu/tests/cli.test.ts
@@ -23,8 +23,8 @@ const routerHelp = `vgpu ${packageVersion}
 TypeScript library for WebGPU: typed shader imports, a tiny gpu-first API, and
 the same code running in the browser, headless Node, and your test suite.
 
-## Read the docs
-  npx vgpu docs cat getting-started.md    The guide for using the current API correctly
+## Start here — read this before touching the project
+  npx vgpu docs cat getting-started.md    The current API and defaults, plus the guide index (performance, testing, shipping)
   npx vgpu docs find "<topic | symbol | VGPU-error-code>"
   npx vgpu docs cat <path>
 


### PR DESCRIPTION
## Summary

Replaces #429 (closed unmerged). Same finding, different lever.

**Finding.** In `n2-ship-hero`, gpt-5 and gemini-2.5-pro read only `npx vgpu` with no arguments, ran `vgpu check`, and shipped; neither ever opened `getting-started.md`, the hub that links every other guide (including the pre-PR checklist). Adding per-topic pointers to the top-level help (#429) did work, but does not scale: the help's job is to get the entry guide read.

**Change.** The help's first section becomes an imperative "start here" and says what the guide leads to. Same three commands, different framing:

```
## Start here — read this before touching the project
  npx vgpu docs cat getting-started.md    The current API and defaults, plus the guide index (performance, testing, shipping)
  npx vgpu docs find "<topic | symbol | VGPU-error-code>"
  npx vgpu docs cat <path>
```

## Result: the framing did not move either model (1 run each)

- **gpt-5**: saw the section verbatim (the string is in its transcript), then ran `vgpu snapshot --help`, `vgpu check` ×3, `npm run build`, `vgpu doctor`, `tsc --noEmit`, and wrote PR.md. Zero `vgpu docs`. It reads the help as a command menu; an imperative line is not an instruction to it.
- **gemini-2.5-pro**: ran `npx vgpu`, `vgpu check` ×4, then `docs find "import"` → `docs cat nextjs.docs.md` (chasing the `.wgsl` import), and wrote PR.md. It used docs, but never `getting-started`, and never reached the pre-PR pointer at its end.

Contrast: with #429's explicit `## Before you ship` line, both models opened the shipping guide and applied pre-warm on the next run. Specific, copy-pasteable commands move these models; "read this first" does not.

**Recommendation: do not merge as-is.** The text is harmless but ineffective for the models it targets. Levers still untested: a `docs` hint field in `vgpu check`'s JSON output (the one command every model ran and read), or moving the pre-PR pointer from the tail of getting-started to its head for the models that do open it.

## Test plan
- [x] `vitest run packages/vgpu/tests/cli.test.ts`
- [x] n2-ship-hero with `openai/gpt-5` and `google/gemini-2.5-pro` against this build: neither read getting-started (see above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)