### PR TITLE
fix(ci): report release impact through the Actions job

### DIFF
--- a/.github/workflows/release-impact.yml
+++ b/.github/workflows/release-impact.yml
@@ -13,29 +13,14 @@ concurrency:
 permissions:
   contents: read
   pull-requests: read
-  checks: write
 
 jobs:
   evaluate:
-    name: release-impact-evaluator
+    # Keep the required check on this execution's Actions suite (see CONTRIBUTING.md).
+    name: release-impact
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      # Mark the head pending before any checkout can fail; always finalize below. Otherwise an
-      # edited description could keep an old green check if checkout or policy execution fails.
-      - name: Start release-impact check on the PR head
-        id: check
-        env:
-          GH_TOKEN: ${{ github.token }}
-          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-        run: |
-          set -euo pipefail
-          check_id="$(gh api --method POST "repos/${GITHUB_REPOSITORY}/check-runs" \
-            --field name=release-impact --field head_sha="$PR_HEAD_SHA" \
-            --field status=in_progress --field details_url="$RUN_URL" --jq '.id')"
-          [[ "$check_id" =~ ^[1-9][0-9]*$ ]]
-          echo "id=$check_id" >> "$GITHUB_OUTPUT"
       - name: Checkout trusted policy
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
         with:
@@ -58,18 +43,3 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: node .release-impact/trusted/scripts/check-release-impact.mjs .release-impact/candidate
-      - name: Complete release-impact check, including checkout failures
-        if: ${{ always() && steps.check.outputs.id != '' }}
-        env:
-          GH_TOKEN: ${{ github.token }}
-          CHECK_ID: ${{ steps.check.outputs.id }}
-          JOB_STATUS: ${{ job.status }}
-        run: |
-          set -euo pipefail
-          conclusion=failure
-          if [ "$JOB_STATUS" = success ]; then conclusion=success; fi
-          if ! gh api --method PATCH "repos/${GITHUB_REPOSITORY}/check-runs/${CHECK_ID}" \
-            --field status=completed --field conclusion="$conclusion"; then
-            observed="$(gh api "repos/${GITHUB_REPOSITORY}/check-runs/${CHECK_ID}" --jq '[.status, .conclusion] | join(":")')"
-            test "$observed" = "completed:$conclusion"
-          fi

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,6 +63,13 @@ preparation. Future guides and regular API/topic documentation remain checked.
 Run `pnpm migrations:check` before opening the PR. The `release-impact` check validates the PR
 description and new changesets, including on description edits. It executes trusted policy code
 and reads candidate Git blobs as data, never running candidate code with write permissions.
+
+The required `release-impact` check is the Actions job itself. Do not replace it with a check
+created through the Checks API using `GITHUB_TOKEN`: after multiple executions on the same commit,
+GitHub can attach that check to an older workflow suite and leave the merge requirement `Expected`
+despite a successful evaluation. The job reports checkout, validation, cancellation and timeout
+outcomes directly, without `checks: write` permission. Description edits must still trigger it.
+
 GitHub attaches checks to commits, so the check validates every open PR targeting `canary` or `main`
 with the same head SHA. An invalid declaration in any of those PRs blocks the shared commit. Correct
 the declaration or close the duplicate PR to refresh the result. If a duplicate moves to a different

--- a/scripts/shared-head-prs.test.ts
+++ b/scripts/shared-head-prs.test.ts
@@ -97,6 +97,25 @@ describe("commit-scoped release impact", () => {
     expect(workflow).toContain("closed, edited]");
     expect(workflow).toContain("group: release-impact-${{ github.event.pull_request.head.sha }}");
     expect(workflow).toContain("ref: ${{ github.workflow_sha }}");
+    expect(workflow).toContain("ref: ${{ github.event.pull_request.head.sha }}");
+    expect(workflow.match(/persist-credentials: false/g)).toHaveLength(2);
     expect(workflow).not.toContain("pnpm install");
+  });
+
+  it("declares the required check as the unconditional Actions job", () => {
+    const workflow = readFileSync(new URL("../.github/workflows/release-impact.yml", import.meta.url), "utf8");
+    expect(workflow.match(/^    name: release-impact$/gm)).toHaveLength(1);
+    expect(workflow).not.toMatch(/^\s+(?:if|continue-on-error):/m);
+    expect(workflow).toContain("timeout-minutes: 5");
+    expect(workflow).toMatch(/^        run: node \.release-impact\/trusted\/scripts\/check-release-impact\.mjs \.release-impact\/candidate$/m);
+  });
+
+  it("leaves check reporting to Actions with read-only token permissions", () => {
+    const workflow = readFileSync(new URL("../.github/workflows/release-impact.yml", import.meta.url), "utf8");
+    expect(workflow).toContain("  contents: read");
+    expect(workflow).toContain("  pull-requests: read");
+    expect(workflow).not.toMatch(/:\s*write(?:-all)?\s*(?:#.*)?$/m);
+    expect(workflow).not.toContain("check-runs");
+    expect(workflow).not.toContain("gh api");
   });
 });


### PR DESCRIPTION
## Summary

Make the required `release-impact` check the unconditional Actions job itself, removing the manually created Checks API result and the `checks: write` permission.

On #436, the evaluator completed successfully in the latest workflow suite, but its manually published `release-impact` check was associated with the first suite for that head commit. Branch protection still showed `Expected — Waiting for status to be reported`. Repeated `GITHUB_TOKEN` check creation on the same SHA has also been [reported to attach to the first suite](https://github.com/orgs/community/discussions/24616).

The change preserves the trusted `pull_request_target` policy checkout, inert candidate-head checkout, pinned actions, description/close triggers, SHA-scoped concurrency, timeout, shared-head PR validation, and release/migration policy. Checkout and evaluator failures now propagate directly through the required job. Repository protections are unchanged.

This is a separate three-file CI fix, not a change to the Metal implementation in #436.

## PR type

development

## Release impact

none — Only CI check reporting, workflow regression tests and repository contribution documentation change; published packages, APIs and bundled CLI/MCP documentation are unaffected.

## Validation

- [x] Two observed RED → GREEN cycles for the required job name and removal of manual reporting/write permissions.
- [x] `pnpm exec vitest run scripts`: 335 tests passed.
- [x] `pnpm typecheck`, including type fixtures.
- [x] `pnpm test:fast`: 1,150 passed, 76 skipped, zero failures.
- [x] `pnpm migrations:check`, `pnpm check:filenames`, and `git diff --check`.
- [x] Independent review of the complete workflow, regression tests and documentation diff.

Local commands used Node 22.19.0. The tests protect workflow configuration and existing policy behavior; they do not simulate GitHub check-suite association.

## Rollout verification

Because `pull_request_target` loads the trusted base workflow, this PR's release-impact run still uses the existing implementation until this change is merged into `canary`. Green CI on this PR alone does not prove the association fix is active.

After the approved merge, trigger a fresh description-only event on a PR without changing its head SHA. Verify that the automatic `release-impact` check belongs to that new run's suite and satisfies the existing required check; repeat the description edit to cover the original regression. This final platform verification remains pending trusted rollout. Do not bypass branch protection or manually publish a passing check.
