### PR TITLE
fix: show the error message in preview overlays on Firefox

### DIFF
--- a/.changeset/olive-pumas-shake.md
+++ b/.changeset/olive-pumas-shake.md
@@ -1,0 +1,20 @@
+---
+"vgpu": patch
+---
+
+## Summary
+
+`init()` now reports a browser that exposes no WebGPU as such, instead of blaming the adapter.
+`requestBrowserDevice` optional-chained `navigator.gpu?.requestAdapter()`, so a browser without
+WebGPU threw `navigator.gpu.requestAdapter() returned null.` — a message that points at a driver
+or adapter problem rather than at a missing API. That case now throws `WebGPU is not available in
+this browser.`, matching the string the docs app and the three.js examples already use. An adapter
+request that genuinely resolves to `null` keeps its existing message.
+
+## Migration
+
+None: both cases already threw a `VGPUError` from `init()` with code `VGPU-RING1-UNSUPPORTED`, and
+both still do. Only the human-readable `message` of the missing-`navigator.gpu` case changes, and
+the set of situations that throw is unchanged. Consumers that branch on the error type, on `code`,
+or that simply surface the message need no adaptation; only code matching that one case's exact
+message string would, and the message text has never been a documented contract.

--- a/apps/docs/app/preview/[slug]/example-canvas.tsx
+++ b/apps/docs/app/preview/[slug]/example-canvas.tsx
@@ -4,13 +4,10 @@ import { Component, lazy, Suspense, useEffect, useMemo, useState, type ErrorInfo
 import { getExampleComponentLoader } from '@/lib/example-components';
 import { createDeduplicatedExampleErrorReporter, ExampleErrorReporterProvider } from '@/lib/example-error-reporter';
 import { type ExampleSlug } from '@/lib/example-slugs';
+import { formatPreviewError } from '@/lib/preview-error-message';
 
 interface ExampleCanvasProps {
   slug: ExampleSlug;
-}
-
-function messageOf(error: unknown): string {
-  return error instanceof Error ? error.stack || error.message : String(error);
 }
 
 function postPreviewError(slug: ExampleSlug, message: string): void {
@@ -42,7 +39,7 @@ class PreviewErrorBoundary extends Component<PreviewErrorBoundaryProps, PreviewE
   state: PreviewErrorBoundaryState = { message: null };
 
   static getDerivedStateFromError(error: unknown): PreviewErrorBoundaryState {
-    return { message: messageOf(error) };
+    return { message: formatPreviewError(error) };
   }
 
   componentDidCatch(error: unknown, _info: ErrorInfo): void {
@@ -71,8 +68,8 @@ function ReactExampleCanvas({ slug }: { slug: ExampleSlug }) {
 function PreviewHost({ slug }: { slug: ExampleSlug }) {
   const [asyncError, setAsyncError] = useState<string | null>(null);
   const reportError = useMemo(() => createDeduplicatedExampleErrorReporter(
-    (error) => setAsyncError(messageOf(error)),
-    (error) => postPreviewError(slug, messageOf(error)),
+    (error) => setAsyncError(formatPreviewError(error)),
+    (error) => postPreviewError(slug, formatPreviewError(error)),
   ), [slug]);
 
   useEffect(() => {

--- a/apps/docs/lib/preview-error-message.test.ts
+++ b/apps/docs/lib/preview-error-message.test.ts
@@ -1,0 +1,59 @@
+import { expect, test } from 'vitest';
+import { formatPreviewError } from './preview-error-message';
+
+/** A SpiderMonkey/JavaScriptCore stack: call frames only, no `name: message` header. */
+function withFramesOnlyStack(error: Error, frames: string): Error {
+  error.stack = frames;
+  return error;
+}
+
+test('a V8 stack is kept verbatim so the headline is not duplicated', () => {
+  const error = new Error('boom');
+  error.stack = 'Error: boom\n    at run (https://vgpu.sh/app.js:1:1)';
+
+  const formatted = formatPreviewError(error);
+
+  expect(formatted).toBe(error.stack);
+  expect(formatted.split('\n').filter((line) => line.includes('boom'))).toHaveLength(1);
+});
+
+test('the headline is prefixed onto a frames-only stack', () => {
+  // Firefox rendered this overlay as a bare frame dump: `error.stack` never carries
+  // the message there, so the reason for the failure was invisible.
+  const error = withFramesOnlyStack(
+    new Error('navigator.gpu.requestAdapter() returned null.'),
+    'r@https://vgpu.sh/chunk.js:1:6014\nt@https://vgpu.sh/chunk.js:1:15326',
+  );
+
+  const formatted = formatPreviewError(error);
+
+  expect(formatted.split('\n')[0]).toBe('Error: navigator.gpu.requestAdapter() returned null.');
+  expect(formatted).toContain('r@https://vgpu.sh/chunk.js:1:6014');
+});
+
+test('a custom error name is kept in the headline', () => {
+  const error = withFramesOnlyStack(new Error('no adapter'), 'VGPUError@https://vgpu.sh/chunk.js:1:1');
+  error.name = 'VGPUError';
+
+  expect(formatPreviewError(error).split('\n')[0]).toBe('VGPUError: no adapter');
+});
+
+test('an error with no stack falls back to the headline', () => {
+  const error = new Error('boom');
+  error.stack = undefined;
+
+  expect(formatPreviewError(error)).toBe('Error: boom');
+});
+
+test('an error with no message keeps its name', () => {
+  const error = withFramesOnlyStack(new Error(''), 'r@https://vgpu.sh/chunk.js:1:1');
+  error.name = 'VGPUError';
+
+  expect(formatPreviewError(error).split('\n')[0]).toBe('VGPUError');
+});
+
+test('values that are not Errors are stringified', () => {
+  expect(formatPreviewError('plain string')).toBe('plain string');
+  expect(formatPreviewError(null)).toBe('null');
+  expect(formatPreviewError(undefined)).toBe('undefined');
+});

--- a/apps/docs/lib/preview-error-message.ts
+++ b/apps/docs/lib/preview-error-message.ts
@@ -1,0 +1,18 @@
+/**
+ * Renders a thrown value as the text shown in the example preview error overlay.
+ *
+ * V8 puts `name: message` on the first line of `error.stack`, so reading the stack
+ * alone looks complete in Chrome. SpiderMonkey and JavaScriptCore emit call frames
+ * only: there the same read drops the one line that says what actually went wrong,
+ * leaving a bare dump of minified frames. Compose the headline unless the engine
+ * already supplied it.
+ */
+export function formatPreviewError(error: unknown): string {
+  if (!(error instanceof Error)) return String(error);
+  const headline = error.message ? `${error.name}: ${error.message}` : error.name;
+  const stack = error.stack;
+  if (!stack) return headline;
+  if (stack.startsWith(headline)) return stack;
+  if (error.message && stack.startsWith(error.message)) return stack;
+  return `${headline}\n${stack}`;
+}

--- a/packages/vgpu-api/src/kernel.ts
+++ b/packages/vgpu-api/src/kernel.ts
@@ -236,7 +236,11 @@ export async function createDevice(entry: EntryKind, opts: InitOptions, adapterF
 
 async function requestBrowserDevice(opts: InitOptions): Promise<Device> {
   const nav = globalThis.navigator as Navigator & { gpu?: GPU };
-  const adapter = await nav.gpu?.requestAdapter({ powerPreference: opts.powerPreference });
+  // A browser that exposes no WebGPU and one whose adapter request came back empty are
+  // different failures, but the optional chain below collapses both into `undefined`.
+  // Reporting the latter for the former sends people hunting for a driver problem.
+  if (!nav?.gpu) throw unsupportedError("init", "WebGPU is not available in this browser.");
+  const adapter = await nav.gpu.requestAdapter({ powerPreference: opts.powerPreference });
   if (!adapter) throw unsupportedError("init", "navigator.gpu.requestAdapter() returned null.");
   validateRequiredFeatures(adapter.features, opts.requiredFeatures);
   const gpuDevice = await adapter.requestDevice({ requiredFeatures: opts.requiredFeatures, requiredLimits: opts.requiredLimits });

--- a/packages/vgpu-api/tests/init-device-options.test.ts
+++ b/packages/vgpu-api/tests/init-device-options.test.ts
@@ -34,6 +34,29 @@ test("browser adapter receives required features and limits unchanged", async ()
   gpu.dispose();
 });
 
+test("browser init reports an absent navigator.gpu as WebGPU being unavailable", async () => {
+  // Firefox does not expose WebGPU on Linux by default. Optional-chaining the
+  // request made that indistinguishable from an adapter request that came back
+  // empty, so the thrown error blamed the adapter for a missing API.
+  vi.stubGlobal("navigator", {});
+
+  await expect(initBrowser()).rejects.toMatchObject({
+    code: "VGPU-RING1-UNSUPPORTED",
+    message: expect.stringContaining("WebGPU is not available in this browser"),
+  });
+});
+
+test("browser init still reports a null adapter distinctly", async () => {
+  const requestAdapter = vi.fn(async () => null);
+  vi.stubGlobal("navigator", { gpu: { requestAdapter } });
+
+  await expect(initBrowser()).rejects.toMatchObject({
+    code: "VGPU-RING1-UNSUPPORTED",
+    message: expect.stringContaining("requestAdapter() returned null"),
+  });
+  expect(requestAdapter).toHaveBeenCalledOnce();
+});
+
 test("browser init fails clearly when the adapter lacks a requested feature", async () => {
   const requestDevice = vi.fn(async () => createMockGPUDevice());
   const requestAdapter = vi.fn(async () => ({ requestDevice, features: new Set<string>(), info: null } as unknown as GPUAdapter));


### PR DESCRIPTION
## PR type

development

## Release impact

changeset — .changeset/olive-pumas-shake.md

## What happens today

Every example preview on https://vgpu.sh fails in Firefox with an overlay that contains a stack and nothing else — no message, no indication of what went wrong:

```
Preview error
r@https://vgpu.sh/_next/static/immutable/chunks/25i9s9l19xma4.js:1:6014
t@https://vgpu.sh/_next/static/immutable/chunks/25i9s9l19xma4.js:1:15326
@https://vgpu.sh/_next/static/immutable/chunks/25i9s9l19xma4.js:1:34847
d@https://vgpu.sh/_next/static/immutable/chunks/25i9s9l19xma4.js:1:39474
...
```

To reproduce, open any `/preview/<slug>` in a Firefox profile without `dom.webgpu.enabled` (the default on Linux today).

Two separate causes stack up.

### 1. The overlay drops the message

`apps/docs/app/preview/[slug]/example-canvas.tsx` formatted the error as:

```ts
return error instanceof Error ? error.stack || error.message : String(error);
```

V8 puts `name: message` on the first line of `error.stack`, so this reads correctly in Chrome. SpiderMonkey and JavaScriptCore emit call frames only, so `error.stack` never contains the message and the `|| error.message` fallback never fires. Measured in Firefox 151, for a thrown `Error`:

```json
{
  "message": "navigator.gpu.requestAdapter() returned null.",
  "stackFirstLine": "VGPUError@https://vgpu.sh/preview/simple-gradient:2:7",
  "stackIncludesMessage": false
}
```

This one function feeds both the in-iframe overlay and the `postMessage` payload that `components/example-preview.tsx` renders on the docs page, so both lost the message.

### 2. The underlying error blamed the wrong thing

`requestBrowserDevice` optional-chained the request:

```ts
const adapter = await nav.gpu?.requestAdapter({ powerPreference: opts.powerPreference });
if (!adapter) throw unsupportedError("init", "navigator.gpu.requestAdapter() returned null.");
```

When `navigator.gpu` is absent the optional chain yields `undefined`, so a browser that exposes no WebGPU at all was reported as an adapter that came back null — sending people to look for a driver or hardware problem instead of a missing API.

## The change

- Extract the formatting into `apps/docs/lib/preview-error-message.ts` so it is unit-testable, and compose `name: message` ahead of the stack unless the engine already supplied it. V8 output is byte-identical; Firefox and Safari gain the headline.
- Guard `navigator.gpu` in `requestBrowserDevice` and throw `WebGPU is not available in this browser.` — the same wording `apps/docs/lib/browser-device.ts` and the three.js examples already use, and the string `docs/topics/agent-browser-webgpu.docs.md` already tells readers to grep overlays for. A genuinely null adapter keeps its existing message.

With both applied, the same Firefox profile shows `VGPUError: WebGPU is not available in this browser.` above the frames instead of frames alone.

## Verification

- `pnpm typecheck` — passes.
- `pnpm test:fast` — 1208 passed, 76 skipped, 0 failed.
- `pnpm migrations:check` — passes.
- `pnpm docs:verify-snippets` — `snippets=623 tsc=OK`.
- `pnpm check:filenames` — passes.
- New tests: 6 in `apps/docs/lib/preview-error-message.test.ts`, 2 in `packages/vgpu-api/tests/init-device-options.test.ts`. Reverting either fix turns 5 of them red, and the V8-path and null-adapter tests stay green both ways.
- Firefox 151 over WebDriver BiDi, used both to capture the failure above and to confirm the new formatter puts the message on line one.

### Bundle budget

`vgpu experience full-root` is a hard client gate and is already close to it, so measuring the delta seemed worth reporting rather than leaving to CI:

| | gzip | budget | headroom |
| --- | --- | --- | --- |
| canary | 41846 B | 41984 B | 138 B |
| this PR | 41871 B | 41984 B | 113 B |

+25 B, from the one added guard and its message. Happy to fold the message into the existing `requestAdapter` throw if you would rather not spend the bytes, though that costs the distinction between the two failures.

The four tooling budgets that `pnpm bundle-check` warns about (`vgpu/node`, `vgpu/mock`, both wgsl loaders) are over on canary already and unchanged here.

## Notes

- Targets `canary` per CONTRIBUTING: the change is not web-only, since it touches `packages/vgpu-api` as well as `apps/docs`.
- The two halves are independent — if you would prefer the docs overlay fix and the `init()` message as separate PRs, say the word and I will split them.
- This is a different Firefox problem from #385, which is a naga validation failure on workgroup pointers in the FFT ocean demo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
