### PR TITLE
chore(release): prepare authenticated native compiler transport

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -387,6 +387,11 @@ emergency operation, never the normal release path.
 
 ### npm Trusted Publishing
 
+For the prerequisite rollout of the native companion, see
+[native compiler release inputs](docs/release/native.md). The companion remains private
+until its separate release-preparation PR activates it; adding a supported package to
+the trusted validator does not add it to the npm publishing workflow.
+
 Publishing uses OIDC, not a token — the repository must not retain an `NPM_TOKEN` secret. Each published package
 has a Trusted Publisher configured on npm (provider GitHub Actions, owner `vercel-labs`,
 repository `vgpu`, workflow `release.yml`, no environment). Under **Allowed actions**, explicitly

--- a/docs/release/native.md
+++ b/docs/release/native.md
@@ -1,0 +1,64 @@
+# Native compiler release inputs
+
+`@vgpu/native` release integration is being prepared; the npm `0.0.1` bootstrap
+package only reserves the name. Do not create an npm RC until the companion is
+included in the release allowlists and its installed candidate has been verified.
+
+## Compiler artifact transport
+
+The npm build must bundle the exact accepted universal Tint worker, not rebuild
+Dawn during publication or download a compiler when a consumer installs the package.
+The existing `source-lock.json` under
+`tooling/native-tint-worker/c1-tint-direct-build/provenance/` remains the authority
+for its byte length and SHA-256. Transport never changes the runtime trust list.
+
+The proposed transport is a separate GitHub Release in `vercel-labs/vgpu`, tagged
+`native-tint-<full universal SHA-256>`, with an asset named
+`vgpu-tint-worker-universal`. This tag does not start with `v`, so it cannot trigger
+npm publication. The binary release must also carry the authenticated Dawn/Tint,
+Abseil and JsonCpp license notices. Creating that release requires maintainer approval;
+documenting its address does not mean the asset is already published.
+
+Run `node scripts/fetch-native-worker.mjs` in a clean release checkout before packing.
+The command downloads only that content-addressed asset, checks its exact length
+and digest before writing, and creates the expected local worker file exclusively.
+It rejects an existing destination, an HTTP failure, truncated/oversized content or
+a digest mismatch. There is no fallback to a previous cached distribution. A failed
+fetch must stop release preparation, not silently omit the native package.
+
+The existing maintainer-only `prepack` authenticates the worker again and adds the
+tracked license notices to the tarball. The OIDC publishing job must continue to
+receive only verified tarballs, without checking out or executing repository code.
+
+## Qualification and publication gates
+
+Roll out in two PRs. The prerequisite development PR adds transport and explicitly
+allowlisted support for a future `@vgpu/native` fixed-group member, leaving today's
+seven-package publication and private native manifest unchanged. The trusted
+`release-impact` evaluator must land on `canary` first: it reads candidate data but
+does not execute the candidate's updated validation code. A subsequent release PR
+activates native, advances the fixed group and finalizes the migration guide. Do not
+weaken the private-to-public version-change checks to bypass release preparation.
+That activation must also update both workflow tarball allowlists and exact artifact
+counts, and extend production authorization's package-version and npm-evidence checks.
+For historical releases, derive the supported package set from the stable candidate's
+fixed group, not the latest canary configuration. Validator acceptance alone does not
+prove that the publishing workflow includes the companion.
+
+The first public companion exposes only `@vgpu/native/cli` for the existing lazy
+CLI protocol. The low-level TypeScript generator remains internal; distributing
+the companion does not promise a second user-facing generator API.
+
+Before enabling the package in a release, verify installation from candidate tarballs
+outside the workspace, shader compilation, generated Swift consumption, and preservation
+of the existing interruption/recovery coverage. Verify the npm tarball contains the
+worker, licenses and C helper sources, with no local checkout dependency or install hook.
+
+The currently accepted worker has an ad hoc signature, not an Apple Developer ID
+signature or notarization. Hash authentication is not Apple signing. Publishing it
+as a limited preview requires an explicit decision; signing it would change its bytes
+and require a separately reviewed compiler baseline. A universal binary and Rosetta
+tests do not establish Intel GPU support or a minimum-macOS qualification matrix.
+
+The ordinary release/migration checklist in [CONTRIBUTING.md](../../CONTRIBUTING.md) still applies. An npm RC
+must use `next`, not `latest`; staged npm publication is a separate future change.

--- a/scripts/check-release-packages.mjs
+++ b/scripts/check-release-packages.mjs
@@ -2,7 +2,10 @@
 
 import fs from "node:fs";
 import path from "node:path";
-import { validateReleasePackages } from "./lib/release-packages.mjs";
+import {
+  releasePackagesFor,
+  validateReleasePackages,
+} from "./lib/release-packages.mjs";
 
 const expectedVersion = process.env.EXPECTED_VERSION;
 if (!expectedVersion) {
@@ -37,6 +40,8 @@ if (errors.length > 0) {
   process.exitCode = 1;
 } else {
   console.log(
-    `Release package validation accepted exactly seven public packages at ${expectedVersion}.`
+    `Release package validation accepted exactly ${
+      releasePackagesFor(config.fixed.flat()).length
+    } public packages at ${expectedVersion}.`
   );
 }

--- a/scripts/fetch-native-worker.mjs
+++ b/scripts/fetch-native-worker.mjs
@@ -1,0 +1,42 @@
+#!/usr/bin/env node
+import { mkdir, readFile, lstat } from "node:fs/promises";
+import { dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { downloadVerifiedAsset } from "./lib/verified-asset.mjs";
+
+if (process.argv.length !== 2) {
+  throw new Error("Usage: node scripts/fetch-native-worker.mjs (no overrides)");
+}
+const source = new URL(
+  "../tooling/native-tint-worker/c1-tint-direct-build/",
+  import.meta.url
+);
+const lock = JSON.parse(
+  await readFile(new URL("provenance/source-lock.json", source), "utf8")
+);
+const expected = lock.build.outputs.universal;
+if (
+  !Number.isSafeInteger(expected.bytes) ||
+  expected.bytes < 1 ||
+  expected.bytes > 16 * 1024 * 1024 ||
+  !/^[a-f0-9]{64}$/.test(expected.sha256)
+) {
+  throw new Error("Invalid locked native worker identity");
+}
+const destination = fileURLToPath(
+  new URL(".artifacts/bin/vgpu-tint-worker-universal", source)
+);
+try {
+  await lstat(destination);
+  throw new Error(
+    "Native worker destination already exists; use a clean release checkout"
+  );
+} catch (error) {
+  if (error.code !== "ENOENT") throw error;
+}
+const url = `https://github.com/vercel-labs/vgpu/releases/download/native-tint-${expected.sha256}/vgpu-tint-worker-universal`;
+await mkdir(dirname(destination), { recursive: true });
+await downloadVerifiedAsset({ url, expected, destination });
+console.log(
+  `Fetched authenticated native worker (${expected.bytes} bytes, SHA-256 ${expected.sha256}).`
+);

--- a/scripts/fetch-native-worker.test.ts
+++ b/scripts/fetch-native-worker.test.ts
@@ -1,0 +1,200 @@
+import { createHash } from "node:crypto";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import { pathToFileURL } from "node:url";
+import {
+  mkdtemp,
+  readFile,
+  rm,
+  lstat,
+  writeFile,
+  mkdir,
+  copyFile,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { expect, test } from "vitest";
+import { downloadVerifiedAsset } from "./lib/verified-asset.mjs";
+
+test("the maintainer CLI derives its URL and destination from the lock and refuses overrides", async () => {
+  const root = await mkdtemp(join(tmpdir(), "vgpu-worker-cli-"));
+  const bytes = Buffer.from("accepted compiler fixture");
+  const expected = {
+    bytes: bytes.length,
+    sha256: createHash("sha256").update(bytes).digest("hex"),
+  };
+  const source = join(root, "tooling/native-tint-worker/c1-tint-direct-build");
+  const script = join(root, "scripts/fetch-native-worker.mjs");
+  const preload = join(root, "transport.mjs");
+  const destination = join(source, ".artifacts/bin/vgpu-tint-worker-universal");
+  try {
+    await mkdir(join(root, "scripts/lib"), { recursive: true });
+    await mkdir(join(source, "provenance"), { recursive: true });
+    await copyFile(
+      new URL("./fetch-native-worker.mjs", import.meta.url),
+      script
+    );
+    await copyFile(
+      new URL("./lib/verified-asset.mjs", import.meta.url),
+      join(root, "scripts/lib/verified-asset.mjs")
+    );
+    await writeFile(
+      join(source, "provenance/source-lock.json"),
+      JSON.stringify({ build: { outputs: { universal: expected } } })
+    );
+    // Mock only the network boundary in the child; execute the real command and filesystem path.
+    await writeFile(
+      preload,
+      `globalThis.fetch = async (url) => { console.log("REQUEST " + url); return new Response("accepted compiler fixture"); };`
+    );
+    const run = (...args: string[]) =>
+      promisify(execFile)(
+        process.execPath,
+        ["--import", pathToFileURL(preload).href, script, ...args],
+        { cwd: root }
+      );
+    await expect(
+      run("--url=https://example.invalid/untrusted")
+    ).rejects.toMatchObject({
+      stderr: expect.stringContaining("no overrides"),
+    });
+    await expect(lstat(destination)).rejects.toMatchObject({ code: "ENOENT" });
+    const result = await run();
+    expect(result.stdout).toContain(
+      `REQUEST https://github.com/vercel-labs/vgpu/releases/download/native-tint-${expected.sha256}/vgpu-tint-worker-universal`
+    );
+    expect(await readFile(destination)).toEqual(bytes);
+    await expect(run()).rejects.toMatchObject({
+      stdout: "",
+      stderr: expect.stringContaining("destination already exists"),
+    });
+    expect(await readFile(destination)).toEqual(bytes);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("downloads the exact authenticated asset into a fresh file", async () => {
+  const root = await mkdtemp(join(tmpdir(), "vgpu-worker-download-"));
+  const bytes = Buffer.from("accepted compiler fixture");
+  const destination = join(root, "worker");
+  try {
+    await downloadVerifiedAsset({
+      url: "https://example.invalid/worker",
+      destination,
+      expected: {
+        bytes: bytes.length,
+        sha256: createHash("sha256").update(bytes).digest("hex"),
+      },
+      fetch: async () => new Response(bytes),
+    });
+    expect(await readFile(destination)).toEqual(bytes);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test.each(["truncated", "tampered"])(
+  "rejects a %s asset before writing",
+  async (kind) => {
+    const root = await mkdtemp(join(tmpdir(), "vgpu-worker-download-"));
+    const destination = join(root, "worker");
+    const accepted = Buffer.from("accepted");
+    try {
+      await expect(
+        downloadVerifiedAsset({
+          url: "https://example.invalid/worker",
+          destination,
+          expected: {
+            bytes: accepted.length,
+            sha256: createHash("sha256").update(accepted).digest("hex"),
+          },
+          fetch: async () =>
+            new Response(kind === "truncated" ? "accept" : "tampered"),
+        })
+      ).rejects.toThrow("does not match");
+      await expect(lstat(destination)).rejects.toMatchObject({
+        code: "ENOENT",
+      });
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  }
+);
+
+test("never replaces a pre-existing asset", async () => {
+  const root = await mkdtemp(join(tmpdir(), "vgpu-worker-download-"));
+  const destination = join(root, "worker");
+  const bytes = Buffer.from("accepted");
+  try {
+    await writeFile(destination, "preserve me");
+    await expect(
+      downloadVerifiedAsset({
+        url: "https://example.invalid/worker",
+        destination,
+        expected: {
+          bytes: bytes.length,
+          sha256: createHash("sha256").update(bytes).digest("hex"),
+        },
+        fetch: async () => new Response(bytes),
+      })
+    ).rejects.toMatchObject({ code: "EEXIST" });
+    expect(await readFile(destination, "utf8")).toBe("preserve me");
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("stops an oversized response without draining it or writing output", async () => {
+  const root = await mkdtemp(join(tmpdir(), "vgpu-worker-download-"));
+  let cancelled = false;
+  let pulls = 0;
+  const body = new ReadableStream({
+    pull(controller) {
+      pulls += 1;
+      controller.enqueue(new Uint8Array(32));
+      if (pulls === 10) controller.close();
+    },
+    cancel() {
+      cancelled = true;
+    },
+  });
+  const destination = join(root, "worker");
+  try {
+    await expect(
+      downloadVerifiedAsset({
+        url: "https://example.invalid/worker",
+        destination,
+        expected: { bytes: 16, sha256: "0".repeat(64) },
+        fetch: async () => new Response(body),
+      })
+    ).rejects.toThrow("exceeds locked size");
+    expect(cancelled).toBe(true);
+    expect(pulls).toBeLessThan(10);
+    await expect(lstat(destination)).rejects.toMatchObject({ code: "ENOENT" });
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("rejects HTTP failure even if its body matches the accepted bytes", async () => {
+  const root = await mkdtemp(join(tmpdir(), "vgpu-worker-download-"));
+  const bytes = Buffer.from("accepted compiler fixture");
+  const destination = join(root, "worker");
+  try {
+    await expect(
+      downloadVerifiedAsset({
+        url: "https://example.invalid/worker",
+        destination,
+        expected: {
+          bytes: bytes.length,
+          sha256: createHash("sha256").update(bytes).digest("hex"),
+        },
+        fetch: async () => new Response(bytes, { status: 404 }),
+      })
+    ).rejects.toThrow("HTTP 404");
+    await expect(lstat(destination)).rejects.toMatchObject({ code: "ENOENT" });
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});

--- a/scripts/lib/release-packages.mjs
+++ b/scripts/lib/release-packages.mjs
@@ -14,12 +14,24 @@ export const RELEASE_PACKAGES = Object.freeze([
   Object.freeze({ name: "@vgpu/render", directory: "packages/render" }),
 ]);
 
+// A reviewed opt-in for the first native release, not automatic discovery of public packages.
+// Keep the seven existing packages mandatory while the companion remains private.
+export function releasePackagesFor(configuredFixedPackageNames) {
+  return configuredFixedPackageNames.includes("@vgpu/native")
+    ? [
+        ...RELEASE_PACKAGES,
+        { name: "@vgpu/native", directory: "packages/native" },
+      ]
+    : RELEASE_PACKAGES;
+}
+
 export function validateReleasePackages({
   configuredFixedPackageNames,
   manifests,
   expectedVersion,
 }) {
-  const expectedNames = new Set(RELEASE_PACKAGES.map(({ name }) => name));
+  const releasePackages = releasePackagesFor(configuredFixedPackageNames);
+  const expectedNames = new Set(releasePackages.map(({ name }) => name));
   const configuredNameCounts = new Map();
   const manifestsByPath = new Map();
   const manifestPathsByName = new Map();
@@ -47,7 +59,7 @@ export function validateReleasePackages({
     }
   }
 
-  for (const { name, directory } of RELEASE_PACKAGES) {
+  for (const { name, directory } of releasePackages) {
     const fixedCount = configuredNameCounts.get(name) ?? 0;
     if (fixedCount === 0) {
       errors.push(`${name}: missing from the Changesets fixed group`);

--- a/scripts/lib/verified-asset.mjs
+++ b/scripts/lib/verified-asset.mjs
@@ -1,0 +1,38 @@
+import { createHash } from "node:crypto";
+import { writeFile } from "node:fs/promises";
+
+/** Maintainer transport only. The caller supplies the reviewed artifact identity. */
+export async function downloadVerifiedAsset({
+  url,
+  expected,
+  destination,
+  fetch: fetchAsset = globalThis.fetch,
+}) {
+  const response = await fetchAsset(url, {
+    signal: AbortSignal.timeout(60_000),
+  });
+  if (!response.ok) {
+    await response.body?.cancel();
+    throw new Error(`Compiler asset download failed: HTTP ${response.status}`);
+  }
+  if (!response.body) throw new Error("Compiler asset response has no body");
+  const chunks = [];
+  let size = 0;
+  for await (const chunk of response.body) {
+    size += chunk.byteLength;
+    if (size > expected.bytes) {
+      throw new Error("Compiler asset response exceeds locked size");
+    }
+    chunks.push(chunk);
+  }
+  const bytes = Buffer.concat(chunks, size);
+  if (
+    bytes.length !== expected.bytes ||
+    createHash("sha256").update(bytes).digest("hex") !== expected.sha256
+  ) {
+    throw new Error(
+      "Compiler asset does not match its locked bytes and SHA-256"
+    );
+  }
+  await writeFile(destination, bytes, { flag: "wx", mode: 0o644 });
+}

--- a/scripts/pr-release.test.ts
+++ b/scripts/pr-release.test.ts
@@ -68,6 +68,22 @@ describe("explicit PR type", () => {
 });
 
 describe("release PR readiness before merge", () => {
+  it("allows an explicitly activated native companion only through full release preparation", () => {
+    const { input, data, before } = fixture();
+    const nativePath = "packages/native/package.json";
+    before[nativePath] = JSON.stringify({ name: "@vgpu/native", version: "0.0.0", private: true });
+    data[nativePath] = JSON.stringify({
+      name: "@vgpu/native", version: "0.5.0-rc.0", private: false,
+      repository: { type: "git", url: "git+https://github.com/vercel-labs/vgpu.git", directory: "packages/native" },
+      publishConfig: { access: "public" },
+    });
+    data[".changeset/config.json"] = JSON.stringify({ fixed: [[...RELEASE_PACKAGES.map(item => item.name), "@vgpu/native"]] });
+    const activation = { ...input, head: reader(data), changedFiles: [...input.changedFiles, { status: "M", path: nativePath }] };
+    expect(checkPrRelease(activation)).toMatchObject({ type: "release", version: "0.5.0-rc.0" });
+    expect(() => checkPrRelease({ ...activation, body: body("development") })).toThrow("Declare PR type release");
+    data["docs/migrations/0.5.0.docs.md"] += "\nChanged guide after review.\n";
+    expect(() => checkPrRelease(activation)).toThrow("review drift");
+  });
   it("accepts a fully prepared release using the publication migration checks", () => {
     const { input } = fixture();
     expect(checkPrRelease(input)).toMatchObject({ type: "release", version: "0.5.0-rc.0" });

--- a/scripts/release-packages.test.ts
+++ b/scripts/release-packages.test.ts
@@ -125,6 +125,63 @@ describe("release package validation", () => {
     expect(validateReleasePackages(validInput())).toEqual([]);
   });
 
+  it("accepts native only when explicitly activated in the fixed group with coherent public metadata", () => {
+    const input = validInput();
+    input.configuredFixedPackageNames.push("@vgpu/native");
+    input.manifests.push({
+      manifestPath: "packages/native/package.json",
+      manifest: {
+        name: "@vgpu/native",
+        version,
+        private: false,
+        repository: {
+          type: "git",
+          url: "git+https://github.com/vercel-labs/vgpu.git",
+          directory: "packages/native",
+        },
+        publishConfig: { access: "public" },
+      },
+    });
+    expect(validateReleasePackages(input)).toEqual([]);
+    input.configuredFixedPackageNames.pop();
+    expect(validateReleasePackages(input)).toContain(
+      "@vgpu/native: public workspace package missing from the release allowlist"
+    );
+  });
+
+  it("requires the activated native package to be present, public and version-aligned", () => {
+    const input = validInput();
+    input.configuredFixedPackageNames.push("@vgpu/native");
+    expect(validateReleasePackages(input)).toContain(
+      "@vgpu/native: package.json not found at packages/native/package.json"
+    );
+    input.manifests.push({
+      manifestPath: "packages/native/package.json",
+      manifest: { name: "@vgpu/native", version: "0.0.0", private: true },
+    });
+    expect(validateReleasePackages(input)).toEqual(
+      expect.arrayContaining([
+        "@vgpu/native: package.json must set private to false",
+        `@vgpu/native: 0.0.0 (expected ${version})`,
+        "@vgpu/native: package.json has invalid repository metadata",
+        '@vgpu/native: publishConfig must be exactly { access: "public" }',
+      ])
+    );
+    input.configuredFixedPackageNames.push("@vgpu/native");
+    expect(validateReleasePackages(input)).toContain(
+      "@vgpu/native: duplicated in the Changesets fixed group"
+    );
+  });
+
+  it("preserves the current seven-package release with a private native workspace", () => {
+    const input = validInput();
+    input.manifests.push({
+      manifestPath: "packages/native/package.json",
+      manifest: { name: "@vgpu/native", version: "0.0.0", private: true },
+    });
+    expect(validateReleasePackages(input)).toEqual([]);
+  });
+
   it("rejects an allowlisted package removed from Changesets or made private", () => {
     const input = validInput();
     input.configuredFixedPackageNames =


### PR DESCRIPTION
## Summary

Prepare the trusted release policy and authenticated compiler transport for a later
native companion RC. Native remains private, the existing seven-package release
workflow is unchanged, and no compiler asset is downloaded during consumer installs.

- Explicitly allow a future fixed-group native member with the same strict manifest/version checks.
- Download only the content-addressed compiler asset; verify size/SHA-256 before exclusive creation.
- Document the two-PR activation, tarball qualification and unchanged OIDC isolation requirements.

## PR type

development

## Release impact

none — Only maintainer transport, trusted release validation and repository documentation change; no published package behavior, versions or current publication set changes.

## Verification

- 1,201 fast tests passed; 76 existing conditional skips.
- 37 focused transport/release-policy tests passed.
- Workspace typecheck and fixtures, migrations check, filename check and diff check passed.
- Two independent review passes approved the final slice.
- Native activation, actual artifact hosting, installed release qualification and npm publication remain separate gates.
